### PR TITLE
fix: alpha-numeric sorting of tokens

### DIFF
--- a/scripts/sortJson.js
+++ b/scripts/sortJson.js
@@ -1,0 +1,79 @@
+const fs = require("fs");
+const path = require("path");
+const { Dirent } = require("fs");
+const { writeFile } = require("fs/promises");
+const fsExtra = require("fs-extra");
+
+// function innerSort(a, b) {
+//   if (!a.hasOwnProperty(key) || !b.hasOwnProperty(key)) {
+//     return 0;
+//   }
+//   const comparison = a[key].localeCompare(b[key]);
+//   return (
+//     order === 'desc' ? comparison * -1 : comparison
+//   );
+// }
+
+function sortAlphaNumeric(a, b) {
+  // convert to strings and force lowercase
+  a = typeof a === "string" ? a.toLowerCase() : a.toString();
+  b = typeof b === "string" ? b.toLowerCase() : b.toString();
+
+  return a.localeCompare(b, "en-us", { numeric: true });
+}
+
+/**
+ * Sort JSON file
+ * @param {Object} data JSON object
+ */
+function sortJson(data) {
+  return data.sort((a, b) => {
+    return sortAlphaNumeric(a[0], b[0]);
+  });
+}
+
+async function convertFilesInDirectory(rootFolder, directoryPath) {
+  const folder = path.join(rootFolder, directoryPath);
+  console.log(`Converting files in folder ${folder}...`);
+
+  // get directory content
+  const entries = await fsExtra.readdir(folder, { withFileTypes: true });
+
+  // iterate over directory content
+  for (let entry of entries) {
+    console.log({ entry });
+    if (entry.isFile() && entry.name.endsWith(".json")) {
+      console.log(`Converting file ${entry.name}...`);
+      // let currentFile = 'src/tokens-studio/spectrum-non-colors/spectrum/icon/desktop.json';
+      let currentFile = path.join(folder, entry.name);
+      let dataFile = JSON.parse(fsExtra.readFileSync(currentFile, "utf-8"));
+      let sortedData = sortJson(Object.entries(dataFile)).reduce(
+        (r, [k, v]) => ({ ...r, [k]: v }),
+        {},
+      );
+      // write the sorted JSON to a new file;
+      await writeFile(currentFile, JSON.stringify(sortedData, null, 2));
+      console.log(`Wrote ${currentFile} with key sorted alpha-numerically.`);
+    } else if (entry.isDirectory()) {
+      console.log(`Found folder ${entry.name}. Go recursive...`);
+      await convertFilesInDirectory(folder, entry.name);
+    }
+  }
+}
+
+const main = async () => {
+  console.log("Running key sorting alpha-numerically...");
+
+  const workingDir = process.cwd();
+
+  await convertFilesInDirectory(
+    workingDir,
+    "src/tokens-studio/spectrum-non-colors/spectrum/",
+  );
+
+  console.log("No Errors");
+  console.log("Finish test.");
+  process.exit(0);
+};
+
+main();

--- a/src/tokens-studio/spectrum-non-colors/spectrum/icon/desktop.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/icon/desktop.json
@@ -1,4 +1,15 @@
 {
+  "arrow-icon-size-75": {
+    "value": "10px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "b39b3ce3-6a48-4025-96ef-659b0c9ae9e8",
+        "name": "arrow-icon-size-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "arrow-icon-size-100": {
     "value": "10px",
     "type": "sizing",
@@ -65,13 +76,13 @@
       }
     }
   },
-  "arrow-icon-size-75": {
-    "value": "10px",
+  "asterisk-icon-size-75": {
+    "value": "8px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "b39b3ce3-6a48-4025-96ef-659b0c9ae9e8",
-        "name": "arrow-icon-size-75",
+        "uuid": "49ea57ee-7b12-4a8b-a9bb-a11cf2c9d72c",
+        "name": "asterisk-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -109,13 +120,24 @@
       }
     }
   },
-  "asterisk-icon-size-75": {
-    "value": "8px",
+  "checkmark-icon-size-50": {
+    "value": "10px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "49ea57ee-7b12-4a8b-a9bb-a11cf2c9d72c",
-        "name": "asterisk-icon-size-75",
+        "uuid": "6335cb3a-6ceb-40e7-b241-ff9b36f1277c",
+        "name": "checkmark-icon-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "checkmark-icon-size-75": {
+    "value": "10px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "0545a68c-f273-4348-84cd-9cd365bdb474",
+        "name": "checkmark-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -164,17 +186,6 @@
       }
     }
   },
-  "checkmark-icon-size-50": {
-    "value": "10px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "6335cb3a-6ceb-40e7-b241-ff9b36f1277c",
-        "name": "checkmark-icon-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "checkmark-icon-size-500": {
     "value": "16px",
     "type": "sizing",
@@ -197,13 +208,24 @@
       }
     }
   },
-  "checkmark-icon-size-75": {
+  "chevron-icon-size-50": {
+    "value": "6px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "785a9152-a69b-4164-a8e2-cc201c1f8063",
+        "name": "chevron-icon-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "chevron-icon-size-75": {
     "value": "10px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "0545a68c-f273-4348-84cd-9cd365bdb474",
-        "name": "checkmark-icon-size-75",
+        "uuid": "43ef1792-b182-419d-966c-a8a2d77dbe03",
+        "name": "chevron-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -252,17 +274,6 @@
       }
     }
   },
-  "chevron-icon-size-50": {
-    "value": "6px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "785a9152-a69b-4164-a8e2-cc201c1f8063",
-        "name": "chevron-icon-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "chevron-icon-size-500": {
     "value": "16px",
     "type": "sizing",
@@ -285,13 +296,13 @@
       }
     }
   },
-  "chevron-icon-size-75": {
-    "value": "10px",
+  "corner-triangle-icon-size-75": {
+    "value": "5px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "43ef1792-b182-419d-966c-a8a2d77dbe03",
-        "name": "chevron-icon-size-75",
+        "uuid": "490fac13-d347-4c21-85fa-57814bff7537",
+        "name": "corner-triangle-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -329,13 +340,13 @@
       }
     }
   },
-  "corner-triangle-icon-size-75": {
-    "value": "5px",
+  "cross-icon-size-75": {
+    "value": "8px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "490fac13-d347-4c21-85fa-57814bff7537",
-        "name": "corner-triangle-icon-size-75",
+        "uuid": "8e597833-1025-4de4-b34a-2f34201487c3",
+        "name": "cross-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -406,13 +417,24 @@
       }
     }
   },
-  "cross-icon-size-75": {
+  "dash-icon-size-50": {
     "value": "8px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "8e597833-1025-4de4-b34a-2f34201487c3",
-        "name": "cross-icon-size-75",
+        "uuid": "59e5a3f7-c1d0-4b76-bb7e-2bcddddb83da",
+        "name": "dash-icon-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "dash-icon-size-75": {
+    "value": "8px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "bfd0ad6e-6656-46d6-aa9f-0940b2c2902a",
+        "name": "dash-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -461,17 +483,6 @@
       }
     }
   },
-  "dash-icon-size-50": {
-    "value": "8px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "59e5a3f7-c1d0-4b76-bb7e-2bcddddb83da",
-        "name": "dash-icon-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "dash-icon-size-500": {
     "value": "16px",
     "type": "sizing",
@@ -494,13 +505,24 @@
       }
     }
   },
