### PR TITLE
Updated existing non-gray S2 palette colors

### DIFF
--- a/src/tokens-studio/spectrum2-colors/spectrum2/palette/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/palette/dark.json
@@ -180,7 +180,7 @@
         }
       },
       "200": {
-        "value": "#0F1B4D",
+        "value": "#0f1c52",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -191,7 +191,7 @@
         }
       },
       "300": {
-        "value": "#0D2277",
+        "value": "#0c2175",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -202,7 +202,7 @@
         }
       },
       "400": {
-        "value": "#112A90",
+        "value": "#122d9a",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -213,7 +213,7 @@
         }
       },
       "500": {
-        "value": "#1634B3",
+        "value": "#1a3ac3",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -224,7 +224,7 @@
         }
       },
       "600": {
-        "value": "#1D3FD1",
+        "value": "#2549e5",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -235,7 +235,7 @@
         }
       },
       "700": {
-        "value": "#284EEC",
+        "value": "#345bf8",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -246,7 +246,7 @@
         }
       },
       "800": {
-        "value": "#3860FA",
+        "value": "#456efe",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -257,7 +257,7 @@
         }
       },
       "900": {
-        "value": "#4D78FF",
+        "value": "#5681ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -268,7 +268,7 @@
         }
       },
       "1000": {
-        "value": "#6692FE",
+        "value": "#6995fe",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -347,7 +347,7 @@
     },
     "green": {
       "100": {
-        "value": "#001F17",
+        "value": "#001e17",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -358,7 +358,7 @@
         }
       },
       "200": {
-        "value": "#00261C",
+        "value": "#00261d",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -369,7 +369,7 @@
         }
       },
       "300": {
-        "value": "#003426",
+        "value": "#003326",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -380,7 +380,7 @@
         }
       },
       "400": {
-        "value": "#00402D",
+        "value": "#004430",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -391,7 +391,7 @@
         }
       },
       "500": {
-        "value": "#014F35",
+        "value": "#02573a",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -402,7 +402,7 @@
         }
       },
       "600": {
-        "value": "#025F3D",
+        "value": "#036a43",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -413,7 +413,7 @@
         }
       },
       "700": {
-        "value": "#037045",
+        "value": "#047c4b",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -424,7 +424,7 @@
         }
       },
       "800": {
-        "value": "#05804C",
+        "value": "#068c52",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -435,7 +435,7 @@
         }
       },
       "900": {
-        "value": "#089555",
+        "value": "#099d59",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -446,7 +446,7 @@
         }
       },
       "1000": {
-        "value": "#0DAC61",
+        "value": "#0eaf62",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -536,7 +536,7 @@
         }
       },
       "200": {
-        "value": "#3B1400",
+        "value": "#3d1500",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -547,7 +547,7 @@
         }
       },
       "300": {
-        "value": "#501B00",
+        "value": "#501b00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -558,7 +558,7 @@
         }
       },
       "400": {
-        "value": "#632200",
+        "value": "#6a2400",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -569,7 +569,7 @@
         }
       },
       "500": {
-        "value": "#7A2A00",
+        "value": "#872f00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -580,7 +580,7 @@
         }
       },
       "600": {
-        "value": "#913400",
+        "value": "#a23b00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -591,7 +591,7 @@
         }
       },
       "700": {
-        "value": "#A93F00",
+        "value": "#b94900",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -602,7 +602,7 @@
         }
       },
       "800": {
-        "value": "#BE4C00",
+        "value": "#cd5600",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -613,7 +613,7 @@
         }
       },
       "900": {
-        "value": "#D65D00",
+        "value": "#e06400",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -624,7 +624,7 @@
         }
       },
       "1000": {
-        "value": "#F07200",
+        "value": "#f37500",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -703,7 +703,7 @@
     },
     "red": {
       "100": {
-        "value": "#360A03",
+        "value": "#360a03",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -714,7 +714,7 @@
         }
       },
       "200": {
-        "value": "#430D05",
+        "value": "#440d05",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -725,7 +725,7 @@
         }
       },
       "300": {
-        "value": "#591207",
+        "value": "#571107",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -736,7 +736,7 @@
         }
       },
       "400": {
-        "value": "#6D160A",
+        "value": "#73180b",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -747,7 +747,7 @@
         }
       },
       "500": {
-        "value": "#861C0F",
+        "value": "#931f11",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -758,7 +758,7 @@
         }
       },
       "600": {
-        "value": "#9E2213",
+        "value": "#b12617",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -769,7 +769,7 @@
         }
       },
       "700": {
-        "value": "#B92918",
+        "value": "#cd2e1d",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -780,7 +780,7 @@
         }
       },
       "800": {
-        "value": "#D4301F",
+        "value": "#e63623",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -791,7 +791,7 @@
         }
       },
       "900": {
-        "value": "#F33924",
+        "value": "#fc432e",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -802,7 +802,7 @@
         }
       },
       "1000": {
-        "value": "#FF624F",
+        "value": "#ff6756",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -892,7 +892,7 @@
         }
       },
       "200": {
-        "value": "#0e2500",
+        "value": "#0f2600",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -914,7 +914,7 @@
         }
       },
       "400": {
-        "value": "#1c3f03",
+        "value": "#1f4304",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -925,7 +925,7 @@
         }
       },
       "500": {
-        "value": "#244e06",
+        "value": "#295608",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -936,7 +936,7 @@
         }
       },
       "600": {
-        "value": "#2c5d09",
+        "value": "#32690b",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -947,7 +947,7 @@
         }
       },
       "700": {
-        "value": "#356e0c",
+        "value": "#3c7a0f",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -958,7 +958,7 @@
         }
       },
       "800": {
-        "value": "#3e7e10",
+        "value": "#458a13",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -969,7 +969,7 @@
         }
       },
       "900": {
-        "value": "#499215",
+        "value": "#4e9a17",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -980,7 +980,7 @@
         }
       },
       "1000": {
-        "value": "#57a91b",
+        "value": "#58ac1c",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1070,7 +1070,7 @@
         }
       },
       "200": {
-        "value": "#1d2300",
+        "value": "#1e2400",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1081,7 +1081,7 @@
         }
       },
       "300": {
-        "value": "#283000",
+        "value": "#272f00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1092,7 +1092,7 @@
         }
       },
       "400": {
-        "value": "#323b00",
+        "value": "#353f00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1103,7 +1103,7 @@
         }
       },
       "500": {
-        "value": "#3e4a00",
+        "value": "#445200",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1114,7 +1114,7 @@
         }
       },
       "600": {
-        "value": "#4a5800",
+        "value": "#536400",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1125,7 +1125,7 @@
         }
       },
       "700": {
-        "value": "#576800",
+        "value": "#617400",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1136,7 +1136,7 @@
         }
       },
       "800": {
-        "value": "#647800",
+        "value": "#6d8300",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1147,7 +1147,7 @@
         }
       },
       "900": {
-        "value": "#748b00",
+        "value": "#7a9300",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1158,7 +1158,7 @@
         }
       },
       "1000": {
-        "value": "#86a100",
+        "value": "#88a400",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1270,7 +1270,7 @@
         }
       },
       "400": {
-        "value": "#003c52",
+        "value": "#004058",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1281,7 +1281,7 @@
         }
       },
       "500": {
-        "value": "#004a65",
+        "value": "#005271",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1292,7 +1292,7 @@
         }
       },
       "600": {
-        "value": "#00587b",
+        "value": "#03638c",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1303,7 +1303,7 @@
         }
       },
       "700": {
-        "value": "#046893",
+        "value": "#0873a8",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1314,7 +1314,7 @@
         }
       },
       "800": {
-        "value": "#0a76af",
+        "value": "#0f80c2",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1325,7 +1325,7 @@
         }
       },
       "900": {
-        "value": "#1388cf",
+        "value": "#188edc",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1336,7 +1336,7 @@
         }
       },
       "1000": {
-        "value": "#249cf2",
+        "value": "#269ff4",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1415,7 +1415,7 @@
     },
     "fuchsia": {
       "100": {
-        "value": "#360035",
+        "value": "#32003d",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1426,7 +1426,7 @@
         }
       },
       "200": {
-        "value": "#410040",
+        "value": "#3d004a",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1437,7 +1437,7 @@
         }
       },
       "300": {
-        "value": "#540052",
+        "value": "#4f005f",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1448,7 +1448,7 @@
         }
       },
       "400": {
-        "value": "#670263",
+        "value": "#660978",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1459,7 +1459,7 @@
         }
       },
       "500": {
-        "value": "#7c0b77",
+        "value": "#7f1792",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1470,7 +1470,7 @@
         }
       },
       "600": {
-        "value": "#91168a",
+        "value": "#9726aa",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1481,7 +1481,7 @@
         }
       },
       "700": {
-        "value": "#a8239e",
+        "value": "#ad33c0",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1492,7 +1492,7 @@
         }
       },
       "800": {
-        "value": "#bd30b1",
+        "value": "#c040d4",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1503,7 +1503,7 @@
         }
       },
       "900": {
-        "value": "#d640c9",
+        "value": "#d549eb",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1514,7 +1514,7 @@
         }
       },
       "1000": {
-        "value": "#f54cea",
+        "value": "#e85bfd",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1525,7 +1525,7 @@
         }
       },
       "1100": {
-        "value": "#ff70f9",
+        "value": "#f07aff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1536,7 +1536,7 @@
         }
       },
       "1200": {
-        "value": "#ff9afd",
+        "value": "#f59fff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1547,7 +1547,7 @@
         }
       },
       "1300": {
-        "value": "#ffbcfe",
+        "value": "#f8bfff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1558,7 +1558,7 @@
         }
       },
       "1400": {
-        "value": "#ffdafe",
+        "value": "#fbdbff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1569,7 +1569,7 @@
         }
       },
       "1500": {
-        "value": "#fff0ff",
+        "value": "#fdf1ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1615,7 +1615,7 @@
         }
       },
       "300": {
-        "value": "#2f018d",
+        "value": "#2f008c",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1626,7 +1626,7 @@
         }
       },
       "400": {
-        "value": "#3a08a5",
+        "value": "#3e0cae",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1637,7 +1637,7 @@
         }
       },
       "500": {
-        "value": "#4815c3",
+        "value": "#4f1ed1",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1648,7 +1648,7 @@
         }
       },
       "600": {
-        "value": "#5526dc",
+        "value": "#5f34eb",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1659,7 +1659,7 @@
         }
       },
       "700": {
-        "value": "#643af0",
+        "value": "#6d4bf8",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1670,7 +1670,7 @@
         }
       },
       "800": {
-        "value": "#7051f9",
+        "value": "#7761fc",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1681,7 +1681,7 @@
         }
       },
       "900": {
-        "value": "#7b6dfd",
+        "value": "#8077fe",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1692,7 +1692,7 @@
         }
       },
       "1000": {
-        "value": "#8989fe",
+        "value": "#8b8dfe",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1771,7 +1771,7 @@
     },
     "magenta": {
       "100": {
-        "value": "#3d0015",
+        "value": "#3b0016",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1782,7 +1782,7 @@
         }
       },
       "200": {
-        "value": "#490019",
+        "value": "#4a001b",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1793,7 +1793,7 @@
         }
       },
       "300": {
-        "value": "#5e0021",
+        "value": "#5d0022",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1804,7 +1804,7 @@
         }
       },
       "400": {
-        "value": "#730029",
+        "value": "#7b002d",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1815,7 +1815,7 @@
         }
       },
       "500": {
-        "value": "#8d0134",
+        "value": "#98073c",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1826,7 +1826,7 @@
         }
       },
       "600": {
-        "value": "#a5053f",
+        "value": "#b5134c",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1837,7 +1837,7 @@
         }
       },
       "700": {
-        "value": "#c00a4a",
+        "value": "#cf1f5c",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1848,7 +1848,7 @@
         }
       },
       "800": {
-        "value": "#db1257",
+        "value": "#e72969",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1859,7 +1859,7 @@
         }
       },
       "900": {
-        "value": "#f7266c",
+        "value": "#ff3377",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1870,7 +1870,7 @@
         }
       },
       "1000": {
-        "value": "#ff5993",
+        "value": "#ff6095",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1881,7 +1881,7 @@
         }
       },
       "1100": {
-        "value": "#ff80ad",
+        "value": "#ff80ab",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1892,7 +1892,7 @@
         }
       },
       "1200": {
-        "value": "#ffa3c4",
+        "value": "#ffa3c2",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1903,7 +1903,7 @@
         }
       },
       "1300": {
-        "value": "#ffc1d7",
+        "value": "#ffc1d6",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1914,7 +1914,7 @@
         }
       },
       "1400": {
-        "value": "#ffdce9",
+        "value": "#ffdce8",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1982,7 +1982,7 @@
         }
       },
       "400": {
-        "value": "#4e0097",
+        "value": "#53009f",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1993,7 +1993,7 @@
         }
       },
       "500": {
-        "value": "#6000b6",
+        "value": "#6b06c3",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2004,7 +2004,7 @@
         }
       },
       "600": {
-        "value": "#740fcd",
+        "value": "#8222d7",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2015,7 +2015,7 @@
         }
       },
       "700": {
-        "value": "#882ada",
+        "value": "#943ee0",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2026,7 +2026,7 @@
         }
       },
       "800": {
-        "value": "#9744e1",
+        "value": "#a154e5",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2037,7 +2037,7 @@
         }
       },
       "900": {
-        "value": "#a75fe7",
+        "value": "#ad69e9",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2048,7 +2048,7 @@
         }
       },
       "1000": {
-        "value": "#b77bec",
+        "value": "#ba7fed",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2127,7 +2127,7 @@
     },
     "seafoam": {
       "100": {
-        "value": "#001d20",
+        "value": "#001e1b",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2138,7 +2138,7 @@
         }
       },
       "200": {
-        "value": "#002528",
+        "value": "#002723",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2149,7 +2149,7 @@
         }
       },
       "300": {
-        "value": "#003235",
+        "value": "#00322c",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2160,7 +2160,7 @@
         }
       },
       "400": {
-        "value": "#003e42",
+        "value": "#00433b",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2171,7 +2171,7 @@
         }
       },
       "500": {
-        "value": "#044d51",
+        "value": "#02564b",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2182,7 +2182,7 @@
         }
       },
       "600": {
-        "value": "#085b60",
+        "value": "#046959",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2193,7 +2193,7 @@
         }
       },
       "700": {
-        "value": "#0d6c71",
+        "value": "#067a67",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2204,7 +2204,7 @@
         }
       },
       "800": {
-        "value": "#137c81",
+        "value": "#088a74",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2215,7 +2215,7 @@
         }
       },
       "900": {
-        "value": "#1a8f94",
+        "value": "#0a9a80",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2226,7 +2226,7 @@
         }
       },
       "1000": {
-        "value": "#24a6ab",
+        "value": "#0cad8e",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2237,7 +2237,7 @@
         }
       },
       "1100": {
-        "value": "#2ebac0",
+        "value": "#0ebe9c",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2248,7 +2248,7 @@
         }
       },
       "1200": {
-        "value": "#3ed1d6",
+        "value": "#1dd6b0",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2259,7 +2259,7 @@
         }
       },
       "1300": {
-        "value": "#5ee5ea",
+        "value": "#7ae5cb",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2270,7 +2270,7 @@
         }
       },
       "1400": {
-        "value": "#aaf2f5",
+        "value": "#baf1de",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2281,7 +2281,7 @@
         }
       },
       "1500": {
-        "value": "#dbfbfc",
+        "value": "#e5f9f3",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2327,7 +2327,7 @@
         }
       },
       "300": {
-        "value": "#3f2800",
+        "value": "#3d2700",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2338,7 +2338,7 @@
         }
       },
       "400": {
-        "value": "#4e3100",
+        "value": "#533400",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2349,7 +2349,7 @@
         }
       },
       "500": {
-        "value": "#613d00",
+        "value": "#6b4300",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2360,7 +2360,7 @@
         }
       },
       "600": {
-        "value": "#744900",
+        "value": "#825200",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2371,7 +2371,7 @@
         }
       },
       "700": {
-        "value": "#875600",
+        "value": "#976100",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2382,7 +2382,7 @@
         }
       },
       "800": {
-        "value": "#9b6400",
+        "value": "#a96e00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2393,7 +2393,7 @@
         }
       },
       "900": {
-        "value": "#b27500",
+        "value": "#ba7c00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2404,7 +2404,7 @@
         }
       },
       "1000": {
-        "value": "#c88a00",
+        "value": "#cb8d00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-colors/spectrum2/palette/light.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/palette/light.json
@@ -202,7 +202,7 @@
         }
       },
       "400": {
-        "value": "#B0D1FD",
+        "value": "#accffd",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -213,7 +213,7 @@
         }
       },
       "500": {
-        "value": "#93BDFC",
+        "value": "#8eb9fc",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -224,7 +224,7 @@
         }
       },
       "600": {
-        "value": "#7AA7FD",
+        "value": "#729efd",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -235,7 +235,7 @@
         }
       },
       "700": {
-        "value": "#6490FF",
+        "value": "#5d89ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -246,7 +246,7 @@
         }
       },
       "800": {
-        "value": "#507BFF",
+        "value": "#4b75ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -257,7 +257,7 @@
         }
       },
       "900": {
-        "value": "#3B63FB",
+        "value": "#3b63fb",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -268,7 +268,7 @@
         }
       },
       "1000": {
-        "value": "#274DEA",
+        "value": "#274dea",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -380,7 +380,7 @@
         }
       },
       "400": {
-        "value": "#71E5A5",
+        "value": "#6be3a2",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -391,7 +391,7 @@
         }
       },
       "500": {
-        "value": "#30D480",
+        "value": "#2bd17d",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -402,7 +402,7 @@
         }
       },
       "600": {
-        "value": "#17C06C",
+        "value": "#12b867",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -413,7 +413,7 @@
         }
       },
       "700": {
-        "value": "#0DAB60",
+        "value": "#0ba45d",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -424,7 +424,7 @@
         }
       },
       "800": {
-        "value": "#089756",
+        "value": "#079355",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -435,7 +435,7 @@
         }
       },
       "900": {
-        "value": "#05834D",
+        "value": "#05834e",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -446,7 +446,7 @@
         }
       },
       "1000": {
-        "value": "#036E44",
+        "value": "#036e45",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -536,7 +536,7 @@
         }
       },
       "200": {
-        "value": "#FFEED2",
+        "value": "#ffeccf",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -558,7 +558,7 @@
         }
       },
       "400": {
-        "value": "#FFC567",
+        "value": "#ffc15e",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -569,7 +569,7 @@
         }
       },
       "500": {
-        "value": "#FFA921",
+        "value": "#ffa213",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -580,7 +580,7 @@
         }
       },
       "600": {
-        "value": "#FF8900",
+        "value": "#fc7d00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -591,7 +591,7 @@
         }
       },
       "700": {
-        "value": "#EF7000",
+        "value": "#e86a00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -602,7 +602,7 @@
         }
       },
       "800": {
-        "value": "#DA5F00",
+        "value": "#d45b00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -613,7 +613,7 @@
         }
       },
       "900": {
-        "value": "#C14E00",
+        "value": "#c24e00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -624,7 +624,7 @@
         }
       },
       "1000": {
-        "value": "#A73E00",
+        "value": "#a73e00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -736,7 +736,7 @@
         }
       },
       "400": {
-        "value": "#FFC0B8",
+        "value": "#ffbcb4",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -747,7 +747,7 @@
         }
       },
       "500": {
-        "value": "#FFA398",
+        "value": "#ff9d91",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -758,7 +758,7 @@
         }
       },
       "600": {
-        "value": "#FF8476",
+        "value": "#ff7665",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -769,7 +769,7 @@
         }
       },
       "700": {
-        "value": "#FF5F4C",
+        "value": "#ff513d",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -780,7 +780,7 @@
         }
       },
       "800": {
-        "value": "#F73B26",
+        "value": "#f03823",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -791,7 +791,7 @@
         }
       },
       "900": {
-        "value": "#D73220",
+        "value": "#d73220",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -802,7 +802,7 @@
         }
       },
       "1000": {
-        "value": "#B72818",
+        "value": "#b72818",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -892,7 +892,7 @@
         }
       },
       "200": {
-        "value": "#caffa4",
+        "value": "#c5ff9c",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -903,7 +903,7 @@
         }
       },
       "300": {
-        "value": "#9bf65a",
+        "value": "#9df75c",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -914,7 +914,7 @@
         }
       },
       "400": {
-        "value": "#83e63c",
+        "value": "#81e43a",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -925,7 +925,7 @@
         }
       },
       "500": {
-        "value": "#71d22c",
+        "value": "#6ece2a",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -936,7 +936,7 @@
         }
       },
       "600": {
-        "value": "#63bd22",
+        "value": "#5db41f",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -947,7 +947,7 @@
         }
       },
       "700": {
-        "value": "#55a81b",
+        "value": "#52a119",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -958,7 +958,7 @@
         }
       },
       "800": {
-        "value": "#4b9515",
+        "value": "#489014",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1092,7 +1092,7 @@
         }
       },
       "400": {
-        "value": "#b8dd00",
+        "value": "#b6db00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1103,7 +1103,7 @@
         }
       },
       "500": {
-        "value": "#a6c800",
+        "value": "#a3c400",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1114,7 +1114,7 @@
         }
       },
       "600": {
-        "value": "#95b400",
+        "value": "#8fac00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1125,7 +1125,7 @@
         }
       },
       "700": {
-        "value": "#859f00",
+        "value": "#809900",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1136,7 +1136,7 @@
         }
       },
       "800": {
-        "value": "#768d00",
+        "value": "#728900",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1259,7 +1259,7 @@
         }
       },
       "300": {
-        "value": "#b5e6fc",
+        "value": "#b7e7fc",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1270,7 +1270,7 @@
         }
       },
       "400": {
-        "value": "#92d8ff",
+        "value": "#8ad5ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1281,7 +1281,7 @@
         }
       },
       "500": {
-        "value": "#63c4ff",
+        "value": "#5cc0ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1292,7 +1292,7 @@
         }
       },
       "600": {
-        "value": "#3cafff",
+        "value": "#30a7fe",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1303,7 +1303,7 @@
         }
       },
       "700": {
-        "value": "#229bef",
+        "value": "#1d95e7",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1314,7 +1314,7 @@
         }
       },
       "800": {
-        "value": "#158ad4",
+        "value": "#1286cd",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1415,7 +1415,7 @@
     },
     "fuchsia": {
       "100": {
-        "value": "#fff5ff",
+        "value": "#fef6ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1426,7 +1426,7 @@
         }
       },
       "200": {
-        "value": "#ffe8fe",
+        "value": "#fde9ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1437,7 +1437,7 @@
         }
       },
       "300": {
-        "value": "#ffd0fe",
+        "value": "#fad3ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1448,7 +1448,7 @@
         }
       },
       "400": {
-        "value": "#ffb6fe",
+        "value": "#f7b5ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1459,7 +1459,7 @@
         }
       },
       "500": {
-        "value": "#ff95fc",
+        "value": "#f393ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1470,7 +1470,7 @@
         }
       },
       "600": {
-        "value": "#ff6df9",
+        "value": "#ec69ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1481,7 +1481,7 @@
         }
       },
       "700": {
-        "value": "#f34be7",
+        "value": "#df4df5",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1492,7 +1492,7 @@
         }
       },
       "800": {
-        "value": "#d942cc",
+        "value": "#c844dc",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1503,7 +1503,7 @@
         }
       },
       "900": {
-        "value": "#c032b4",
+        "value": "#b539c8",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1514,7 +1514,7 @@
         }
       },
       "1000": {
-        "value": "#a6229d",
+        "value": "#9c28af",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1525,7 +1525,7 @@
         }
       },
       "1100": {
-        "value": "#901589",
+        "value": "#871b9a",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1536,7 +1536,7 @@
         }
       },
       "1200": {
-        "value": "#780974",
+        "value": "#710f83",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1547,7 +1547,7 @@
         }
       },
       "1300": {
-        "value": "#630160",
+        "value": "#5c046d",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1558,7 +1558,7 @@
         }
       },
       "1400": {
-        "value": "#4d004b",
+        "value": "#480058",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1569,7 +1569,7 @@
         }
       },
       "1500": {
-        "value": "#390038",
+        "value": "#360042",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1580,7 +1580,7 @@
         }
       },
       "1600": {
-        "value": "#1f001e",
+        "value": "#1d0023",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1615,7 +1615,7 @@
         }
       },
       "300": {
-        "value": "#d6ddff",
+        "value": "#d8deff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1626,7 +1626,7 @@
         }
       },
       "400": {
-        "value": "#c3ccff",
+        "value": "#c0c9ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1637,7 +1637,7 @@
         }
       },
       "500": {
-        "value": "#abb6ff",
+        "value": "#a7b2ff",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1648,7 +1648,7 @@
         }
       },
       "600": {
-        "value": "#98a0ff",
+        "value": "#9197fe",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1659,7 +1659,7 @@
         }
       },
       "700": {
-        "value": "#8888fe",
+        "value": "#8480fe",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1670,7 +1670,7 @@
         }
       },
       "800": {
-        "value": "#7d70fe",
+        "value": "#7a6afd",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1681,7 +1681,7 @@
         }
       },
       "900": {
-        "value": "#7154fa",
+        "value": "#7155fa",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1782,7 +1782,7 @@
         }
       },
       "200": {
-        "value": "#ffebf2",
+        "value": "#ffe8f0",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1793,7 +1793,7 @@
         }
       },
       "300": {
-        "value": "#ffd3e2",
+        "value": "#ffd5e3",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1804,7 +1804,7 @@
         }
       },
       "400": {
-        "value": "#ffbdd4",
+        "value": "#ffb9d0",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1815,7 +1815,7 @@
         }
       },
       "500": {
-        "value": "#ff9ec0",
+        "value": "#ff98bb",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1826,7 +1826,7 @@
         }
       },
       "600": {
-        "value": "#ff7eac",
+        "value": "#ff709f",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1837,7 +1837,7 @@
         }
       },
       "700": {
-        "value": "#ff5691",
+        "value": "#ff4885",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1848,7 +1848,7 @@
         }
       },
       "800": {
-        "value": "#f9296f",
+        "value": "#f02d6e",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1859,7 +1859,7 @@
         }
       },
       "900": {
-        "value": "#de1459",
+        "value": "#d92361",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1870,7 +1870,7 @@
         }
       },
       "1000": {
-        "value": "#be0949",
+        "value": "#ba1650",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1960,7 +1960,7 @@
         }
       },
       "200": {
-        "value": "#f5edfc",
+        "value": "#f4ebfc",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1971,7 +1971,7 @@
         }
       },
       "300": {
-        "value": "#ead8f9",
+        "value": "#ebdaf9",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1982,7 +1982,7 @@
         }
       },
       "400": {
-        "value": "#dfc4f7",
+        "value": "#ddc1f6",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1993,7 +1993,7 @@
         }
       },
       "500": {
-        "value": "#d2abf3",
+        "value": "#d0a7f3",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2004,7 +2004,7 @@
         }
       },
       "600": {
-        "value": "#c493f0",
+        "value": "#bf8aee",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2015,7 +2015,7 @@
         }
       },
       "700": {
-        "value": "#b77aec",
+        "value": "#b272eb",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2026,7 +2026,7 @@
         }
       },
       "800": {
-        "value": "#a962e8",
+        "value": "#a65ce7",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2037,7 +2037,7 @@
         }
       },
       "900": {
-        "value": "#9947e2",
+        "value": "#9a47e2",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2127,7 +2127,7 @@
     },
     "seafoam": {
       "100": {
-        "value": "#e2fcfd",
+        "value": "#ebfbf6",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2138,7 +2138,7 @@
         }
       },
       "200": {
-        "value": "#caf8fa",
+        "value": "#d3f6ea",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2149,7 +2149,7 @@
         }
       },
       "300": {
-        "value": "#8aeff2",
+        "value": "#a9edd8",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2160,7 +2160,7 @@
         }
       },
       "400": {
-        "value": "#56e2e7",
+        "value": "#5ce1c2",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2171,7 +2171,7 @@
         }
       },
       "500": {
-        "value": "#3cced3",
+        "value": "#10cfa9",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2182,7 +2182,7 @@
         }
       },
       "600": {
-        "value": "#2db9be",
+        "value": "#0db595",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2193,7 +2193,7 @@
         }
       },
       "700": {
-        "value": "#23a4a9",
+        "value": "#0ba286",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2204,7 +2204,7 @@
         }
       },
       "800": {
-        "value": "#1b9297",
+        "value": "#099078",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2215,7 +2215,7 @@
         }
       },
       "900": {
-        "value": "#147e83",
+        "value": "#07816d",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2226,7 +2226,7 @@
         }
       },
       "1000": {
-        "value": "#0d6a6f",
+        "value": "#056c5c",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2237,7 +2237,7 @@
         }
       },
       "1100": {
-        "value": "#085a5f",
+        "value": "#035c50",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2248,7 +2248,7 @@
         }
       },
       "1200": {
-        "value": "#034a4f",
+        "value": "#014b43",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2259,7 +2259,7 @@
         }
       },
       "1300": {
-        "value": "#003b3f",
+        "value": "#003c36",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2270,7 +2270,7 @@
         }
       },
       "1400": {
-        "value": "#002d30",
+        "value": "#002e28",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2281,7 +2281,7 @@
         }
       },
       "1500": {
-        "value": "#002023",
+        "value": "#00211d",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2292,7 +2292,7 @@
         }
       },
       "1600": {
-        "value": "#000f11",
+        "value": "#000f0e",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2338,7 +2338,7 @@
         }
       },
       "400": {
-        "value": "#f7cb00",
+        "value": "#f5c700",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2349,7 +2349,7 @@
         }
       },
       "500": {
-        "value": "#e9b300",
+        "value": "#e6af00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2360,7 +2360,7 @@
         }
       },
       "600": {
-        "value": "#d99e00",
+        "value": "#d29500",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2371,7 +2371,7 @@
         }
       },
       "700": {
-        "value": "#c78900",
+        "value": "#c18300",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2382,7 +2382,7 @@
         }
       },
       "800": {
-        "value": "#b47700",
+        "value": "#af7400",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao -->

## Description

Updated existing non-gray S2 palette colors, in light and dark:
- blue
- green
- orange
- red
- celery
- chartreuse
- cyan
- fuchsia
- indigo
- magenta
- purple
- seafoam
- yellow

## Motivation and context

This update addresses several improvements:
- fuchsia, seafoam: all values shifted to make room for new colors, pink and turquoise
- all other colors: certain values were updated to address accessibility contrast requirements against Spectrum 2 background layer colors

## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->
[SDS-13195](https://jira.corp.adobe.com/browse/SDS-13195)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue)
- [x] Minor (add a new token, changing a value; non-breaking change which adds functionality)
- [ ] Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.)
