### PR TITLE
Updated tooltip layout tokens

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -5038,7 +5038,7 @@
     }
   },
   "tooltip-tip-height": {
-    "value": "4px",
+    "value": "5px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -5049,7 +5049,7 @@
     }
   },
   "tooltip-tip-width": {
-    "value": "8px",
+    "value": "10px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -5067,6 +5067,17 @@
         "uuid": "74787427-ea2f-4b94-99c0-88454e8be6cf",
         "name": "tray-top-to-content-area",
         "constant-token-duplicate": false
+      }
+    }
+  },
+  "tooltip-tip-corner-radius": {
+    "value": "1px",
+    "type": "borderRadius",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "tooltip-tip-corner-radius",
+        "constant-token-duplicate": true
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -5038,7 +5038,7 @@
     }
   },
   "tooltip-tip-height": {
-    "value": "5px",
+    "value": "6px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -5049,7 +5049,7 @@
     }
   },
   "tooltip-tip-width": {
-    "value": "10px",
+    "value": "12px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -5067,6 +5067,17 @@
         "uuid": "794ad497-1725-4a03-a7c9-425eaee3178e",
         "name": "tray-top-to-content-area",
         "constant-token-duplicate": false
+      }
+    }
+  },
+  "tooltip-tip-corner-radius": {
+    "value": "1px",
+    "type": "borderRadius",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "tooltip-tip-corner-radius",
+        "constant-token-duplicate": true
       }
     }
   }


### PR DESCRIPTION
## Description

- Updated `tooltip-tip-height` and `tooltip-tip-width` token values in desktop and mobile
- Added new `tooltip-tip-corner-radius` token with type `borderRadius`

## Motivation and context

- The updated tooltip component in Spectrum 2 has a larger, slightly rounded tip

## Related issue

[SDS-13271](https://jira.corp.adobe.com/browse/SDS-13271)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue)
- [x] Minor (add a new token, changing a value; non-breaking change which adds functionality)
- [ ] Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.)