-  "dash-icon-size-75": {
-    "value": "8px",
+  "workflow-icon-size-50": {
+    "value": "14px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "bfd0ad6e-6656-46d6-aa9f-0940b2c2902a",
-        "name": "dash-icon-size-75",
+        "uuid": "1423caf1-75ca-4ca8-aa6a-22dcf3655b0e",
+        "name": "workflow-icon-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "workflow-icon-size-75": {
+    "value": "16px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "85cdef34-0682-45eb-ac06-98c76883cdf7",
+        "name": "workflow-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -534,28 +556,6 @@
       "spectrum-tokens": {
         "uuid": "25908278-79d3-47f4-9b53-adbdd1c13e2a",
         "name": "workflow-icon-size-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "workflow-icon-size-50": {
-    "value": "14px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "1423caf1-75ca-4ca8-aa6a-22dcf3655b0e",
-        "name": "workflow-icon-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "workflow-icon-size-75": {
-    "value": "16px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "85cdef34-0682-45eb-ac06-98c76883cdf7",
-        "name": "workflow-icon-size-75",
         "constant-token-duplicate": false
       }
     }

--- a/src/tokens-studio/spectrum-non-colors/spectrum/icon/mobile.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/icon/mobile.json
@@ -1,4 +1,15 @@
 {
+  "arrow-icon-size-75": {
+    "value": "12px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "6ff35aff-8a9f-466c-bdd3-dda460ccaee5",
+        "name": "arrow-icon-size-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "arrow-icon-size-100": {
     "value": "14px",
     "type": "sizing",
@@ -65,13 +76,13 @@
       }
     }
   },
-  "arrow-icon-size-75": {
-    "value": "12px",
+  "asterisk-icon-size-75": {
+    "value": "8px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "6ff35aff-8a9f-466c-bdd3-dda460ccaee5",
-        "name": "arrow-icon-size-75",
+        "uuid": "bcba4d11-e15a-4ebc-a152-224ef228036a",
+        "name": "asterisk-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -109,13 +120,24 @@
       }
     }
   },
-  "asterisk-icon-size-75": {
-    "value": "8px",
+  "checkmark-icon-size-50": {
+    "value": "12px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "bcba4d11-e15a-4ebc-a152-224ef228036a",
-        "name": "asterisk-icon-size-75",
+        "uuid": "ee52f114-1ab6-430b-bd54-62a82bf3600e",
+        "name": "checkmark-icon-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "checkmark-icon-size-75": {
+    "value": "12px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "99224b4e-751a-49ec-8db4-41c8cc4c7bf5",
+        "name": "checkmark-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -164,17 +186,6 @@
       }
     }
   },
-  "checkmark-icon-size-50": {
-    "value": "12px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "ee52f114-1ab6-430b-bd54-62a82bf3600e",
-        "name": "checkmark-icon-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "checkmark-icon-size-500": {
     "value": "20px",
     "type": "sizing",
@@ -197,13 +208,24 @@
       }
     }
   },
-  "checkmark-icon-size-75": {
+  "chevron-icon-size-50": {
+    "value": "8px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "6d8ce7eb-a2a2-496c-9ce7-847f4da5fc0c",
+        "name": "chevron-icon-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "chevron-icon-size-75": {
     "value": "12px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "99224b4e-751a-49ec-8db4-41c8cc4c7bf5",
-        "name": "checkmark-icon-size-75",
+        "uuid": "74dbb8c0-2e65-413d-8b52-7215993b5696",
+        "name": "chevron-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -252,17 +274,6 @@
       }
     }
   },
-  "chevron-icon-size-50": {
-    "value": "8px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "6d8ce7eb-a2a2-496c-9ce7-847f4da5fc0c",
-        "name": "chevron-icon-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "chevron-icon-size-500": {
     "value": "20px",
     "type": "sizing",
@@ -285,13 +296,13 @@
       }
     }
   },
-  "chevron-icon-size-75": {
-    "value": "12px",
+  "corner-triangle-icon-size-75": {
+    "value": "6px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "74dbb8c0-2e65-413d-8b52-7215993b5696",
-        "name": "chevron-icon-size-75",
+        "uuid": "434b019c-efde-437a-967b-b841ec95e621",
+        "name": "corner-triangle-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -329,13 +340,13 @@
       }
     }
   },
-  "corner-triangle-icon-size-75": {
-    "value": "6px",
+  "cross-icon-size-75": {
+    "value": "10px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "434b019c-efde-437a-967b-b841ec95e621",
-        "name": "corner-triangle-icon-size-75",
+        "uuid": "622d259d-b52b-409a-bf58-04705d8423f9",
+        "name": "cross-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -406,13 +417,24 @@
       }
     }
   },
-  "cross-icon-size-75": {
+  "dash-icon-size-50": {
     "value": "10px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "622d259d-b52b-409a-bf58-04705d8423f9",
-        "name": "cross-icon-size-75",
+        "uuid": "ea331ff6-aa92-4cb4-936a-554a2404152d",
+        "name": "dash-icon-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "dash-icon-size-75": {
+    "value": "10px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "1b6d0e50-3ba2-43c9-8b8c-c220364f4434",
+        "name": "dash-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -461,17 +483,6 @@
       }
     }
   },
-  "dash-icon-size-50": {
-    "value": "10px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "ea331ff6-aa92-4cb4-936a-554a2404152d",
-        "name": "dash-icon-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "dash-icon-size-500": {
     "value": "20px",
     "type": "sizing",
@@ -494,13 +505,24 @@
       }
     }
   },
-  "dash-icon-size-75": {
-    "value": "10px",
+  "workflow-icon-size-50": {
+    "value": "18px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "1b6d0e50-3ba2-43c9-8b8c-c220364f4434",
-        "name": "dash-icon-size-75",
+        "uuid": "4c4cb541-7d42-4bb4-9c86-7197c4600896",
+        "name": "workflow-icon-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "workflow-icon-size-75": {
+    "value": "20px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "b720c214-babe-426d-9629-9ec60d5e8622",
+        "name": "workflow-icon-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -534,28 +556,6 @@
       "spectrum-tokens": {
         "uuid": "df0dc6c3-59fc-4ee0-87a9-c3d49a07cf9c",
         "name": "workflow-icon-size-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "workflow-icon-size-50": {
-    "value": "18px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "4c4cb541-7d42-4bb4-9c86-7197c4600896",
-        "name": "workflow-icon-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "workflow-icon-size-75": {
-    "value": "20px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "b720c214-babe-426d-9629-9ec60d5e8622",
-        "name": "workflow-icon-size-75",
         "constant-token-duplicate": false
       }
     }

--- a/src/tokens-studio/spectrum-non-colors/spectrum/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/layout.component/desktop.json
@@ -516,6 +516,28 @@
       }
     }
   },
+  "avatar-size-50": {
+    "value": "16px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "60fd0b38-3bad-4a0f-8a69-d4cf79b635ff",
+        "name": "avatar-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "avatar-size-75": {
+    "value": "18px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "6aa2d529-0e10-4eaf-8786-f38e04e4d438",
+        "name": "avatar-size-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "avatar-size-100": {
     "value": "20px",
     "type": "sizing",
@@ -560,17 +582,6 @@
       }
     }
   },
