### PR TITLE
fix: corner-radius-1000 type should be borderRadius

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout/desktop.json
@@ -562,7 +562,7 @@
   },
   "corner-radius-1000": {
     "value": "0.5",
-    "type": "number",
+    "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e4ad85b2-97bf-48cf-a5a9-3ff3d1fada5b",

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout/mobile.json
@@ -562,7 +562,7 @@
   },
   "corner-radius-1000": {
     "value": "0.5",
-    "type": "number",
+    "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9cd69903-8417-4d6a-92cf-7ec759d5f60f",


### PR DESCRIPTION
## Description

corner-radius-1000 was introduced with type "number" instead of type "borderRadius", which other corner-radius tokens use.

## Motivation and context

Consistency and accuracy.

## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue)
- [ ] Minor (add a new token, changing a value; non-breaking change which adds functionality)
- [ ] Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.)
