### PR TITLE
Updated workflow-icon-sizes for desktop and mobile

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/icon/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/icon/desktop.json
@@ -506,7 +506,7 @@
     }
   },
   "workflow-icon-size-100": {
-    "value": "18px",
+    "value": "20px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -517,7 +517,7 @@
     }
   },
   "workflow-icon-size-200": {
-    "value": "20px",
+    "value": "22px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -528,7 +528,7 @@
     }
   },
   "workflow-icon-size-300": {
-    "value": "22px",
+    "value": "26px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/icon/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/icon/mobile.json
@@ -506,7 +506,7 @@
     }
   },
   "workflow-icon-size-100": {
-    "value": "22px",
+    "value": "24px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -517,7 +517,7 @@
     }
   },
   "workflow-icon-size-200": {
-    "value": "24px",
+    "value": "28px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -528,7 +528,7 @@
     }
   },
   "workflow-icon-size-300": {
-    "value": "28px",
+    "value": "30px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -539,7 +539,7 @@
     }
   },
   "workflow-icon-size-50": {
-    "value": "18px",
+    "value": "16px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -550,7 +550,7 @@
     }
   },
   "workflow-icon-size-75": {
-    "value": "20px",
+    "value": "18px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao -->

## Description

- Updated workflow-icon-size-50, 75, 100, 200, 300 with Spectrum 2 values in mobile and desktop

## Motivation and context

- Spectrum 2 icons have a different workflow icon sizing with base sizes 20 px (desktop), 24 px (mobile)

## Related issue

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue)
- [x] Minor (add a new token, changing a value; non-breaking change which adds functionality)
- [ ] Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.)