-  "avatar-size-50": {
-    "value": "16px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "60fd0b38-3bad-4a0f-8a69-d4cf79b635ff",
-        "name": "avatar-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "avatar-size-500": {
     "value": "32px",
     "type": "sizing",
@@ -600,17 +611,6 @@
       "spectrum-tokens": {
         "uuid": "92260f9e-ad2a-4e46-ad65-d83d99f7e7b7",
         "name": "avatar-size-700",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "avatar-size-75": {
-    "value": "18px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "6aa2d529-0e10-4eaf-8786-f38e04e4d438",
-        "name": "avatar-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -4839,6 +4839,28 @@
       }
     }
   },
+  "thumbnail-size-50": {
+    "value": "16px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "0578d5e5-9c2d-46f2-9268-85bdf566b3a5",
+        "name": "thumbnail-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "thumbnail-size-75": {
+    "value": "18px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "20706cc7-9d07-4938-8328-debd3ab8d822",
+        "name": "thumbnail-size-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "thumbnail-size-100": {
     "value": "20px",
     "type": "sizing",
@@ -4846,17 +4868,6 @@
       "spectrum-tokens": {
         "uuid": "46dd2eca-598a-45e3-8c7d-c6cf17e148bf",
         "name": "thumbnail-size-100",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "thumbnail-size-1000": {
-    "value": "56px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "48959be8-02f9-45b9-8190-af60c93cbb6c",
-        "name": "thumbnail-size-1000",
         "constant-token-duplicate": false
       }
     }
@@ -4894,17 +4905,6 @@
       }
     }
   },
-  "thumbnail-size-50": {
-    "value": "16px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "0578d5e5-9c2d-46f2-9268-85bdf566b3a5",
-        "name": "thumbnail-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "thumbnail-size-500": {
     "value": "32px",
     "type": "sizing",
@@ -4938,17 +4938,6 @@
       }
     }
   },
-  "thumbnail-size-75": {
-    "value": "18px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "20706cc7-9d07-4938-8328-debd3ab8d822",
-        "name": "thumbnail-size-75",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "thumbnail-size-800": {
     "value": "44px",
     "type": "sizing",
@@ -4967,6 +4956,17 @@
       "spectrum-tokens": {
         "uuid": "5b9fb77d-8a2e-4e1c-ba86-475cd66b4202",
         "name": "thumbnail-size-900",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "thumbnail-size-1000": {
+    "value": "56px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "48959be8-02f9-45b9-8190-af60c93cbb6c",
+        "name": "thumbnail-size-1000",
         "constant-token-duplicate": false
       }
     }

--- a/src/tokens-studio/spectrum-non-colors/spectrum/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/layout.component/mobile.json
@@ -516,6 +516,28 @@
       }
     }
   },
+  "avatar-size-50": {
+    "value": "20px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "6f6fae3d-eafd-41d7-a863-b2f0b57240ab",
+        "name": "avatar-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "avatar-size-75": {
+    "value": "22px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "f23636e9-93e2-444d-a95b-1311a7e074f3",
+        "name": "avatar-size-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "avatar-size-100": {
     "value": "26px",
     "type": "sizing",
@@ -560,17 +582,6 @@
       }
     }
   },
-  "avatar-size-50": {
-    "value": "20px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "6f6fae3d-eafd-41d7-a863-b2f0b57240ab",
-        "name": "avatar-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "avatar-size-500": {
     "value": "40px",
     "type": "sizing",
@@ -600,17 +611,6 @@
       "spectrum-tokens": {
         "uuid": "0bec4f0f-efb2-44f9-a131-28f8fe248c40",
         "name": "avatar-size-700",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "avatar-size-75": {
-    "value": "22px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "f23636e9-93e2-444d-a95b-1311a7e074f3",
-        "name": "avatar-size-75",
         "constant-token-duplicate": false
       }
     }
@@ -4839,6 +4839,28 @@
       }
     }
   },
+  "thumbnail-size-50": {
+    "value": "20px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "7f33676b-63dd-4d16-b7e1-36520ade716d",
+        "name": "thumbnail-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "thumbnail-size-75": {
+    "value": "22px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "852fc55b-beb7-428c-bc0c-452abc204de3",
+        "name": "thumbnail-size-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "thumbnail-size-100": {
     "value": "26px",
     "type": "sizing",
@@ -4846,17 +4868,6 @@
       "spectrum-tokens": {
         "uuid": "545604c8-484f-4697-907c-31e2b2cb46d0",
         "name": "thumbnail-size-100",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "thumbnail-size-1000": {
-    "value": "70px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "cfbf3ec4-f51d-4a50-b81c-765fff84ce14",
-        "name": "thumbnail-size-1000",
         "constant-token-duplicate": false
       }
     }
@@ -4894,17 +4905,6 @@
       }
     }
   },
-  "thumbnail-size-50": {
-    "value": "20px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "7f33676b-63dd-4d16-b7e1-36520ade716d",
-        "name": "thumbnail-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "thumbnail-size-500": {
     "value": "40px",
     "type": "sizing",
@@ -4938,17 +4938,6 @@
       }
     }
   },
-  "thumbnail-size-75": {
-    "value": "22px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "852fc55b-beb7-428c-bc0c-452abc204de3",
-        "name": "thumbnail-size-75",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "thumbnail-size-800": {
     "value": "55px",
     "type": "sizing",
@@ -4967,6 +4956,17 @@
       "spectrum-tokens": {
         "uuid": "97f11dd2-0173-464c-9eef-c260c9e8cf22",
         "name": "thumbnail-size-900",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "thumbnail-size-1000": {
+    "value": "70px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "cfbf3ec4-f51d-4a50-b81c-765fff84ce14",
+        "name": "thumbnail-size-1000",
         "constant-token-duplicate": false
       }
     }

--- a/src/tokens-studio/spectrum-non-colors/spectrum/layout/desktop.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/layout/desktop.json
@@ -98,6 +98,28 @@
       }
     }
   },
+  "component-bottom-to-text-50": {
+    "value": "3px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "ee165c7d-3e9a-4a8d-a71f-3083fd7fdc4b",
+        "name": "component-bottom-to-text-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "component-bottom-to-text-75": {
+    "value": "5px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "923c46e1-b6f7-4d8a-844d-b4c0661b5e60",
+        "name": "component-bottom-to-text-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "component-bottom-to-text-100": {
     "value": "9px",
     "type": "spacing",
@@ -131,24 +153,24 @@
       }
     }
   },
-  "component-bottom-to-text-50": {
-    "value": "3px",
+  "component-edge-to-text-50": {
+    "value": "8px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "ee165c7d-3e9a-4a8d-a71f-3083fd7fdc4b",
-        "name": "component-bottom-to-text-50",
+        "uuid": "b8af0ff9-1e4b-4298-907d-3ffcde88ba03",
+        "name": "component-edge-to-text-50",
         "constant-token-duplicate": false
       }
     }
   },
-  "component-bottom-to-text-75": {
-    "value": "5px",
+  "component-edge-to-text-75": {
+    "value": "9px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "923c46e1-b6f7-4d8a-844d-b4c0661b5e60",
-        "name": "component-bottom-to-text-75",
+        "uuid": "40778817-6e47-4b58-a495-c4f34cee78df",
+        "name": "component-edge-to-text-75",
         "constant-token-duplicate": false
       }
     }
@@ -186,24 +208,24 @@
       }
     }
   },
-  "component-edge-to-text-50": {
-    "value": "8px",
+  "component-edge-to-visual-50": {
+    "value": "6px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "b8af0ff9-1e4b-4298-907d-3ffcde88ba03",
-        "name": "component-edge-to-text-50",
+        "uuid": "a0b6c266-499d-4292-9be4-705ddd5e9fbc",
+        "name": "component-edge-to-visual-50",
         "constant-token-duplicate": false
       }
     }
   },
-  "component-edge-to-text-75": {
-    "value": "9px",
+  "component-edge-to-visual-75": {
+    "value": "7px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "40778817-6e47-4b58-a495-c4f34cee78df",
-        "name": "component-edge-to-text-75",
+        "uuid": "8d128c7d-ab8e-4a4e-9243-a2e919cb6e6f",
+        "name": "component-edge-to-visual-75",
         "constant-token-duplicate": false
       }
     }
@@ -241,24 +263,24 @@
       }
     }
   },
-  "component-edge-to-visual-50": {
-    "value": "6px",
+  "component-edge-to-visual-only-50": {
+    "value": "3px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "a0b6c266-499d-4292-9be4-705ddd5e9fbc",
-        "name": "component-edge-to-visual-50",
+        "uuid": "9c536051-7794-4282-bf07-c920cda83cbe",
+        "name": "component-edge-to-visual-only-50",
         "constant-token-duplicate": false
       }
     }
   },
-  "component-edge-to-visual-75": {
-    "value": "7px",
+  "component-edge-to-visual-only-75": {
+    "value": "4px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "8d128c7d-ab8e-4a4e-9243-a2e919cb6e6f",
-        "name": "component-edge-to-visual-75",
+        "uuid": "c38259e9-87f4-4e7d-a041-692ca676a638",
+        "name": "component-edge-to-visual-only-75",
         "constant-token-duplicate": false
       }
     }
@@ -296,24 +318,24 @@
       }
     }
   },
-  "component-edge-to-visual-only-50": {
-    "value": "3px",
-    "type": "spacing",
+  "component-height-50": {
+    "value": "20px",
+    "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "9c536051-7794-4282-bf07-c920cda83cbe",
-        "name": "component-edge-to-visual-only-50",
+        "uuid": "81ebf2b1-01fd-45a3-a099-72048e7d7991",
+        "name": "component-height-50",
         "constant-token-duplicate": false
       }
     }
   },
-  "component-edge-to-visual-only-75": {
-    "value": "4px",
-    "type": "spacing",
+  "component-height-75": {
+    "value": "24px",
+    "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "c38259e9-87f4-4e7d-a041-692ca676a638",
-        "name": "component-edge-to-visual-only-75",
+        "uuid": "f70d4c16-f588-4fa9-9318-b7184a739193",
+        "name": "component-height-75",
         "constant-token-duplicate": false
       }
     }
@@ -362,17 +384,6 @@
       }
     }
   },
-  "component-height-50": {
-    "value": "20px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "81ebf2b1-01fd-45a3-a099-72048e7d7991",
-        "name": "component-height-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "component-height-500": {
     "value": "64px",
     "type": "sizing",
@@ -384,13 +395,13 @@
       }
     }
   },
-  "component-height-75": {
-    "value": "24px",
-    "type": "sizing",
+  "component-pill-edge-to-text-75": {
+    "value": "12px",
+    "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "f70d4c16-f588-4fa9-9318-b7184a739193",
-        "name": "component-height-75",
+        "uuid": "5c80900c-ff68-4b78-86fa-571bbf1eb9aa",
+        "name": "component-pill-edge-to-text-75",
         "constant-token-duplicate": false
       }
     }
@@ -428,13 +439,13 @@
       }
     }
   },
-  "component-pill-edge-to-text-75": {
-    "value": "12px",
+  "component-pill-edge-to-visual-75": {
+    "value": "10px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "5c80900c-ff68-4b78-86fa-571bbf1eb9aa",
-        "name": "component-pill-edge-to-text-75",
+        "uuid": "3eaca9fb-25c0-4a1d-8c44-320cc0e0305b",
+        "name": "component-pill-edge-to-visual-75",
         "constant-token-duplicate": false
       }
     }
@@ -472,13 +483,13 @@
       }
     }
   },
-  "component-pill-edge-to-visual-75": {
-    "value": "10px",
+  "component-pill-edge-to-visual-only-75": {
+    "value": "4px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "3eaca9fb-25c0-4a1d-8c44-320cc0e0305b",
-        "name": "component-pill-edge-to-visual-75",
+        "uuid": "47f5ab02-22db-4d82-be1d-804669d7fbd4",
+        "name": "component-pill-edge-to-visual-only-75",
         "constant-token-duplicate": false
       }
     }
@@ -512,17 +523,6 @@
       "spectrum-tokens": {
         "uuid": "9654369a-5bf8-4436-a331-aeac1fd25a70",
         "name": "component-pill-edge-to-visual-only-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "component-pill-edge-to-visual-only-75": {
-    "value": "4px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "47f5ab02-22db-4d82-be1d-804669d7fbd4",
-        "name": "component-pill-edge-to-visual-only-75",
         "constant-token-duplicate": false
       }
     }
@@ -571,6 +571,28 @@
       }
     }
   },
+  "component-top-to-text-50": {
+    "value": "3px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "c71c0953-d9da-4e22-93a1-6982c7665ed6",
+        "name": "component-top-to-text-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "component-top-to-text-75": {
+    "value": "4px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "477d659b-6489-4e90-84db-75a93174559a",
+        "name": "component-top-to-text-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "component-top-to-text-100": {
     "value": "6px",
     "type": "spacing",
@@ -604,24 +626,24 @@
       }
     }
   },
-  "component-top-to-text-50": {
+  "component-top-to-workflow-icon-50": {
     "value": "3px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "c71c0953-d9da-4e22-93a1-6982c7665ed6",
-        "name": "component-top-to-text-50",
+        "uuid": "0fafc819-d65b-4952-849a-b3c426e9a4a9",
+        "name": "component-top-to-workflow-icon-50",
         "constant-token-duplicate": false
       }
     }
   },
-  "component-top-to-text-75": {
+  "component-top-to-workflow-icon-75": {
     "value": "4px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "477d659b-6489-4e90-84db-75a93174559a",
-        "name": "component-top-to-text-75",
+        "uuid": "2bc8b2ca-9792-4034-a604-43ce28ce8ede",
+        "name": "component-top-to-workflow-icon-75",
         "constant-token-duplicate": false
       }
     }
@@ -659,24 +681,13 @@
       }
     }
   },
-  "component-top-to-workflow-icon-50": {
-    "value": "3px",
-    "type": "spacing",
+  "corner-radius-75": {
+    "value": "2px",
+    "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "0fafc819-d65b-4952-849a-b3c426e9a4a9",
-        "name": "component-top-to-workflow-icon-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "component-top-to-workflow-icon-75": {
-    "value": "4px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "2bc8b2ca-9792-4034-a604-43ce28ce8ede",
-        "name": "component-top-to-workflow-icon-75",
+        "uuid": "ecb9d03a-7340-4b43-8aa7-f89eef9f3a20",
+        "name": "corner-radius-75",
         "constant-token-duplicate": false
       }
     }
@@ -699,17 +710,6 @@
       "spectrum-tokens": {
         "uuid": "52ad01be-f512-4fa3-ae67-8c6cef70810c",
         "name": "corner-radius-200",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "corner-radius-75": {
-    "value": "2px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "ecb9d03a-7340-4b43-8aa7-f89eef9f3a20",
-        "name": "corner-radius-75",
         "constant-token-duplicate": false
       }
     }
@@ -857,6 +857,17 @@
       }
     }
   },
+  "field-edge-to-disclosure-icon-75": {
+    "value": "7px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "7b68e88f-8ddd-496e-9fae-7fbe44317965",
+        "name": "field-edge-to-disclosure-icon-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "field-edge-to-disclosure-icon-100": {
     "value": "11px",
     "type": "spacing",
@@ -886,17 +897,6 @@
       "spectrum-tokens": {
         "uuid": "e84ef1dc-392b-4ab9-a13b-76364484a28d",
         "name": "field-edge-to-disclosure-icon-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "field-edge-to-disclosure-icon-75": {
-    "value": "7px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "7b68e88f-8ddd-496e-9fae-7fbe44317965",
-        "name": "field-edge-to-disclosure-icon-75",
         "constant-token-duplicate": false
       }
     }
@@ -978,6 +978,17 @@
       }
     }
   },
+  "field-end-edge-to-disclosure-icon-75": {
+    "value": "7px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "b79e5061-87c4-495c-ab01-90dcc5ae14ab",
+        "name": "field-end-edge-to-disclosure-icon-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "field-end-edge-to-disclosure-icon-100": {
     "value": "11px",
     "type": "spacing",
@@ -1007,17 +1018,6 @@
       "spectrum-tokens": {
         "uuid": "43ec5915-b039-4210-9bc0-ce547f90ce32",
         "name": "field-end-edge-to-disclosure-icon-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "field-end-edge-to-disclosure-icon-75": {
-    "value": "7px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "b79e5061-87c4-495c-ab01-90dcc5ae14ab",
-        "name": "field-end-edge-to-disclosure-icon-75",
         "constant-token-duplicate": false
       }
     }
@@ -1154,6 +1154,17 @@
       }
     }
   },
+  "field-top-to-disclosure-icon-75": {
+    "value": "7px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "c5778e77-0ff1-431a-a72e-37f3066d3257",
+        "name": "field-top-to-disclosure-icon-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "field-top-to-disclosure-icon-100": {
     "value": "11px",
     "type": "spacing",
@@ -1183,17 +1194,6 @@
       "spectrum-tokens": {
         "uuid": "d5db6c17-700e-4782-9c29-001269b50200",
         "name": "field-top-to-disclosure-icon-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "field-top-to-disclosure-icon-75": {
-    "value": "7px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "c5778e77-0ff1-431a-a72e-37f3066d3257",
-        "name": "field-top-to-disclosure-icon-75",
         "constant-token-duplicate": false
       }
     }
@@ -1418,6 +1418,28 @@
       }
     }
   },
+  "spacing-50": {
+    "value": "2px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "1b06f6e2-d9be-4934-b3da-bed75986d104",
+        "name": "spacing-50",
+        "constant-token-duplicate": true
+      }
+    }
+  },
+  "spacing-75": {
+    "value": "4px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "576a60a3-ca80-46c5-a066-ba7b6197decd",
+        "name": "spacing-75",
+        "constant-token-duplicate": true
+      }
+    }
+  },
   "spacing-100": {
     "value": "8px",
     "type": "spacing",
@@ -1425,17 +1447,6 @@
       "spectrum-tokens": {
         "uuid": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
         "name": "spacing-100",
-        "constant-token-duplicate": true
-      }
-    }
-  },
-  "spacing-1000": {
-    "value": "96px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "9d688a67-5ff6-4b72-8398-964c0337dce1",
-        "name": "spacing-1000",
         "constant-token-duplicate": true
       }
     }
@@ -1473,17 +1484,6 @@
       }
     }
   },
-  "spacing-50": {
-    "value": "2px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "1b06f6e2-d9be-4934-b3da-bed75986d104",
-        "name": "spacing-50",
-        "constant-token-duplicate": true
-      }
-    }
-  },
   "spacing-500": {
     "value": "32px",
     "type": "spacing",
@@ -1517,17 +1517,6 @@
       }
     }
   },
-  "spacing-75": {
-    "value": "4px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "576a60a3-ca80-46c5-a066-ba7b6197decd",
-        "name": "spacing-75",
-        "constant-token-duplicate": true
-      }
-    }
-  },
   "spacing-800": {
     "value": "64px",
     "type": "spacing",
@@ -1547,6 +1536,28 @@
         "uuid": "d04e5d81-0b6e-48e7-9e47-744753dfcff3",
         "name": "spacing-900",
         "constant-token-duplicate": true
+      }
+    }
+  },
+  "spacing-1000": {
+    "value": "96px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "9d688a67-5ff6-4b72-8398-964c0337dce1",
+        "name": "spacing-1000",
+        "constant-token-duplicate": true
+      }
+    }
+  },
+  "text-to-control-75": {
+    "value": "9px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "aa27af6e-baef-4d7c-bf8c-f9a972e51713",
+        "name": "text-to-control-75",
+        "constant-token-duplicate": false
       }
     }
   },
@@ -1583,13 +1594,24 @@
       }
     }
   },
-  "text-to-control-75": {
-    "value": "9px",
+  "text-to-visual-50": {
+    "value": "6px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "aa27af6e-baef-4d7c-bf8c-f9a972e51713",
-        "name": "text-to-control-75",
+        "uuid": "ff1fadc2-9ec0-456f-a054-4512e51c85c8",
+        "name": "text-to-visual-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "text-to-visual-75": {
+    "value": "7px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "50763a0d-c6eb-47f0-8b56-4c86ee22a430",
+        "name": "text-to-visual-75",
         "constant-token-duplicate": false
       }
     }
@@ -1623,28 +1645,6 @@
       "spectrum-tokens": {
         "uuid": "4366909e-3bfb-481c-abdc-4ae71f965bc3",
         "name": "text-to-visual-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "text-to-visual-50": {
-    "value": "6px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "ff1fadc2-9ec0-456f-a054-4512e51c85c8",
-        "name": "text-to-visual-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "text-to-visual-75": {
-    "value": "7px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "50763a0d-c6eb-47f0-8b56-4c86ee22a430",
-        "name": "text-to-visual-75",
         "constant-token-duplicate": false
       }
     }

--- a/src/tokens-studio/spectrum-non-colors/spectrum/layout/mobile.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/layout/mobile.json
@@ -98,6 +98,28 @@
       }
     }
   },
+  "component-bottom-to-text-50": {
+    "value": "6px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "80f01183-a152-4c55-ac11-24edae62df64",
+        "name": "component-bottom-to-text-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "component-bottom-to-text-75": {
+    "value": "6px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "0f1a6c63-bc4f-444c-9a18-67b6c35464b1",
+        "name": "component-bottom-to-text-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "component-bottom-to-text-100": {
     "value": "11px",
     "type": "spacing",
@@ -131,24 +153,24 @@
       }
     }
   },
-  "component-bottom-to-text-50": {
-    "value": "6px",
+  "component-edge-to-text-50": {
+    "value": "10px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "80f01183-a152-4c55-ac11-24edae62df64",
-        "name": "component-bottom-to-text-50",
+        "uuid": "d660beeb-278b-4157-b6fc-852c680ecae7",
+        "name": "component-edge-to-text-50",
         "constant-token-duplicate": false
       }
     }
   },
-  "component-bottom-to-text-75": {
-    "value": "6px",
+  "component-edge-to-text-75": {
+    "value": "11px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "0f1a6c63-bc4f-444c-9a18-67b6c35464b1",
-        "name": "component-bottom-to-text-75",
+        "uuid": "942f0f34-611a-4318-9b0e-3632e7f520b3",
+        "name": "component-edge-to-text-75",
         "constant-token-duplicate": false
       }
     }
@@ -186,24 +208,24 @@
       }
     }
   },
-  "component-edge-to-text-50": {
-    "value": "10px",
+  "component-edge-to-visual-50": {
+    "value": "7px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "d660beeb-278b-4157-b6fc-852c680ecae7",
-        "name": "component-edge-to-text-50",
+        "uuid": "0b157417-e40f-481c-87e3-8563d55b3135",
+        "name": "component-edge-to-visual-50",
         "constant-token-duplicate": false
       }
     }
   },
-  "component-edge-to-text-75": {
-    "value": "11px",
+  "component-edge-to-visual-75": {
+    "value": "9px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "942f0f34-611a-4318-9b0e-3632e7f520b3",
-        "name": "component-edge-to-text-75",
+        "uuid": "acc3e1b9-532d-485e-84e4-06e744c744b3",
+        "name": "component-edge-to-visual-75",
         "constant-token-duplicate": false
       }
     }
@@ -241,24 +263,24 @@
       }
     }
   },
-  "component-edge-to-visual-50": {
-    "value": "7px",
+  "component-edge-to-visual-only-50": {
+    "value": "4px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "0b157417-e40f-481c-87e3-8563d55b3135",
-        "name": "component-edge-to-visual-50",
+        "uuid": "fd1c11a6-53d5-4253-a7d7-c4131c4b1a5e",
+        "name": "component-edge-to-visual-only-50",
         "constant-token-duplicate": false
       }
     }
   },
-  "component-edge-to-visual-75": {
-    "value": "9px",
+  "component-edge-to-visual-only-75": {
+    "value": "5px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "acc3e1b9-532d-485e-84e4-06e744c744b3",
-        "name": "component-edge-to-visual-75",
+        "uuid": "5c4f1f7a-2218-4d03-ac83-9750c2c9336b",
+        "name": "component-edge-to-visual-only-75",
         "constant-token-duplicate": false
       }
     }
@@ -296,24 +318,24 @@
       }
     }
   },
-  "component-edge-to-visual-only-50": {
-    "value": "4px",
-    "type": "spacing",
+  "component-height-50": {
+    "value": "26px",
+    "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "fd1c11a6-53d5-4253-a7d7-c4131c4b1a5e",
-        "name": "component-edge-to-visual-only-50",
+        "uuid": "fede8012-f00b-412b-8981-16f60a6133ab",
+        "name": "component-height-50",
         "constant-token-duplicate": false
       }
     }
   },
-  "component-edge-to-visual-only-75": {
-    "value": "5px",
-    "type": "spacing",
+  "component-height-75": {
+    "value": "30px",
+    "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "5c4f1f7a-2218-4d03-ac83-9750c2c9336b",
-        "name": "component-edge-to-visual-only-75",
+        "uuid": "5f363452-6317-4e7c-965a-291b3dfa8a8f",
+        "name": "component-height-75",
         "constant-token-duplicate": false
       }
     }
@@ -362,17 +384,6 @@
       }
     }
   },
-  "component-height-50": {
-    "value": "26px",
-    "type": "sizing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "fede8012-f00b-412b-8981-16f60a6133ab",
-        "name": "component-height-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
   "component-height-500": {
     "value": "80px",
     "type": "sizing",
@@ -384,13 +395,13 @@
       }
     }
   },
-  "component-height-75": {
-    "value": "30px",
-    "type": "sizing",
+  "component-pill-edge-to-text-75": {
+    "value": "15px",
+    "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "5f363452-6317-4e7c-965a-291b3dfa8a8f",
-        "name": "component-height-75",
+        "uuid": "8a23edfc-b993-48bb-917f-377051e02dff",
+        "name": "component-pill-edge-to-text-75",
         "constant-token-duplicate": false
       }
     }
@@ -428,13 +439,13 @@
       }
     }
   },
-  "component-pill-edge-to-text-75": {
-    "value": "15px",
+  "component-pill-edge-to-visual-75": {
+    "value": "13px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "8a23edfc-b993-48bb-917f-377051e02dff",
-        "name": "component-pill-edge-to-text-75",
+        "uuid": "64343da6-f1a6-4615-b2b8-41f9509679e5",
+        "name": "component-pill-edge-to-visual-75",
         "constant-token-duplicate": false
       }
     }
@@ -472,13 +483,13 @@
       }
     }
   },
-  "component-pill-edge-to-visual-75": {
-    "value": "13px",
+  "component-pill-edge-to-visual-only-75": {
+    "value": "5px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "64343da6-f1a6-4615-b2b8-41f9509679e5",
-        "name": "component-pill-edge-to-visual-75",
+        "uuid": "7332a4d3-3775-4247-a4c0-fb01f0604d63",
+        "name": "component-pill-edge-to-visual-only-75",
         "constant-token-duplicate": false
       }
     }
@@ -512,17 +523,6 @@
       "spectrum-tokens": {
         "uuid": "cb4f356c-2dcd-4043-8f5c-3da904716b48",
         "name": "component-pill-edge-to-visual-only-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "component-pill-edge-to-visual-only-75": {
-    "value": "5px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "7332a4d3-3775-4247-a4c0-fb01f0604d63",
-        "name": "component-pill-edge-to-visual-only-75",
         "constant-token-duplicate": false
       }
     }
@@ -571,6 +571,28 @@
       }
     }
   },
+  "component-top-to-text-50": {
+    "value": "4px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "cb2a6539-4cee-420c-aeef-dbdd3220039d",
+        "name": "component-top-to-text-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "component-top-to-text-75": {
+    "value": "5px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "54a0e5cf-3e4a-454b-9dba-a6a2c277fa5e",
+        "name": "component-top-to-text-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "component-top-to-text-100": {
     "value": "8px",
     "type": "spacing",
@@ -604,24 +626,24 @@
       }
     }
   },
-  "component-top-to-text-50": {
+  "component-top-to-workflow-icon-50": {
     "value": "4px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "cb2a6539-4cee-420c-aeef-dbdd3220039d",
-        "name": "component-top-to-text-50",
+        "uuid": "24853983-c1b0-422d-84b6-05b9313066ed",
+        "name": "component-top-to-workflow-icon-50",
         "constant-token-duplicate": false
       }
     }
   },
-  "component-top-to-text-75": {
+  "component-top-to-workflow-icon-75": {
     "value": "5px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "54a0e5cf-3e4a-454b-9dba-a6a2c277fa5e",
-        "name": "component-top-to-text-75",
+        "uuid": "9d1b0ef4-5433-43fe-aa33-0274ff29f6f3",
+        "name": "component-top-to-workflow-icon-75",
         "constant-token-duplicate": false
       }
     }
@@ -659,24 +681,13 @@
       }
     }
   },
-  "component-top-to-workflow-icon-50": {
-    "value": "4px",
-    "type": "spacing",
+  "corner-radius-75": {
+    "value": "2px",
+    "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "24853983-c1b0-422d-84b6-05b9313066ed",
-        "name": "component-top-to-workflow-icon-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "component-top-to-workflow-icon-75": {
-    "value": "5px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "9d1b0ef4-5433-43fe-aa33-0274ff29f6f3",
-        "name": "component-top-to-workflow-icon-75",
+        "uuid": "cddbb2f6-b3a8-4416-90ed-0d7cd1bc7248",
+        "name": "corner-radius-75",
         "constant-token-duplicate": false
       }
     }
@@ -699,17 +710,6 @@
       "spectrum-tokens": {
         "uuid": "23f751eb-a076-487d-a5e1-1c0eb2937018",
         "name": "corner-radius-200",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "corner-radius-75": {
-    "value": "2px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "cddbb2f6-b3a8-4416-90ed-0d7cd1bc7248",
-        "name": "corner-radius-75",
         "constant-token-duplicate": false
       }
     }
@@ -857,6 +857,17 @@
       }
     }
   },
+  "field-edge-to-disclosure-icon-75": {
+    "value": "9px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "87d3f491-f45f-4bee-9dbd-00086cca5858",
+        "name": "field-edge-to-disclosure-icon-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "field-edge-to-disclosure-icon-100": {
     "value": "13px",
     "type": "spacing",
@@ -886,17 +897,6 @@
       "spectrum-tokens": {
         "uuid": "0d3045e2-a493-406a-a247-8d20f35db2d9",
         "name": "field-edge-to-disclosure-icon-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "field-edge-to-disclosure-icon-75": {
-    "value": "9px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "87d3f491-f45f-4bee-9dbd-00086cca5858",
-        "name": "field-edge-to-disclosure-icon-75",
         "constant-token-duplicate": false
       }
     }
@@ -978,6 +978,17 @@
       }
     }
   },
+  "field-end-edge-to-disclosure-icon-75": {
+    "value": "9px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "927e7b5a-57b4-4d47-9ad8-e287199e68a3",
+        "name": "field-end-edge-to-disclosure-icon-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "field-end-edge-to-disclosure-icon-100": {
     "value": "13px",
     "type": "spacing",
@@ -1007,17 +1018,6 @@
       "spectrum-tokens": {
         "uuid": "7c2b5cc0-01c0-4e5f-a157-1d2432f8bbc1",
         "name": "field-end-edge-to-disclosure-icon-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "field-end-edge-to-disclosure-icon-75": {
-    "value": "9px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "927e7b5a-57b4-4d47-9ad8-e287199e68a3",
-        "name": "field-end-edge-to-disclosure-icon-75",
         "constant-token-duplicate": false
       }
     }
@@ -1154,6 +1154,17 @@
       }
     }
   },
+  "field-top-to-disclosure-icon-75": {
+    "value": "9px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "2f62718d-3df8-498b-9520-baf8be65f3bd",
+        "name": "field-top-to-disclosure-icon-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "field-top-to-disclosure-icon-100": {
     "value": "13px",
     "type": "spacing",
@@ -1183,17 +1194,6 @@
       "spectrum-tokens": {
         "uuid": "631146ab-f3f2-4ea0-aac1-2bea622d0c85",
         "name": "field-top-to-disclosure-icon-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "field-top-to-disclosure-icon-75": {
-    "value": "9px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "2f62718d-3df8-498b-9520-baf8be65f3bd",
-        "name": "field-top-to-disclosure-icon-75",
         "constant-token-duplicate": false
       }
     }
@@ -1418,6 +1418,28 @@
       }
     }
   },
+  "spacing-50": {
+    "value": "2px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "1b06f6e2-d9be-4934-b3da-bed75986d104",
+        "name": "spacing-50",
+        "constant-token-duplicate": true
+      }
+    }
+  },
+  "spacing-75": {
+    "value": "4px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "576a60a3-ca80-46c5-a066-ba7b6197decd",
+        "name": "spacing-75",
+        "constant-token-duplicate": true
+      }
+    }
+  },
   "spacing-100": {
     "value": "8px",
     "type": "spacing",
@@ -1425,17 +1447,6 @@
       "spectrum-tokens": {
         "uuid": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
         "name": "spacing-100",
-        "constant-token-duplicate": true
-      }
-    }
-  },
-  "spacing-1000": {
-    "value": "96px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "9d688a67-5ff6-4b72-8398-964c0337dce1",
-        "name": "spacing-1000",
         "constant-token-duplicate": true
       }
     }
@@ -1473,17 +1484,6 @@
       }
     }
   },
-  "spacing-50": {
-    "value": "2px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "1b06f6e2-d9be-4934-b3da-bed75986d104",
-        "name": "spacing-50",
-        "constant-token-duplicate": true
-      }
-    }
-  },
   "spacing-500": {
     "value": "32px",
     "type": "spacing",
@@ -1517,17 +1517,6 @@
       }
     }
   },
-  "spacing-75": {
-    "value": "4px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "576a60a3-ca80-46c5-a066-ba7b6197decd",
-        "name": "spacing-75",
-        "constant-token-duplicate": true
-      }
-    }
-  },
   "spacing-800": {
     "value": "64px",
     "type": "spacing",
@@ -1547,6 +1536,28 @@
         "uuid": "d04e5d81-0b6e-48e7-9e47-744753dfcff3",
         "name": "spacing-900",
         "constant-token-duplicate": true
+      }
+    }
+  },
+  "spacing-1000": {
+    "value": "96px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "9d688a67-5ff6-4b72-8398-964c0337dce1",
+        "name": "spacing-1000",
+        "constant-token-duplicate": true
+      }
+    }
+  },
+  "text-to-control-75": {
+    "value": "11px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "45f94495-0f53-42b2-94f6-7a6d91eb2ca1",
+        "name": "text-to-control-75",
+        "constant-token-duplicate": false
       }
     }
   },
@@ -1583,13 +1594,24 @@
       }
     }
   },
-  "text-to-control-75": {
-    "value": "11px",
+  "text-to-visual-50": {
+    "value": "8px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "45f94495-0f53-42b2-94f6-7a6d91eb2ca1",
-        "name": "text-to-control-75",
+        "uuid": "8588bf80-96df-40fb-8b6f-61d06899f8dd",
+        "name": "text-to-visual-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "text-to-visual-75": {
+    "value": "9px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "77dc4cd4-8e4e-4873-b6f3-d573eb7fc315",
+        "name": "text-to-visual-75",
         "constant-token-duplicate": false
       }
     }
@@ -1623,28 +1645,6 @@
       "spectrum-tokens": {
         "uuid": "205f0c77-6588-4cc7-927f-3ba767200bac",
         "name": "text-to-visual-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "text-to-visual-50": {
-    "value": "8px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "8588bf80-96df-40fb-8b6f-61d06899f8dd",
-        "name": "text-to-visual-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "text-to-visual-75": {
-    "value": "9px",
-    "type": "spacing",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "77dc4cd4-8e4e-4873-b6f3-d573eb7fc315",
-        "name": "text-to-visual-75",
         "constant-token-duplicate": false
       }
     }

--- a/src/tokens-studio/spectrum-non-colors/spectrum/typography/desktop.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/typography/desktop.json
@@ -98,6 +98,28 @@
       }
     }
   },
+  "font-size-50": {
+    "value": "11px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "8593a326-de37-414d-b3f6-5254b41dce07",
+        "name": "font-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-75": {
+    "value": "12px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "55d90327-8cc9-4d4f-891f-9d42751d989a",
+        "name": "font-size-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "font-size-100": {
     "value": "14px",
     "type": "fontSizes",
@@ -105,6 +127,94 @@
       "spectrum-tokens": {
         "uuid": "938e2d24-1e90-48f0-a596-595a69103707",
         "name": "font-size-100",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-200": {
+    "value": "16px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "b36caaa3-7047-4dfb-8a84-f990a8ac3a91",
+        "name": "font-size-200",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-300": {
+    "value": "18px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "3dc9b6a4-77e3-484b-be8c-fbc2f50e6175",
+        "name": "font-size-300",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-400": {
+    "value": "20px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "292a28d6-2e15-46e2-80cd-5171d977e9b5",
+        "name": "font-size-400",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-500": {
+    "value": "22px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "9be56e29-2e79-41e0-b5a9-6a2dabc70aa1",
+        "name": "font-size-500",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-600": {
+    "value": "25px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "db1d7d01-8dd4-4c27-b58c-686f030e5e46",
+        "name": "font-size-600",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-700": {
+    "value": "28px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "77da1638-cb39-4c80-8c13-db77b9aa528e",
+        "name": "font-size-700",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-800": {
+    "value": "32px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "8425654d-7f46-4b6d-8997-5ae6b6980e06",
+        "name": "font-size-800",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-900": {
+    "value": "36px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "df2d6c8d-dc03-4581-96c6-d6a92a270b77",
+        "name": "font-size-900",
         "constant-token-duplicate": false
       }
     }
@@ -149,116 +259,6 @@
       "spectrum-tokens": {
         "uuid": "e8853e10-cc03-47c1-9b66-11755ff513a5",
         "name": "font-size-1300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-200": {
-    "value": "16px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "b36caaa3-7047-4dfb-8a84-f990a8ac3a91",
-        "name": "font-size-200",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-300": {
-    "value": "18px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "3dc9b6a4-77e3-484b-be8c-fbc2f50e6175",
-        "name": "font-size-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-400": {
-    "value": "20px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "292a28d6-2e15-46e2-80cd-5171d977e9b5",
-        "name": "font-size-400",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-50": {
-    "value": "11px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "8593a326-de37-414d-b3f6-5254b41dce07",
-        "name": "font-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-500": {
-    "value": "22px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "9be56e29-2e79-41e0-b5a9-6a2dabc70aa1",
-        "name": "font-size-500",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-600": {
-    "value": "25px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "db1d7d01-8dd4-4c27-b58c-686f030e5e46",
-        "name": "font-size-600",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-700": {
-    "value": "28px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "77da1638-cb39-4c80-8c13-db77b9aa528e",
-        "name": "font-size-700",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-75": {
-    "value": "12px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "55d90327-8cc9-4d4f-891f-9d42751d989a",
-        "name": "font-size-75",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-800": {
-    "value": "32px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "8425654d-7f46-4b6d-8997-5ae6b6980e06",
-        "name": "font-size-800",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-900": {
-    "value": "36px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "df2d6c8d-dc03-4581-96c6-d6a92a270b77",
-        "name": "font-size-900",
         "constant-token-duplicate": false
       }
     }

--- a/src/tokens-studio/spectrum-non-colors/spectrum/typography/mobile.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/typography/mobile.json
@@ -98,6 +98,28 @@
       }
     }
   },
+  "font-size-50": {
+    "value": "13px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "b7561ce1-e12e-4aed-9766-181f7eca309e",
+        "name": "font-size-50",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-75": {
+    "value": "15px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "07e1c2a8-3925-4d71-8fae-3486483ff44c",
+        "name": "font-size-75",
+        "constant-token-duplicate": false
+      }
+    }
+  },
   "font-size-100": {
     "value": "17px",
     "type": "fontSizes",
@@ -105,6 +127,94 @@
       "spectrum-tokens": {
         "uuid": "2f9ee3cf-ccb1-4f0b-aed6-96e472fb7411",
         "name": "font-size-100",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-200": {
+    "value": "19px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "7e51ff4e-2749-49d1-b9ed-75de92a73991",
+        "name": "font-size-200",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-300": {
+    "value": "22px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "9b9a7175-dcca-43aa-98ce-f1c3e4eefda7",
+        "name": "font-size-300",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-400": {
+    "value": "24px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "d5ed0e8d-01ac-495f-bd15-fecc30af17c4",
+        "name": "font-size-400",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-500": {
+    "value": "27px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "a69a5079-1b5b-4ccf-946f-8b6e3fae4d7e",
+        "name": "font-size-500",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-600": {
+    "value": "31px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "ac892307-2559-48f5-9e2c-98dabbb0abc2",
+        "name": "font-size-600",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-700": {
+    "value": "34px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "6bd6456c-b73b-4926-8e67-7b942e32bbc2",
+        "name": "font-size-700",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-800": {
+    "value": "39px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "bdfae93d-ae49-456b-af54-8620ea976ca8",
+        "name": "font-size-800",
+        "constant-token-duplicate": false
+      }
+    }
+  },
+  "font-size-900": {
+    "value": "44px",
+    "type": "fontSizes",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "5296e771-6d04-4e9a-b1fe-ab22d4dfd92b",
+        "name": "font-size-900",
         "constant-token-duplicate": false
       }
     }
@@ -149,116 +259,6 @@
       "spectrum-tokens": {
         "uuid": "bd880141-81f6-47fe-a421-01124fe66b67",
         "name": "font-size-1300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-200": {
-    "value": "19px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "7e51ff4e-2749-49d1-b9ed-75de92a73991",
-        "name": "font-size-200",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-300": {
-    "value": "22px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "9b9a7175-dcca-43aa-98ce-f1c3e4eefda7",
-        "name": "font-size-300",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-400": {
-    "value": "24px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "d5ed0e8d-01ac-495f-bd15-fecc30af17c4",
-        "name": "font-size-400",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-50": {
-    "value": "13px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "b7561ce1-e12e-4aed-9766-181f7eca309e",
-        "name": "font-size-50",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-500": {
-    "value": "27px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "a69a5079-1b5b-4ccf-946f-8b6e3fae4d7e",
-        "name": "font-size-500",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-600": {
-    "value": "31px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "ac892307-2559-48f5-9e2c-98dabbb0abc2",
-        "name": "font-size-600",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-700": {
-    "value": "34px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "6bd6456c-b73b-4926-8e67-7b942e32bbc2",
-        "name": "font-size-700",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-75": {
-    "value": "15px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "07e1c2a8-3925-4d71-8fae-3486483ff44c",
-        "name": "font-size-75",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-800": {
-    "value": "39px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "bdfae93d-ae49-456b-af54-8620ea976ca8",
-        "name": "font-size-800",
-        "constant-token-duplicate": false
-      }
-    }
-  },
-  "font-size-900": {
-    "value": "44px",
-    "type": "fontSizes",
-    "$extensions": {
-      "spectrum-tokens": {
-        "uuid": "5296e771-6d04-4e9a-b1fe-ab22d4dfd92b",
-        "name": "font-size-900",
         "constant-token-duplicate": false
       }
     }


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao -->

## Description

* get tokens with number in the token name sorted/ordered properly by alpha-numeric order
* spectrum-non-color data only

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->
https://jira.corp.adobe.com/browse/DTT-1952

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue)
- [ ] Minor (add a new token, changing a value; non-breaking change which adds functionality)
- [ ] Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.)
