### PR TITLE
feat: remove 'constant-token-duplicate' metadata and use (S2)

### DIFF
--- a/src/tokens-studio/spectrum2-colors/spectrum2/alias/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/alias/dark.json
@@ -6,8 +6,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "e54491a8-d3ca-4d67-bacb-74ac192a387f",
-          "name": "drop-shadow-color",
-          "constant-token-duplicate": false
+          "name": "drop-shadow-color"
         }
       }
     },
@@ -17,8 +16,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "af66daa6-9e52-4e68-a605-86d1de4ee971",
-          "name": "overlay-color",
-          "constant-token-duplicate": true
+          "name": "overlay-color"
         }
       }
     },
@@ -30,8 +28,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "43ca4c0d-7803-4e8e-b444-26fe70d5304c",
-              "name": "neutral-content-color-default",
-              "constant-token-duplicate": true
+              "name": "neutral-content-color-default"
             }
           }
         },
@@ -41,8 +38,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "d236bdc5-037b-4838-8401-8a0d5136936c",
-              "name": "neutral-content-color-hover",
-              "constant-token-duplicate": true
+              "name": "neutral-content-color-hover"
             }
           }
         },
@@ -52,8 +48,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "cf169d95-e427-4665-a983-c24727dbfa60",
-              "name": "neutral-content-color-down",
-              "constant-token-duplicate": true
+              "name": "neutral-content-color-down"
             }
           }
         },
@@ -63,8 +58,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a370f375-b3b1-4af8-9628-fa901c0252fb",
-              "name": "neutral-content-color-focus-hover",
-              "constant-token-duplicate": true
+              "name": "neutral-content-color-focus-hover"
             }
           }
         },
@@ -74,8 +68,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f218dfd0-23be-4f07-becb-6027cc971c8b",
-              "name": "neutral-content-color-focus",
-              "constant-token-duplicate": true
+              "name": "neutral-content-color-focus"
             }
           }
         },
@@ -85,8 +78,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c2c538e0-6f8d-4586-953a-b98ef40c9eca",
-              "name": "neutral-content-color-key-focus",
-              "constant-token-duplicate": true
+              "name": "neutral-content-color-key-focus"
             }
           }
         }
@@ -98,8 +90,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "7a058b23-341c-4dd3-83d8-358917277836",
-              "name": "neutral-subdued-content-color-default",
-              "constant-token-duplicate": true
+              "name": "neutral-subdued-content-color-default"
             }
           }
         },
@@ -109,8 +100,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a6d8a177-3e5c-4d28-a675-c21c2695d2f6",
-              "name": "neutral-subdued-content-color-hover",
-              "constant-token-duplicate": true
+              "name": "neutral-subdued-content-color-hover"
             }
           }
         },
@@ -120,8 +110,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "8ab4accc-bd95-48e0-ae3a-539740a07cc6",
-              "name": "neutral-subdued-content-color-down",
-              "constant-token-duplicate": true
+              "name": "neutral-subdued-content-color-down"
             }
           }
         },
@@ -131,8 +120,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4e79877b-254d-4226-a28f-4c80d2d8b2f3",
-              "name": "neutral-subdued-content-color-key-focus",
-              "constant-token-duplicate": true
+              "name": "neutral-subdued-content-color-key-focus"
             }
           }
         },
@@ -142,8 +130,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "ea46f6d3-4261-4482-a70f-2cddd113aa4a",
-              "name": "neutral-subdued-content-color-selected",
-              "constant-token-duplicate": true
+              "name": "neutral-subdued-content-color-selected"
             }
           }
         }
@@ -156,8 +143,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "b14c876e-2930-413b-8688-1e0cf2358185",
-                "name": "accent-content-color-default",
-                "constant-token-duplicate": true
+                "name": "accent-content-color-default"
               }
             }
           },
@@ -167,8 +153,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "d6cd141c-d7a4-457f-bed5-9a725ca7a0fe",
-                "name": "accent-content-color-hover",
-                "constant-token-duplicate": true
+                "name": "accent-content-color-hover"
               }
             }
           },
@@ -178,8 +163,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "25d3b2d2-e7d5-4686-95ff-bfaaddc14ff1",
-                "name": "accent-content-color-down",
-                "constant-token-duplicate": true
+                "name": "accent-content-color-down"
               }
             }
           },
@@ -189,8 +173,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "71dcd137-f767-4d2c-b6ac-942b99ac8621",
-                "name": "accent-content-color-key-focus",
-                "constant-token-duplicate": true
+                "name": "accent-content-color-key-focus"
               }
             }
           },
@@ -200,8 +183,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "9cfbf8bc-e4f3-4658-922e-9421e2ed126b",
-                "name": "accent-content-color-selected",
-                "constant-token-duplicate": true
+                "name": "accent-content-color-selected"
               }
             }
           }
@@ -213,8 +195,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "2a1b0c71-c3a4-4f4c-a625-346e026853e5",
-                "name": "negative-content-color-default",
-                "constant-token-duplicate": true
+                "name": "negative-content-color-default"
               }
             }
           },
@@ -224,8 +205,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "ff90152d-86bf-4a34-9a7e-ede61966bda0",
-                "name": "negative-content-color-hover",
-                "constant-token-duplicate": true
+                "name": "negative-content-color-hover"
               }
             }
           },
@@ -235,8 +215,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "f760cc99-ebec-4d34-931e-5621aef995a0",
-                "name": "negative-content-color-down",
-                "constant-token-duplicate": true
+                "name": "negative-content-color-down"
               }
             }
           },
@@ -246,8 +225,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "03a7aa1f-9493-4054-bb21-eb10e593da73",
-                "name": "negative-content-color-key-focus",
-                "constant-token-duplicate": true
+                "name": "negative-content-color-key-focus"
               }
             }
           }
@@ -261,8 +239,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "8ccd197f-fc8e-4d31-866c-2b96049eea89",
-                "name": "accent-visual-color",
-                "constant-token-duplicate": false
+                "name": "accent-visual-color"
               }
             }
           },
@@ -272,8 +249,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "fd64c9ca-6ad7-415c-b0b8-2579399e33a5",
-                "name": "informative-visual-color",
-                "constant-token-duplicate": false
+                "name": "informative-visual-color"
               }
             }
           },
@@ -283,8 +259,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "35ef6675-7e66-4ef5-8c8d-e8e70939b224",
-                "name": "neutral-visual-color",
-                "constant-token-duplicate": false
+                "name": "neutral-visual-color"
               }
             }
           },
@@ -294,8 +269,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "25e8289f-6c82-4485-8920-a187f790cd47",
-                "name": "positive-visual-color",
-                "constant-token-duplicate": false
+                "name": "positive-visual-color"
               }
             }
           },
@@ -305,8 +279,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "2759c912-6385-40e4-9ed9-ff2e11815b4d",
-                "name": "notice-visual-color",
-                "constant-token-duplicate": false
+                "name": "notice-visual-color"
               }
             }
           },
@@ -316,8 +289,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "70cb0316-5b7a-416c-bf93-7d8885c4fce6",
-                "name": "negative-visual-color",
-                "constant-token-duplicate": false
+                "name": "negative-visual-color"
               }
             }
           }
@@ -329,8 +301,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "0f7a39c2-3ee7-4ff0-873f-334c81054b77",
-                "name": "gray-visual-color",
-                "constant-token-duplicate": false
+                "name": "gray-visual-color"
               }
             }
           },
@@ -340,8 +311,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "63fe16ed-70fa-4eaf-918c-f642ff69ce05",
-                "name": "blue-visual-color",
-                "constant-token-duplicate": false
+                "name": "blue-visual-color"
               }
             }
           },
@@ -351,8 +321,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "1219770d-543d-4216-9e87-c158f8a74df6",
-                "name": "green-visual-color",
-                "constant-token-duplicate": false
+                "name": "green-visual-color"
               }
             }
           },
@@ -362,8 +331,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "e7bf9977-2edf-48bc-8099-ad95e57b55b1",
-                "name": "orange-visual-color",
-                "constant-token-duplicate": false
+                "name": "orange-visual-color"
               }
             }
           },
@@ -373,8 +341,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "870f90ab-7f3e-41b6-9c11-59e9c4ff82c6",
-                "name": "red-visual-color",
-                "constant-token-duplicate": false
+                "name": "red-visual-color"
               }
             }
           },
@@ -384,8 +351,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "37c1311b-29ed-44ab-b656-a7538726ad77",
-                "name": "celery-visual-color",
-                "constant-token-duplicate": false
+                "name": "celery-visual-color"
               }
             }
           },
@@ -395,8 +361,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "a46d8e05-4f56-4b46-a279-0164abfa42e8",
-                "name": "chartreuse-visual-color",
-                "constant-token-duplicate": false
+                "name": "chartreuse-visual-color"
               }
             }
           },
@@ -406,8 +371,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "091a2073-baa0-4cc6-b943-9dddc285ad62",
-                "name": "cyan-visual-color",
-                "constant-token-duplicate": false
+                "name": "cyan-visual-color"
               }
             }
           },
@@ -417,8 +381,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "38e60263-cb08-4090-a653-5acbd1664ae0",
-                "name": "fuchsia-visual-color",
-                "constant-token-duplicate": false
+                "name": "fuchsia-visual-color"
               }
             }
           },
@@ -428,8 +391,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "584ccbd4-3243-4041-b665-e2342d2b26e8",
-                "name": "indigo-visual-color",
-                "constant-token-duplicate": false
+                "name": "indigo-visual-color"
               }
             }
           },
@@ -439,8 +401,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "178e4bc6-6986-4e77-aab0-78dbe66f8e6f",
-                "name": "magenta-visual-color",
-                "constant-token-duplicate": false
+                "name": "magenta-visual-color"
               }
             }
           },
@@ -450,8 +411,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "0ee2957b-c401-4106-8ff3-9de9fa544a03",
-                "name": "purple-visual-color",
-                "constant-token-duplicate": false
+                "name": "purple-visual-color"
               }
             }
           },
@@ -461,8 +421,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "736e4768-7944-40ec-a412-4cd36299e03d",
-                "name": "seafoam-visual-color",
-                "constant-token-duplicate": false
+                "name": "seafoam-visual-color"
               }
             }
           },
@@ -472,8 +431,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "4a2ebbb5-b8b7-43a0-9d64-4974bb382a8b",
-                "name": "yellow-visual-color",
-                "constant-token-duplicate": false
+                "name": "yellow-visual-color"
               }
             }
           }
@@ -486,8 +444,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "60300cd2-9b30-4ee3-b7a1-b8dae00270d9",
-              "name": "heading-color",
-              "constant-token-duplicate": true
+              "name": "heading-color"
             }
           }
         },
@@ -497,8 +454,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a7218010-91c1-4f20-8072-7b1801593014",
-              "name": "body-color",
-              "constant-token-duplicate": true
+              "name": "body-color"
             }
           }
         },
@@ -508,8 +464,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "5f6b9d7a-2433-44fa-8de5-1fb40137e334",
-              "name": "detail-color",
-              "constant-token-duplicate": true
+              "name": "detail-color"
             }
           }
         },
@@ -519,8 +474,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "851aebc5-5aa2-42ae-9032-59a5c9e8db5f",
-              "name": "code-color",
-              "constant-token-duplicate": true
+              "name": "code-color"
             }
           }
         }
@@ -532,8 +486,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "8bf69fd3-1462-49b9-a78a-cc2f03380823",
-              "name": "disabled-content-color",
-              "constant-token-duplicate": true
+              "name": "disabled-content-color"
             }
           }
         },
@@ -543,8 +496,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "e75dbb08-80eb-4de5-afd4-55a532c69c97",
-              "name": "disabled-static-black-content-color",
-              "constant-token-duplicate": true
+              "name": "disabled-static-black-content-color"
             }
           }
         },
@@ -554,8 +506,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "fe319bca-0413-4ad8-a783-c64563e05816",
-              "name": "disabled-static-white-content-color",
-              "constant-token-duplicate": true
+              "name": "disabled-static-white-content-color"
             }
           }
         }
@@ -569,8 +520,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4c19885d-0411-43dc-8f4a-db81905728e6",
-              "name": "background-elevated-color",
-              "constant-token-duplicate": false
+              "name": "background-elevated-color"
             }
           }
         },
@@ -580,8 +530,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "e30b7936-6ae7-4ada-8892-94a1f67d55c9",
-              "name": "background-layer-2-color",
-              "constant-token-duplicate": false
+              "name": "background-layer-2-color"
             }
           }
         },
@@ -590,9 +539,8 @@
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
-              "uuid": "da228344-5b83-4e08-96d2-089068138ba0",
-              "name": "background-layer-1-color",
-              "constant-token-duplicate": false
+              "uuid": "7e6678b7-2903-434b-8ee2-06c83815b01d",
+              "name": "background-layer-1-color"
             }
           }
         },
@@ -602,8 +550,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "6a7c5092-c262-49b0-b5ec-5b8b4fa66d1e",
-              "name": "background-pasteboard-color",
-              "constant-token-duplicate": false
+              "name": "background-pasteboard-color"
             }
           }
         },
@@ -612,9 +559,8 @@
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
-              "uuid": "cf1299aa-86c7-4523-b6ae-6de597ac3712",
-              "name": "background-base-color",
-              "constant-token-duplicate": false
+              "uuid": "e0d8739d-18dd-44bc-92ea-e443882a780b",
+              "name": "background-base-color"
             }
           }
         }
@@ -626,8 +572,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "95cf1481-f476-47ce-a45a-54da64b44255",
-              "name": "neutral-background-color-default",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-default"
             }
           }
         },
@@ -637,8 +582,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "142f9467-e519-4ed7-bd98-69a31e876e70",
-              "name": "neutral-background-color-hover",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-hover"
             }
           }
         },
@@ -648,8 +592,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "5a0fdda5-6ac2-4a31-a7b9-6b3a5dd868d6",
-              "name": "neutral-background-color-down",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-down"
             }
           }
         },
@@ -659,8 +602,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f52c6bfb-2d62-4fc8-a1cd-6c8d7420eeb4",
-              "name": "neutral-background-color-key-focus",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-key-focus"
             }
           }
         }
@@ -672,8 +614,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "fd1c9f2b-8358-4bd3-a5cc-d211673428bc",
-              "name": "neutral-background-color-selected-default",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-selected-default"
             }
           }
         },
@@ -683,8 +624,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "1c220122-5f32-42f9-848f-ae10061241e5",
-              "name": "neutral-background-color-selected-hover",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-selected-hover"
             }
           }
         },
@@ -694,8 +634,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "966c56d0-4461-45e7-9e20-0277f2111a34",
-              "name": "neutral-background-color-selected-down",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-selected-down"
             }
           }
         },
@@ -705,8 +644,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "9b8df7df-3439-4614-b446-97a4de782e27",
-              "name": "neutral-background-color-selected-key-focus",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-selected-key-focus"
             }
           }
         }
@@ -718,8 +656,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "bc9979cb-e7c6-45b2-be4d-0ba3c817e2ef",
-              "name": "neutral-subdued-background-color-default",
-              "constant-token-duplicate": false
+              "name": "neutral-subdued-background-color-default"
             }
           }
         },
@@ -729,8 +666,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "2d72c9fc-22d0-4e4d-9b00-fae4b30a47b5",
-              "name": "neutral-subdued-background-color-hover",
-              "constant-token-duplicate": false
+              "name": "neutral-subdued-background-color-hover"
             }
           }
         },
@@ -740,8 +676,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "11bf9149-d8df-4f37-ba21-51ff911b0517",
-              "name": "neutral-subdued-background-color-down",
-              "constant-token-duplicate": false
+              "name": "neutral-subdued-background-color-down"
             }
           }
         },
@@ -751,8 +686,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a1e08db6-3a72-4b8e-9475-b54a7b9be506",
-              "name": "neutral-subdued-background-color-key-focus",
-              "constant-token-duplicate": false
+              "name": "neutral-subdued-background-color-key-focus"
             }
           }
         }
@@ -765,8 +699,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "f24eb871-6419-4cef-88a2-cca8548ae31e",
-                "name": "accent-background-color-default",
-                "constant-token-duplicate": false
+                "name": "accent-background-color-default"
               }
             }
           },
@@ -776,8 +709,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "9e140a94-c11f-470b-b7af-49880e58d4ce",
-                "name": "accent-background-color-hover",
-                "constant-token-duplicate": false
+                "name": "accent-background-color-hover"
               }
             }
           },
@@ -787,8 +719,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "e2c0de7e-d271-4b2c-9393-d864a95732e6",
-                "name": "accent-background-color-down",
-                "constant-token-duplicate": false
+                "name": "accent-background-color-down"
               }
             }
           },
@@ -798,8 +729,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "af809118-7a97-409c-925f-8d7636a791c8",
-                "name": "accent-background-color-key-focus",
-                "constant-token-duplicate": false
+                "name": "accent-background-color-key-focus"
               }
             }
           }
@@ -811,8 +741,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "da3a7c08-7f54-4486-bb66-146db21f0627",
-                "name": "informative-background-color-default",
-                "constant-token-duplicate": false
+                "name": "informative-background-color-default"
               }
             }
           },
@@ -822,8 +751,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "092415a8-0054-4f6d-9a93-1541c767b2c5",
-                "name": "informative-background-color-hover",
-                "constant-token-duplicate": false
+                "name": "informative-background-color-hover"
               }
             }
           },
@@ -833,8 +761,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "c9c09cc9-1ebd-4738-9613-6a0a67bea4f9",
-                "name": "informative-background-color-down",
-                "constant-token-duplicate": false
+                "name": "informative-background-color-down"
               }
             }
           },
@@ -844,8 +771,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "e5292c94-ea4a-49ba-8c25-6ab1114e0fe3",
-                "name": "informative-background-color-key-focus",
-                "constant-token-duplicate": false
+                "name": "informative-background-color-key-focus"
               }
             }
           }
@@ -857,8 +783,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "82b54f71-7c9e-4388-9e3b-4d13f12fad60",
-                "name": "positive-background-color-default",
-                "constant-token-duplicate": false
+                "name": "positive-background-color-default"
               }
             }
           },
@@ -868,8 +793,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "2992a78b-9ce0-4b29-a4f6-ddbc51f820f2",
-                "name": "positive-background-color-hover",
-                "constant-token-duplicate": false
+                "name": "positive-background-color-hover"
               }
             }
           },
@@ -879,8 +803,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "58a934d2-a715-4544-aa79-7f94bd493f09",
-                "name": "positive-background-color-down",
-                "constant-token-duplicate": false
+                "name": "positive-background-color-down"
               }
             }
           },
@@ -890,8 +813,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "56d371b4-437f-4ca9-854f-ae6daf5dcfce",
-                "name": "positive-background-color-key-focus",
-                "constant-token-duplicate": false
+                "name": "positive-background-color-key-focus"
               }
             }
           }
@@ -903,8 +825,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "323428c1-792d-41b4-8a17-a12f1ac00e2a",
-                "name": "notice-background-color-default",
-                "constant-token-duplicate": false
+                "name": "notice-background-color-default"
               }
             }
           }
@@ -916,8 +837,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "1117b73b-42e3-4ad6-8b26-af76859a27bb",
-                "name": "negative-background-color-default",
-                "constant-token-duplicate": false
+                "name": "negative-background-color-default"
               }
             }
           },
@@ -927,8 +847,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "648da867-549e-47c3-9312-e9cfda288705",
-                "name": "negative-background-color-hover",
-                "constant-token-duplicate": false
+                "name": "negative-background-color-hover"
               }
             }
           },
@@ -938,8 +857,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "8565ec8e-2196-47ac-8636-40084acbfd4f",
-                "name": "negative-background-color-down",
-                "constant-token-duplicate": false
+                "name": "negative-background-color-down"
               }
             }
           },
@@ -949,8 +867,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "f1470931-f4f8-47d9-b118-5b813e4c154a",
-                "name": "negative-background-color-key-focus",
-                "constant-token-duplicate": false
+                "name": "negative-background-color-key-focus"
               }
             }
           }
@@ -963,8 +880,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a46de9d2-5c68-4a1e-97cd-7cbaf4038303",
-              "name": "disabled-background-color",
-              "constant-token-duplicate": true
+              "name": "disabled-background-color"
             }
           }
         },
@@ -974,8 +890,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "579e401c-de49-41af-a8c7-a0a070c31979",
-              "name": "disabled-static-black-background-color",
-              "constant-token-duplicate": true
+              "name": "disabled-static-black-background-color"
             }
           }
         },
@@ -985,8 +900,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "fbd40c55-bb12-43ff-9fa6-c93884befc89",
-              "name": "disabled-static-white-background-color",
-              "constant-token-duplicate": true
+              "name": "disabled-static-white-background-color"
             }
           }
         }
@@ -997,9 +911,8 @@
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
-              "uuid": "fa68c3bf-88b5-4653-a42d-7de5ce7cec3d",
-              "name": "gray-background-color-default",
-              "constant-token-duplicate": false
+              "uuid": "5adeb281-3183-43e0-b20c-bd4e29f4da7e",
+              "name": "gray-background-color-default"
             }
           }
         },
@@ -1009,8 +922,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "83591a94-83e1-4557-8f50-cc1fe9793b76",
-              "name": "blue-background-color-default",
-              "constant-token-duplicate": false
+              "name": "blue-background-color-default"
             }
           }
         },
@@ -1020,8 +932,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "49170573-9c22-42e1-a1ce-cd3d3972ddb7",
-              "name": "green-background-color-default",
-              "constant-token-duplicate": false
+              "name": "green-background-color-default"
             }
           }
         },
@@ -1031,8 +942,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "3e9a6c2a-bd09-4d28-a95c-920109c1852f",
-              "name": "orange-background-color-default",
-              "constant-token-duplicate": false
+              "name": "orange-background-color-default"
             }
           }
         },
@@ -1042,8 +952,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "ce074ee2-a2a2-4da3-a99e-603524193d46",
-              "name": "red-background-color-default",
-              "constant-token-duplicate": false
+              "name": "red-background-color-default"
             }
           }
         },
@@ -1053,8 +962,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a9ab7a59-9cab-47fb-876d-6f0af93dc5df",
-              "name": "celery-background-color-default",
-              "constant-token-duplicate": false
+              "name": "celery-background-color-default"
             }
           }
         },
@@ -1064,8 +972,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "5df9a029-dc91-4078-a198-574486948834",
-              "name": "chartreuse-background-color-default",
-              "constant-token-duplicate": false
+              "name": "chartreuse-background-color-default"
             }
           }
         },
@@ -1075,8 +982,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "543af64f-9c28-4e88-8597-3259cd7ebf1f",
-              "name": "cyan-background-color-default",
-              "constant-token-duplicate": false
+              "name": "cyan-background-color-default"
             }
           }
         },
@@ -1086,8 +992,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "7b4d71d3-ad78-4e02-a48e-fa79f40854a2",
-              "name": "fuchsia-background-color-default",
-              "constant-token-duplicate": false
+              "name": "fuchsia-background-color-default"
             }
           }
         },
@@ -1097,8 +1002,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b7f5a677-4e89-40e1-8324-7619a628ce8b",
-              "name": "indigo-background-color-default",
-              "constant-token-duplicate": false
+              "name": "indigo-background-color-default"
             }
           }
         },
@@ -1108,8 +1012,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "5867d764-d909-4490-b947-533e89997d0a",
-              "name": "magenta-background-color-default",
-              "constant-token-duplicate": false
+              "name": "magenta-background-color-default"
             }
           }
         },
@@ -1119,8 +1022,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "e577d521-0271-4226-a094-624b35a05826",
-              "name": "purple-background-color-default",
-              "constant-token-duplicate": false
+              "name": "purple-background-color-default"
             }
           }
         },
@@ -1130,8 +1032,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "9a727140-328d-430f-9b10-8965eebe77d1",
-              "name": "seafoam-background-color-default",
-              "constant-token-duplicate": false
+              "name": "seafoam-background-color-default"
             }
           }
         },
@@ -1141,8 +1042,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "61c5e375-bff3-479f-8c32-2d2a5edb906c",
-              "name": "yellow-background-color-default",
-              "constant-token-duplicate": false
+              "name": "yellow-background-color-default"
             }
           }
         }
@@ -1157,8 +1057,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "6effed65-3d52-465f-9eb2-7994f1ee90fb",
-                "name": "negative-border-color-default",
-                "constant-token-duplicate": true
+                "name": "negative-border-color-default"
               }
             }
           },
@@ -1168,8 +1067,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "496571fc-18ce-44a3-a89e-40ff6397adcd",
-                "name": "negative-border-color-hover",
-                "constant-token-duplicate": true
+                "name": "negative-border-color-hover"
               }
             }
           },
@@ -1179,8 +1077,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "0c35da5c-cf37-4349-82e4-8739ea94aa65",
-                "name": "negative-border-color-down",
-                "constant-token-duplicate": true
+                "name": "negative-border-color-down"
               }
             }
           },
@@ -1190,8 +1087,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "63abd660-13c4-47b8-be9e-61e270b95212",
-                "name": "negative-border-color-focus-hover",
-                "constant-token-duplicate": true
+                "name": "negative-border-color-focus-hover"
               }
             }
           },
@@ -1201,8 +1097,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "aae2b3a5-1f68-4832-9539-62227179e69e",
-                "name": "negative-border-color-focus",
-                "constant-token-duplicate": true
+                "name": "negative-border-color-focus"
               }
             }
           },
@@ -1212,8 +1107,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "393cb93a-3d0a-4118-a2ee-451fdc871b0f",
-                "name": "negative-border-color-key-focus",
-                "constant-token-duplicate": true
+                "name": "negative-border-color-key-focus"
               }
             }
           }
@@ -1226,8 +1120,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "474ae56c-709a-4f5a-a56b-62d01093f412",
-              "name": "disabled-border-color",
-              "constant-token-duplicate": true
+              "name": "disabled-border-color"
             }
           }
         },
@@ -1237,8 +1130,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "2df7303f-3c34-47d1-9ec9-b901dfbcf947",
-              "name": "disabled-static-black-border-color",
-              "constant-token-duplicate": true
+              "name": "disabled-static-black-border-color"
             }
           }
         },
@@ -1248,8 +1140,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c0dfeb64-983e-4f4c-a13e-24b5fbd2b791",
-              "name": "disabled-static-white-border-color",
-              "constant-token-duplicate": true
+              "name": "disabled-static-white-border-color"
             }
           }
         }
@@ -1263,8 +1154,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "2e080bb5-6f2c-4fd9-96a2-bf9fc19d2649",
-              "name": "accent-color-100",
-              "constant-token-duplicate": true
+              "name": "accent-color-100"
             }
           }
         },
@@ -1274,8 +1164,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "cf583998-4dfd-4222-a554-8e05ed7fb5d6",
-              "name": "accent-color-200",
-              "constant-token-duplicate": true
+              "name": "accent-color-200"
             }
           }
         },
@@ -1285,8 +1174,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "ea67f054-1f42-427e-a768-beb8d21de2a3",
-              "name": "accent-color-300",
-              "constant-token-duplicate": true
+              "name": "accent-color-300"
             }
           }
         },
@@ -1296,8 +1184,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a249e4b1-e6f9-4ef3-96c6-1559059839a7",
-              "name": "accent-color-400",
-              "constant-token-duplicate": true
+              "name": "accent-color-400"
             }
           }
         },
@@ -1307,8 +1194,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c1c0e6fb-ce21-49d7-91bb-73ce873aa69f",
-              "name": "accent-color-500",
-              "constant-token-duplicate": true
+              "name": "accent-color-500"
             }
           }
         },
@@ -1318,8 +1204,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "5a2000be-5640-4389-a128-b2c164ad2253",
-              "name": "accent-color-600",
-              "constant-token-duplicate": true
+              "name": "accent-color-600"
             }
           }
         },
@@ -1329,8 +1214,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae",
-              "name": "accent-color-700",
-              "constant-token-duplicate": true
+              "name": "accent-color-700"
             }
           }
         },
@@ -1340,8 +1224,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
-              "name": "accent-color-800",
-              "constant-token-duplicate": true
+              "name": "accent-color-800"
             }
           }
         },
@@ -1351,8 +1234,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54",
-              "name": "accent-color-900",
-              "constant-token-duplicate": true
+              "name": "accent-color-900"
             }
           }
         },
@@ -1362,8 +1244,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
-              "name": "accent-color-1000",
-              "constant-token-duplicate": true
+              "name": "accent-color-1000"
             }
           }
         },
@@ -1373,8 +1254,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f7f853a5-f091-4a7e-8aea-68d060c840f0",
-              "name": "accent-color-1100",
-              "constant-token-duplicate": true
+              "name": "accent-color-1100"
             }
           }
         },
@@ -1384,8 +1264,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "7c141cdb-1e5e-468a-ba48-0df01b275402",
-              "name": "accent-color-1200",
-              "constant-token-duplicate": true
+              "name": "accent-color-1200"
             }
           }
         },
@@ -1395,8 +1274,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f7307eba-e311-41a8-bb50-0b1e96833dfa",
-              "name": "accent-color-1300",
-              "constant-token-duplicate": true
+              "name": "accent-color-1300"
             }
           }
         },
@@ -1406,8 +1284,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "06585cf4-a924-49b2-b6c8-f0e80b57c576",
-              "name": "accent-color-1400",
-              "constant-token-duplicate": true
+              "name": "accent-color-1400"
             }
           }
         },
@@ -1417,8 +1294,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c43d9991-8929-4b1c-8631-670eef6bde83",
-              "name": "accent-color-1500",
-              "constant-token-duplicate": true
+              "name": "accent-color-1500"
             }
           }
         },
@@ -1428,8 +1304,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4b70c929-f48d-403d-9607-5963203433dc",
-              "name": "accent-color-1600",
-              "constant-token-duplicate": true
+              "name": "accent-color-1600"
             }
           }
         }
@@ -1441,8 +1316,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b9fc8b82-275a-49fe-98d7-95f136b48772",
-              "name": "informative-color-100",
-              "constant-token-duplicate": true
+              "name": "informative-color-100"
             }
           }
         },
@@ -1452,8 +1326,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "df4ceb7f-aa84-4d71-ab3f-a56146ef146c",
-              "name": "informative-color-200",
-              "constant-token-duplicate": true
+              "name": "informative-color-200"
             }
           }
         },
@@ -1463,8 +1336,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "0caae9f7-cad1-4cd6-b4a3-d47ac090d40a",
-              "name": "informative-color-300",
-              "constant-token-duplicate": true
+              "name": "informative-color-300"
             }
           }
         },
@@ -1474,8 +1346,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "46f3f214-5211-452b-8dc0-ffb7e9f9712b",
-              "name": "informative-color-400",
-              "constant-token-duplicate": true
+              "name": "informative-color-400"
             }
           }
         },
@@ -1485,8 +1356,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "546f860f-4e17-455a-a6eb-f7a6a3b37128",
-              "name": "informative-color-500",
-              "constant-token-duplicate": true
+              "name": "informative-color-500"
             }
           }
         },
@@ -1496,8 +1366,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "79a0fe09-63fb-4c96-a3bf-a8e126e7838c",
-              "name": "informative-color-600",
-              "constant-token-duplicate": true
+              "name": "informative-color-600"
             }
           }
         },
@@ -1507,8 +1376,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "04a018bd-229c-47da-99e9-d338d05f0fb6",
-              "name": "informative-color-700",
-              "constant-token-duplicate": true
+              "name": "informative-color-700"
             }
           }
         },
@@ -1518,8 +1386,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b4efe4b2-3787-47df-a7a0-5d89c3641f9f",
-              "name": "informative-color-800",
-              "constant-token-duplicate": true
+              "name": "informative-color-800"
             }
           }
         },
@@ -1529,8 +1396,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "41b73196-0bc1-493e-9b5d-49f608914f5a",
-              "name": "informative-color-900",
-              "constant-token-duplicate": true
+              "name": "informative-color-900"
             }
           }
         },
@@ -1540,8 +1406,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "6b609325-2bcf-491a-ad38-1409025caae0",
-              "name": "informative-color-1000",
-              "constant-token-duplicate": true
+              "name": "informative-color-1000"
             }
           }
         },
@@ -1551,8 +1416,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "7bf54313-58b6-4581-b5ac-a2e51df4a9ed",
-              "name": "informative-color-1100",
-              "constant-token-duplicate": true
+              "name": "informative-color-1100"
             }
           }
         },
@@ -1562,8 +1426,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4504d6a9-87f7-48ea-94a0-d075f28bbcff",
-              "name": "informative-color-1200",
-              "constant-token-duplicate": true
+              "name": "informative-color-1200"
             }
           }
         },
@@ -1573,8 +1436,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f7a736c2-db44-4668-90a8-c27778ae9892",
-              "name": "informative-color-1300",
-              "constant-token-duplicate": true
+              "name": "informative-color-1300"
             }
           }
         },
@@ -1584,8 +1446,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b178b13b-93ee-422c-af98-3bf89105754b",
-              "name": "informative-color-1400",
-              "constant-token-duplicate": true
+              "name": "informative-color-1400"
             }
           }
         },
@@ -1595,8 +1456,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "beeee44c-dc6b-4892-949e-67f069fc4a94",
-              "name": "informative-color-1500",
-              "constant-token-duplicate": true
+              "name": "informative-color-1500"
             }
           }
         },
@@ -1606,8 +1466,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "68aa069d-d8a6-413a-b330-0ec6af905e6d",
-              "name": "informative-color-1600",
-              "constant-token-duplicate": true
+              "name": "informative-color-1600"
             }
           }
         }
@@ -1619,8 +1478,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "09503086-ccd2-4dfb-9bc1-6b86cf595976",
-              "name": "positive-color-100",
-              "constant-token-duplicate": true
+              "name": "positive-color-100"
             }
           }
         },
@@ -1630,8 +1488,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "00a2adcc-7b8a-4e94-97d2-51a647016265",
-              "name": "positive-color-200",
-              "constant-token-duplicate": true
+              "name": "positive-color-200"
             }
           }
         },
@@ -1641,8 +1498,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "2c75e63f-e628-487d-a143-e03de065d5ee",
-              "name": "positive-color-300",
-              "constant-token-duplicate": true
+              "name": "positive-color-300"
             }
           }
         },
@@ -1652,8 +1508,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "906a05ca-0b2f-4ada-9e71-507d9f0653be",
-              "name": "positive-color-400",
-              "constant-token-duplicate": true
+              "name": "positive-color-400"
             }
           }
         },
@@ -1663,8 +1518,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b2e94182-57ae-479d-ab91-717edc0ec3f6",
-              "name": "positive-color-500",
-              "constant-token-duplicate": true
+              "name": "positive-color-500"
             }
           }
         },
@@ -1674,8 +1528,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "d3a018bf-0abe-4031-8c38-80a94b0d62ae",
-              "name": "positive-color-600",
-              "constant-token-duplicate": true
+              "name": "positive-color-600"
             }
           }
         },
@@ -1685,8 +1538,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "ffdde321-5c1d-489e-8a0f-afc582248594",
-              "name": "positive-color-700",
-              "constant-token-duplicate": true
+              "name": "positive-color-700"
             }
           }
         },
@@ -1696,8 +1548,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "ee02d9d5-b840-44af-be8a-0f10086e8f7e",
-              "name": "positive-color-800",
-              "constant-token-duplicate": true
+              "name": "positive-color-800"
             }
           }
         },
@@ -1707,8 +1558,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "1cd86108-ff79-4ccf-911e-8de9986c9053",
-              "name": "positive-color-900",
-              "constant-token-duplicate": true
+              "name": "positive-color-900"
             }
           }
         },
@@ -1718,8 +1568,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "82d9fc42-d750-43d2-b227-b8df29abaca4",
-              "name": "positive-color-1000",
-              "constant-token-duplicate": true
+              "name": "positive-color-1000"
             }
           }
         },
@@ -1729,8 +1578,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "05f42672-455e-421c-8a7e-cb187355d23d",
-              "name": "positive-color-1100",
-              "constant-token-duplicate": true
+              "name": "positive-color-1100"
             }
           }
         },
@@ -1740,8 +1588,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c4f84a4a-cfc4-42a6-81d4-11f27e1b38eb",
-              "name": "positive-color-1200",
-              "constant-token-duplicate": true
+              "name": "positive-color-1200"
             }
           }
         },
@@ -1751,8 +1598,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "7d2d9fe7-5498-4f73-be6a-3a4ac91b6e15",
-              "name": "positive-color-1300",
-              "constant-token-duplicate": true
+              "name": "positive-color-1300"
             }
           }
         },
@@ -1762,8 +1608,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "eb2fdab7-ea9e-42a3-a3d1-f9beec0c7b66",
-              "name": "positive-color-1400",
-              "constant-token-duplicate": true
+              "name": "positive-color-1400"
             }
           }
         },
@@ -1773,8 +1618,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "2381ba55-11ff-4ef0-a770-dfd402650d5d",
-              "name": "positive-color-1500",
-              "constant-token-duplicate": true
+              "name": "positive-color-1500"
             }
           }
         },
@@ -1784,8 +1628,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "de206438-991f-4580-8aa1-1488acb03a09",
-              "name": "positive-color-1600",
-              "constant-token-duplicate": true
+              "name": "positive-color-1600"
             }
           }
         }
@@ -1797,8 +1640,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "d0382c45-0cf7-4c3b-89fb-3536459cbc31",
-              "name": "notice-color-100",
-              "constant-token-duplicate": true
+              "name": "notice-color-100"
             }
           }
         },
@@ -1808,8 +1650,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b9218264-6bd0-4fee-8ab7-346428c9bbaa",
-              "name": "notice-color-200",
-              "constant-token-duplicate": true
+              "name": "notice-color-200"
             }
           }
         },
@@ -1819,8 +1660,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f1e8d13d-d9d2-46ea-befe-ebf1927e08dd",
-              "name": "notice-color-300",
-              "constant-token-duplicate": true
+              "name": "notice-color-300"
             }
           }
         },
@@ -1830,8 +1670,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "77535709-6e67-4d7c-aaeb-d2dea1918430",
-              "name": "notice-color-400",
-              "constant-token-duplicate": true
+              "name": "notice-color-400"
             }
           }
         },
@@ -1841,8 +1680,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "ab679012-b7cb-4f24-b401-b02e523d7c99",
-              "name": "notice-color-500",
-              "constant-token-duplicate": true
+              "name": "notice-color-500"
             }
           }
         },
@@ -1852,8 +1690,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "716af828-c64d-465d-8476-d142892ca59c",
-              "name": "notice-color-600",
-              "constant-token-duplicate": true
+              "name": "notice-color-600"
             }
           }
         },
@@ -1863,8 +1700,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "adb5159c-654f-4b9a-a101-3afa90328c42",
-              "name": "notice-color-700",
-              "constant-token-duplicate": true
+              "name": "notice-color-700"
             }
           }
         },
@@ -1874,8 +1710,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a83cdd4d-b8a9-42af-98c4-459f721abbff",
-              "name": "notice-color-800",
-              "constant-token-duplicate": true
+              "name": "notice-color-800"
             }
           }
         },
@@ -1885,8 +1720,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "df87ca09-ff38-485e-90f7-6d9cbfbb6714",
-              "name": "notice-color-900",
-              "constant-token-duplicate": true
+              "name": "notice-color-900"
             }
           }
         },
@@ -1896,8 +1730,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "d6fdcf63-c135-48a0-a767-e8f1e93e8190",
-              "name": "notice-color-1000",
-              "constant-token-duplicate": true
+              "name": "notice-color-1000"
             }
           }
         },
@@ -1907,8 +1740,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c30c4ce0-ed40-44eb-ae0b-3549523d5bc9",
-              "name": "notice-color-1100",
-              "constant-token-duplicate": true
+              "name": "notice-color-1100"
             }
           }
         },
@@ -1918,8 +1750,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "7e22e4fe-bd28-4dac-b518-e35ec6900da3",
-              "name": "notice-color-1200",
-              "constant-token-duplicate": true
+              "name": "notice-color-1200"
             }
           }
         },
@@ -1929,8 +1760,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "197c8ecc-3d6a-46e5-82f2-c315a52169fb",
-              "name": "notice-color-1300",
-              "constant-token-duplicate": true
+              "name": "notice-color-1300"
             }
           }
         },
@@ -1940,8 +1770,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4eccc44a-1cd5-4d9e-8627-18f7a363d3c8",
-              "name": "notice-color-1400",
-              "constant-token-duplicate": true
+              "name": "notice-color-1400"
             }
           }
         },
@@ -1951,8 +1780,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "3da89d37-cf33-4408-b316-05bb61c25759",
-              "name": "notice-color-1500",
-              "constant-token-duplicate": true
+              "name": "notice-color-1500"
             }
           }
         },
@@ -1962,8 +1790,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "67e534f5-5421-493c-9324-624f0fd491f3",
-              "name": "notice-color-1600",
-              "constant-token-duplicate": true
+              "name": "notice-color-1600"
             }
           }
         }
@@ -1975,8 +1802,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c37f795e-e338-4220-b0ab-5cf899f114c0",
-              "name": "negative-color-100",
-              "constant-token-duplicate": true
+              "name": "negative-color-100"
             }
           }
         },
@@ -1986,8 +1812,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "14919f0c-a40f-48d1-adfd-55826de8e600",
-              "name": "negative-color-200",
-              "constant-token-duplicate": true
+              "name": "negative-color-200"
             }
           }
         },
@@ -1997,8 +1822,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "53486ec0-79f7-4853-ad5b-dacc5a904f8a",
-              "name": "negative-color-300",
-              "constant-token-duplicate": true
+              "name": "negative-color-300"
             }
           }
         },
@@ -2008,8 +1832,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "de87c624-7f43-406e-8cdf-584343a55edc",
-              "name": "negative-color-400",
-              "constant-token-duplicate": true
+              "name": "negative-color-400"
             }
           }
         },
@@ -2019,8 +1842,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "67d09223-03a0-444a-95b6-645a2d66f8c7",
-              "name": "negative-color-500",
-              "constant-token-duplicate": true
+              "name": "negative-color-500"
             }
           }
         },
@@ -2030,8 +1852,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4a0c11a4-4e77-43e0-a2cd-9931ac51d87d",
-              "name": "negative-color-600",
-              "constant-token-duplicate": true
+              "name": "negative-color-600"
             }
           }
         },
@@ -2041,8 +1862,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b7d5d2db-0282-436b-8cb0-873e891b22a6",
-              "name": "negative-color-700",
-              "constant-token-duplicate": true
+              "name": "negative-color-700"
             }
           }
         },
@@ -2052,8 +1872,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "d858b481-8970-4547-aed1-b6388c36aba4",
-              "name": "negative-color-800",
-              "constant-token-duplicate": true
+              "name": "negative-color-800"
             }
           }
         },
@@ -2063,8 +1882,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
-              "name": "negative-color-900",
-              "constant-token-duplicate": true
+              "name": "negative-color-900"
             }
           }
         },
@@ -2074,8 +1892,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
-              "name": "negative-color-1000",
-              "constant-token-duplicate": true
+              "name": "negative-color-1000"
             }
           }
         },
@@ -2085,8 +1902,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "8a3dacc3-93f7-4e22-8bd7-c338da1a2489",
-              "name": "negative-color-1100",
-              "constant-token-duplicate": true
+              "name": "negative-color-1100"
             }
           }
         },
@@ -2096,8 +1912,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "1b24f4e8-224c-41f9-b0eb-6a01e9261598",
-              "name": "negative-color-1200",
-              "constant-token-duplicate": true
+              "name": "negative-color-1200"
             }
           }
         },
@@ -2107,8 +1922,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "fa641bdd-0714-4ae4-9a8f-8d829a9977e5",
-              "name": "negative-color-1300",
-              "constant-token-duplicate": true
+              "name": "negative-color-1300"
             }
           }
         },
@@ -2118,8 +1932,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "58824d04-e2c0-4f0c-a3d7-9b88a01bf28d",
-              "name": "negative-color-1400",
-              "constant-token-duplicate": true
+              "name": "negative-color-1400"
             }
           }
         },
@@ -2129,8 +1942,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b4c1f747-e665-43bb-a1a9-1bf9f252471d",
-              "name": "negative-color-1500",
-              "constant-token-duplicate": true
+              "name": "negative-color-1500"
             }
           }
         },
@@ -2140,8 +1952,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "62beb7ee-c347-4cd7-a84b-40c84fcbc135",
-              "name": "negative-color-1600",
-              "constant-token-duplicate": true
+              "name": "negative-color-1600"
             }
           }
         }
@@ -2154,8 +1965,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fe914904-a368-414b-a4ac-21c0b0340d05",
-            "name": "focus-indicator-color",
-            "constant-token-duplicate": true
+            "name": "focus-indicator-color"
           }
         }
       },
@@ -2165,8 +1975,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c6b8275b-f44e-43b4-b763-82dda94d963c",
-            "name": "static-black-focus-indicator-color",
-            "constant-token-duplicate": true
+            "name": "static-black-focus-indicator-color"
           }
         }
       },
@@ -2176,8 +1985,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1dd6dc5b-47a2-41eb-80fc-f06293ae8e13",
-            "name": "static-white-focus-indicator-color",
-            "constant-token-duplicate": true
+            "name": "static-white-focus-indicator-color"
           }
         }
       }

--- a/src/tokens-studio/spectrum2-colors/spectrum2/alias/light.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/alias/light.json
@@ -6,8 +6,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "be45ace6-9227-41d1-80be-0c58c3f8b3cb",
-          "name": "drop-shadow-color",
-          "constant-token-duplicate": false
+          "name": "drop-shadow-color"
         }
       }
     },
@@ -17,8 +16,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "af66daa6-9e52-4e68-a605-86d1de4ee971",
-          "name": "overlay-color",
-          "constant-token-duplicate": true
+          "name": "overlay-color"
         }
       }
     },
@@ -30,8 +28,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "43ca4c0d-7803-4e8e-b444-26fe70d5304c",
-              "name": "neutral-content-color-default",
-              "constant-token-duplicate": true
+              "name": "neutral-content-color-default"
             }
           }
         },
@@ -41,8 +38,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "d236bdc5-037b-4838-8401-8a0d5136936c",
-              "name": "neutral-content-color-hover",
-              "constant-token-duplicate": true
+              "name": "neutral-content-color-hover"
             }
           }
         },
@@ -52,8 +48,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "cf169d95-e427-4665-a983-c24727dbfa60",
-              "name": "neutral-content-color-down",
-              "constant-token-duplicate": true
+              "name": "neutral-content-color-down"
             }
           }
         },
@@ -63,8 +58,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a370f375-b3b1-4af8-9628-fa901c0252fb",
-              "name": "neutral-content-color-focus-hover",
-              "constant-token-duplicate": true
+              "name": "neutral-content-color-focus-hover"
             }
           }
         },
@@ -74,8 +68,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f218dfd0-23be-4f07-becb-6027cc971c8b",
-              "name": "neutral-content-color-focus",
-              "constant-token-duplicate": true
+              "name": "neutral-content-color-focus"
             }
           }
         },
@@ -85,8 +78,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c2c538e0-6f8d-4586-953a-b98ef40c9eca",
-              "name": "neutral-content-color-key-focus",
-              "constant-token-duplicate": true
+              "name": "neutral-content-color-key-focus"
             }
           }
         }
@@ -98,8 +90,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "7a058b23-341c-4dd3-83d8-358917277836",
-              "name": "neutral-subdued-content-color-default",
-              "constant-token-duplicate": true
+              "name": "neutral-subdued-content-color-default"
             }
           }
         },
@@ -109,8 +100,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a6d8a177-3e5c-4d28-a675-c21c2695d2f6",
-              "name": "neutral-subdued-content-color-hover",
-              "constant-token-duplicate": true
+              "name": "neutral-subdued-content-color-hover"
             }
           }
         },
@@ -120,8 +110,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "8ab4accc-bd95-48e0-ae3a-539740a07cc6",
-              "name": "neutral-subdued-content-color-down",
-              "constant-token-duplicate": true
+              "name": "neutral-subdued-content-color-down"
             }
           }
         },
@@ -131,8 +120,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4e79877b-254d-4226-a28f-4c80d2d8b2f3",
-              "name": "neutral-subdued-content-color-key-focus",
-              "constant-token-duplicate": true
+              "name": "neutral-subdued-content-color-key-focus"
             }
           }
         },
@@ -142,8 +130,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "ea46f6d3-4261-4482-a70f-2cddd113aa4a",
-              "name": "neutral-subdued-content-color-selected",
-              "constant-token-duplicate": true
+              "name": "neutral-subdued-content-color-selected"
             }
           }
         }
@@ -156,8 +143,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "b14c876e-2930-413b-8688-1e0cf2358185",
-                "name": "accent-content-color-default",
-                "constant-token-duplicate": true
+                "name": "accent-content-color-default"
               }
             }
           },
@@ -167,8 +153,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "d6cd141c-d7a4-457f-bed5-9a725ca7a0fe",
-                "name": "accent-content-color-hover",
-                "constant-token-duplicate": true
+                "name": "accent-content-color-hover"
               }
             }
           },
@@ -178,8 +163,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "25d3b2d2-e7d5-4686-95ff-bfaaddc14ff1",
-                "name": "accent-content-color-down",
-                "constant-token-duplicate": true
+                "name": "accent-content-color-down"
               }
             }
           },
@@ -189,8 +173,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "71dcd137-f767-4d2c-b6ac-942b99ac8621",
-                "name": "accent-content-color-key-focus",
-                "constant-token-duplicate": true
+                "name": "accent-content-color-key-focus"
               }
             }
           },
@@ -200,8 +183,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "9cfbf8bc-e4f3-4658-922e-9421e2ed126b",
-                "name": "accent-content-color-selected",
-                "constant-token-duplicate": true
+                "name": "accent-content-color-selected"
               }
             }
           }
@@ -213,8 +195,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "2a1b0c71-c3a4-4f4c-a625-346e026853e5",
-                "name": "negative-content-color-default",
-                "constant-token-duplicate": true
+                "name": "negative-content-color-default"
               }
             }
           },
@@ -224,8 +205,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "ff90152d-86bf-4a34-9a7e-ede61966bda0",
-                "name": "negative-content-color-hover",
-                "constant-token-duplicate": true
+                "name": "negative-content-color-hover"
               }
             }
           },
@@ -235,8 +215,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "f760cc99-ebec-4d34-931e-5621aef995a0",
-                "name": "negative-content-color-down",
-                "constant-token-duplicate": true
+                "name": "negative-content-color-down"
               }
             }
           },
@@ -246,8 +225,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "03a7aa1f-9493-4054-bb21-eb10e593da73",
-                "name": "negative-content-color-key-focus",
-                "constant-token-duplicate": true
+                "name": "negative-content-color-key-focus"
               }
             }
           }
@@ -261,8 +239,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "dbcb4372-f250-42bd-a5bc-b9d48cfb9322",
-                "name": "accent-visual-color",
-                "constant-token-duplicate": false
+                "name": "accent-visual-color"
               }
             }
           },
@@ -272,8 +249,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "cd900a8d-1852-4592-9031-9edab2f9721f",
-                "name": "informative-visual-color",
-                "constant-token-duplicate": false
+                "name": "informative-visual-color"
               }
             }
           },
@@ -283,8 +259,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "0dc6ed4d-17d5-4878-8ac3-bd99549b4f42",
-                "name": "neutral-visual-color",
-                "constant-token-duplicate": false
+                "name": "neutral-visual-color"
               }
             }
           },
@@ -294,8 +269,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "455acfc0-1997-4fee-b1dc-3c91bbd9fca2",
-                "name": "positive-visual-color",
-                "constant-token-duplicate": false
+                "name": "positive-visual-color"
               }
             }
           },
@@ -305,8 +279,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "b8b38df6-aac5-49fc-99bb-d64a543c5bf8",
-                "name": "notice-visual-color",
-                "constant-token-duplicate": false
+                "name": "notice-visual-color"
               }
             }
           },
@@ -316,8 +289,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "d1beeda3-a00d-4f8c-8553-0a0f84093b1f",
-                "name": "negative-visual-color",
-                "constant-token-duplicate": false
+                "name": "negative-visual-color"
               }
             }
           }
@@ -329,8 +301,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "744537db-023b-4833-8262-9c349b0915ee",
-                "name": "gray-visual-color",
-                "constant-token-duplicate": false
+                "name": "gray-visual-color"
               }
             }
           },
@@ -340,8 +311,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "b7cca44c-7c7d-4904-8f2c-d5bde4ea42a2",
-                "name": "blue-visual-color",
-                "constant-token-duplicate": false
+                "name": "blue-visual-color"
               }
             }
           },
@@ -351,8 +321,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "83f76815-8660-425e-80e6-825a5be0628f",
-                "name": "green-visual-color",
-                "constant-token-duplicate": false
+                "name": "green-visual-color"
               }
             }
           },
@@ -362,8 +331,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "8fdaf9e0-bd3e-4188-84bd-7abf72e50b58",
-                "name": "orange-visual-color",
-                "constant-token-duplicate": false
+                "name": "orange-visual-color"
               }
             }
           },
@@ -373,8 +341,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "7fe7c804-7e6b-48ac-b1fa-b88874e0a330",
-                "name": "red-visual-color",
-                "constant-token-duplicate": false
+                "name": "red-visual-color"
               }
             }
           },
@@ -384,8 +351,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "8f6f9f6e-1762-4ac3-a9b9-6cacd135dfac",
-                "name": "celery-visual-color",
-                "constant-token-duplicate": false
+                "name": "celery-visual-color"
               }
             }
           },
@@ -395,8 +361,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "18735078-a942-442b-bc04-1b72bac77c98",
-                "name": "chartreuse-visual-color",
-                "constant-token-duplicate": false
+                "name": "chartreuse-visual-color"
               }
             }
           },
@@ -406,8 +371,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "c3c126c9-2133-416a-ac0e-4ae00546941b",
-                "name": "cyan-visual-color",
-                "constant-token-duplicate": false
+                "name": "cyan-visual-color"
               }
             }
           },
@@ -417,8 +381,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "36b69bb1-d443-4ec6-807b-ea449a886825",
-                "name": "fuchsia-visual-color",
-                "constant-token-duplicate": false
+                "name": "fuchsia-visual-color"
               }
             }
           },
@@ -428,8 +391,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "cb59d4d5-c17e-428d-a22a-e9a3fc02ac9c",
-                "name": "indigo-visual-color",
-                "constant-token-duplicate": false
+                "name": "indigo-visual-color"
               }
             }
           },
@@ -439,8 +401,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "8bc581a9-558c-424d-a72b-f24b48207b82",
-                "name": "magenta-visual-color",
-                "constant-token-duplicate": false
+                "name": "magenta-visual-color"
               }
             }
           },
@@ -450,8 +411,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "681fc141-b235-4cde-9c3a-f0033943d772",
-                "name": "purple-visual-color",
-                "constant-token-duplicate": false
+                "name": "purple-visual-color"
               }
             }
           },
@@ -461,8 +421,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "2b0a6584-db41-43b9-ba39-39171548c01a",
-                "name": "seafoam-visual-color",
-                "constant-token-duplicate": false
+                "name": "seafoam-visual-color"
               }
             }
           },
@@ -472,8 +431,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "73e40884-6d55-4a56-a376-bd788e615754",
-                "name": "yellow-visual-color",
-                "constant-token-duplicate": false
+                "name": "yellow-visual-color"
               }
             }
           }
@@ -486,8 +444,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "60300cd2-9b30-4ee3-b7a1-b8dae00270d9",
-              "name": "heading-color",
-              "constant-token-duplicate": true
+              "name": "heading-color"
             }
           }
         },
@@ -497,8 +454,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a7218010-91c1-4f20-8072-7b1801593014",
-              "name": "body-color",
-              "constant-token-duplicate": true
+              "name": "body-color"
             }
           }
         },
@@ -508,8 +464,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "5f6b9d7a-2433-44fa-8de5-1fb40137e334",
-              "name": "detail-color",
-              "constant-token-duplicate": true
+              "name": "detail-color"
             }
           }
         },
@@ -519,8 +474,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "851aebc5-5aa2-42ae-9032-59a5c9e8db5f",
-              "name": "code-color",
-              "constant-token-duplicate": true
+              "name": "code-color"
             }
           }
         }
@@ -532,8 +486,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "8bf69fd3-1462-49b9-a78a-cc2f03380823",
-              "name": "disabled-content-color",
-              "constant-token-duplicate": true
+              "name": "disabled-content-color"
             }
           }
         },
@@ -543,8 +496,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "e75dbb08-80eb-4de5-afd4-55a532c69c97",
-              "name": "disabled-static-black-content-color",
-              "constant-token-duplicate": true
+              "name": "disabled-static-black-content-color"
             }
           }
         },
@@ -554,8 +506,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "fe319bca-0413-4ad8-a783-c64563e05816",
-              "name": "disabled-static-white-content-color",
-              "constant-token-duplicate": true
+              "name": "disabled-static-white-content-color"
             }
           }
         }
@@ -569,8 +520,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "2275e0fa-69a3-4542-9ec6-919e44035118",
-              "name": "background-elevated-color",
-              "constant-token-duplicate": false
+              "name": "background-elevated-color"
             }
           }
         },
@@ -580,8 +530,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b7b2bf98-b96a-40ca-b51e-5876d3418085",
-              "name": "background-layer-2-color",
-              "constant-token-duplicate": false
+              "name": "background-layer-2-color"
             }
           }
         },
@@ -591,8 +540,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "7e6678b7-2903-434b-8ee2-06c83815b01d",
-              "name": "background-layer-1-color",
-              "constant-token-duplicate": false
+              "name": "background-layer-1-color"
             }
           }
         },
@@ -602,8 +550,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4938710b-5a69-49eb-8517-6f5556c23298",
-              "name": "background-pasteboard-color",
-              "constant-token-duplicate": false
+              "name": "background-pasteboard-color"
             }
           }
         },
@@ -613,8 +560,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "e0d8739d-18dd-44bc-92ea-e443882a780b",
-              "name": "background-base-color",
-              "constant-token-duplicate": false
+              "name": "background-base-color"
             }
           }
         }
@@ -626,8 +572,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "95cf1481-f476-47ce-a45a-54da64b44255",
-              "name": "neutral-background-color-default",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-default"
             }
           }
         },
@@ -637,8 +582,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "142f9467-e519-4ed7-bd98-69a31e876e70",
-              "name": "neutral-background-color-hover",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-hover"
             }
           }
         },
@@ -648,8 +592,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "5a0fdda5-6ac2-4a31-a7b9-6b3a5dd868d6",
-              "name": "neutral-background-color-down",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-down"
             }
           }
         },
@@ -659,8 +602,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f52c6bfb-2d62-4fc8-a1cd-6c8d7420eeb4",
-              "name": "neutral-background-color-key-focus",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-key-focus"
             }
           }
         }
@@ -672,8 +614,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "fd1c9f2b-8358-4bd3-a5cc-d211673428bc",
-              "name": "neutral-background-color-selected-default",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-selected-default"
             }
           }
         },
@@ -683,8 +624,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "1c220122-5f32-42f9-848f-ae10061241e5",
-              "name": "neutral-background-color-selected-hover",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-selected-hover"
             }
           }
         },
@@ -694,8 +634,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "966c56d0-4461-45e7-9e20-0277f2111a34",
-              "name": "neutral-background-color-selected-down",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-selected-down"
             }
           }
         },
@@ -705,8 +644,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "9b8df7df-3439-4614-b446-97a4de782e27",
-              "name": "neutral-background-color-selected-key-focus",
-              "constant-token-duplicate": true
+              "name": "neutral-background-color-selected-key-focus"
             }
           }
         }
@@ -718,8 +656,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "3b09b2fd-cbf9-4933-9655-27a75d984f06",
-              "name": "neutral-subdued-background-color-default",
-              "constant-token-duplicate": false
+              "name": "neutral-subdued-background-color-default"
             }
           }
         },
@@ -729,8 +666,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a1ab50d5-1aa1-4198-9510-7ea8458cc62f",
-              "name": "neutral-subdued-background-color-hover",
-              "constant-token-duplicate": false
+              "name": "neutral-subdued-background-color-hover"
             }
           }
         },
@@ -740,8 +676,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "300d2800-a6e5-4b78-9b6c-aaf2f4af39c6",
-              "name": "neutral-subdued-background-color-down",
-              "constant-token-duplicate": false
+              "name": "neutral-subdued-background-color-down"
             }
           }
         },
@@ -751,8 +686,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "eece165c-743c-4d7a-b770-3ee50e1951cf",
-              "name": "neutral-subdued-background-color-key-focus",
-              "constant-token-duplicate": false
+              "name": "neutral-subdued-background-color-key-focus"
             }
           }
         }
@@ -765,8 +699,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "d9d8488d-9b38-47e0-9660-dcad040f3ca8",
-                "name": "accent-background-color-default",
-                "constant-token-duplicate": false
+                "name": "accent-background-color-default"
               }
             }
           },
@@ -776,8 +709,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "9651d413-47dc-4b55-976f-91e5c6c91fb5",
-                "name": "accent-background-color-hover",
-                "constant-token-duplicate": false
+                "name": "accent-background-color-hover"
               }
             }
           },
@@ -787,8 +719,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "026b1d5e-7cbc-4ee9-91e8-19766b9ac541",
-                "name": "accent-background-color-down",
-                "constant-token-duplicate": false
+                "name": "accent-background-color-down"
               }
             }
           },
@@ -798,8 +729,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "43ca5f34-decc-4de8-9413-74ce57802b65",
-                "name": "accent-background-color-key-focus",
-                "constant-token-duplicate": false
+                "name": "accent-background-color-key-focus"
               }
             }
           }
@@ -811,8 +741,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "3acd52f0-d19c-4174-9ad5-42885ec9d49d",
-                "name": "informative-background-color-default",
-                "constant-token-duplicate": false
+                "name": "informative-background-color-default"
               }
             }
           },
@@ -822,8 +751,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "06dcb775-28b2-454e-89ce-fda34f30c7d7",
-                "name": "informative-background-color-hover",
-                "constant-token-duplicate": false
+                "name": "informative-background-color-hover"
               }
             }
           },
@@ -833,8 +761,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "91f91b8c-0e65-4b7b-8c7b-60d3b6e235d8",
-                "name": "informative-background-color-down",
-                "constant-token-duplicate": false
+                "name": "informative-background-color-down"
               }
             }
           },
@@ -844,8 +771,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "ea314056-fd9a-4325-b19a-33f56fad2859",
-                "name": "informative-background-color-key-focus",
-                "constant-token-duplicate": false
+                "name": "informative-background-color-key-focus"
               }
             }
           }
@@ -857,8 +783,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "d878d795-2292-4d90-a9e2-37af1d97a532",
-                "name": "positive-background-color-default",
-                "constant-token-duplicate": false
+                "name": "positive-background-color-default"
               }
             }
           },
@@ -868,8 +793,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "d60ab5e9-9ada-4587-a75f-91f2b492800f",
-                "name": "positive-background-color-hover",
-                "constant-token-duplicate": false
+                "name": "positive-background-color-hover"
               }
             }
           },
@@ -879,8 +803,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "4096a319-241e-410c-ad51-521d57155004",
-                "name": "positive-background-color-down",
-                "constant-token-duplicate": false
+                "name": "positive-background-color-down"
               }
             }
           },
@@ -890,8 +813,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "036525d0-c6c4-478c-9aa3-84242737c6b1",
-                "name": "positive-background-color-key-focus",
-                "constant-token-duplicate": false
+                "name": "positive-background-color-key-focus"
               }
             }
           }
@@ -903,8 +825,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "48f3445a-63d8-4477-a2f5-1fee6a022328",
-                "name": "notice-background-color-default",
-                "constant-token-duplicate": false
+                "name": "notice-background-color-default"
               }
             }
           }
@@ -916,8 +837,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "46204746-7fe7-4f22-887e-2c9b85c3b7bc",
-                "name": "negative-background-color-default",
-                "constant-token-duplicate": false
+                "name": "negative-background-color-default"
               }
             }
           },
@@ -927,8 +847,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "d2481a50-13a0-4f19-8faa-a1a215fee21d",
-                "name": "negative-background-color-hover",
-                "constant-token-duplicate": false
+                "name": "negative-background-color-hover"
               }
             }
           },
@@ -938,8 +857,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "3c2d5afe-fff4-487d-a312-000f738c8704",
-                "name": "negative-background-color-down",
-                "constant-token-duplicate": false
+                "name": "negative-background-color-down"
               }
             }
           },
@@ -949,8 +867,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "41a6ee21-8db2-410b-a694-fca1fbf70f2a",
-                "name": "negative-background-color-key-focus",
-                "constant-token-duplicate": false
+                "name": "negative-background-color-key-focus"
               }
             }
           }
@@ -963,8 +880,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a46de9d2-5c68-4a1e-97cd-7cbaf4038303",
-              "name": "disabled-background-color",
-              "constant-token-duplicate": true
+              "name": "disabled-background-color"
             }
           }
         },
@@ -974,8 +890,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "579e401c-de49-41af-a8c7-a0a070c31979",
-              "name": "disabled-static-black-background-color",
-              "constant-token-duplicate": true
+              "name": "disabled-static-black-background-color"
             }
           }
         },
@@ -985,8 +900,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "fbd40c55-bb12-43ff-9fa6-c93884befc89",
-              "name": "disabled-static-white-background-color",
-              "constant-token-duplicate": true
+              "name": "disabled-static-white-background-color"
             }
           }
         }
@@ -998,8 +912,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "5adeb281-3183-43e0-b20c-bd4e29f4da7e",
-              "name": "gray-background-color-default",
-              "constant-token-duplicate": false
+              "name": "gray-background-color-default"
             }
           }
         },
@@ -1009,8 +922,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c6c435b6-34b3-4fc1-bf96-a56a15e01fe5",
-              "name": "blue-background-color-default",
-              "constant-token-duplicate": false
+              "name": "blue-background-color-default"
             }
           }
         },
@@ -1020,8 +932,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "d5cac08e-56e8-4217-a153-33f43c1a2059",
-              "name": "green-background-color-default",
-              "constant-token-duplicate": false
+              "name": "green-background-color-default"
             }
           }
         },
@@ -1031,8 +942,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "981c054e-9db5-4589-b9e7-eed307b115ca",
-              "name": "orange-background-color-default",
-              "constant-token-duplicate": false
+              "name": "orange-background-color-default"
             }
           }
         },
@@ -1042,8 +952,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "8cec4a84-3eea-45d6-ae1b-64907be7da78",
-              "name": "red-background-color-default",
-              "constant-token-duplicate": false
+              "name": "red-background-color-default"
             }
           }
         },
@@ -1053,8 +962,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "d4fd682d-4bef-4a92-bf14-90ce02b534e6",
-              "name": "celery-background-color-default",
-              "constant-token-duplicate": false
+              "name": "celery-background-color-default"
             }
           }
         },
@@ -1064,8 +972,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f6e68186-e7fe-4d36-b371-72461a271358",
-              "name": "chartreuse-background-color-default",
-              "constant-token-duplicate": false
+              "name": "chartreuse-background-color-default"
             }
           }
         },
@@ -1075,8 +982,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "12c060c6-db12-41ca-8b53-f4fc0afd2ed7",
-              "name": "cyan-background-color-default",
-              "constant-token-duplicate": false
+              "name": "cyan-background-color-default"
             }
           }
         },
@@ -1086,8 +992,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "5f61f890-93b3-4ab9-bc80-d75198a5bacf",
-              "name": "fuchsia-background-color-default",
-              "constant-token-duplicate": false
+              "name": "fuchsia-background-color-default"
             }
           }
         },
@@ -1097,8 +1002,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "23859fff-27f5-4576-83c9-0fbc316e880a",
-              "name": "indigo-background-color-default",
-              "constant-token-duplicate": false
+              "name": "indigo-background-color-default"
             }
           }
         },
@@ -1108,8 +1012,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4e02601f-12da-4ce2-b58c-0aa0e309442d",
-              "name": "magenta-background-color-default",
-              "constant-token-duplicate": false
+              "name": "magenta-background-color-default"
             }
           }
         },
@@ -1119,8 +1022,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "ed07d8f4-390f-4124-a4c4-81b62767c6cd",
-              "name": "purple-background-color-default",
-              "constant-token-duplicate": false
+              "name": "purple-background-color-default"
             }
           }
         },
@@ -1130,8 +1032,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "be1d8187-effc-430f-ac31-3904cf83a6d6",
-              "name": "seafoam-background-color-default",
-              "constant-token-duplicate": false
+              "name": "seafoam-background-color-default"
             }
           }
         },
@@ -1141,8 +1042,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f8e435de-1630-4628-8b6d-128987d66ddc",
-              "name": "yellow-background-color-default",
-              "constant-token-duplicate": false
+              "name": "yellow-background-color-default"
             }
           }
         }
@@ -1157,8 +1057,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "6effed65-3d52-465f-9eb2-7994f1ee90fb",
-                "name": "negative-border-color-default",
-                "constant-token-duplicate": true
+                "name": "negative-border-color-default"
               }
             }
           },
@@ -1168,8 +1067,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "496571fc-18ce-44a3-a89e-40ff6397adcd",
-                "name": "negative-border-color-hover",
-                "constant-token-duplicate": true
+                "name": "negative-border-color-hover"
               }
             }
           },
@@ -1179,8 +1077,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "0c35da5c-cf37-4349-82e4-8739ea94aa65",
-                "name": "negative-border-color-down",
-                "constant-token-duplicate": true
+                "name": "negative-border-color-down"
               }
             }
           },
@@ -1190,8 +1087,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "63abd660-13c4-47b8-be9e-61e270b95212",
-                "name": "negative-border-color-focus-hover",
-                "constant-token-duplicate": true
+                "name": "negative-border-color-focus-hover"
               }
             }
           },
@@ -1201,8 +1097,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "aae2b3a5-1f68-4832-9539-62227179e69e",
-                "name": "negative-border-color-focus",
-                "constant-token-duplicate": true
+                "name": "negative-border-color-focus"
               }
             }
           },
@@ -1212,8 +1107,7 @@
             "$extensions": {
               "spectrum-tokens": {
                 "uuid": "393cb93a-3d0a-4118-a2ee-451fdc871b0f",
-                "name": "negative-border-color-key-focus",
-                "constant-token-duplicate": true
+                "name": "negative-border-color-key-focus"
               }
             }
           }
@@ -1226,8 +1120,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "474ae56c-709a-4f5a-a56b-62d01093f412",
-              "name": "disabled-border-color",
-              "constant-token-duplicate": true
+              "name": "disabled-border-color"
             }
           }
         },
@@ -1237,8 +1130,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "2df7303f-3c34-47d1-9ec9-b901dfbcf947",
-              "name": "disabled-static-black-border-color",
-              "constant-token-duplicate": true
+              "name": "disabled-static-black-border-color"
             }
           }
         },
@@ -1248,8 +1140,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c0dfeb64-983e-4f4c-a13e-24b5fbd2b791",
-              "name": "disabled-static-white-border-color",
-              "constant-token-duplicate": true
+              "name": "disabled-static-white-border-color"
             }
           }
         }
@@ -1263,8 +1154,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "2e080bb5-6f2c-4fd9-96a2-bf9fc19d2649",
-              "name": "accent-color-100",
-              "constant-token-duplicate": true
+              "name": "accent-color-100"
             }
           }
         },
@@ -1274,8 +1164,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "cf583998-4dfd-4222-a554-8e05ed7fb5d6",
-              "name": "accent-color-200",
-              "constant-token-duplicate": true
+              "name": "accent-color-200"
             }
           }
         },
@@ -1285,8 +1174,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "ea67f054-1f42-427e-a768-beb8d21de2a3",
-              "name": "accent-color-300",
-              "constant-token-duplicate": true
+              "name": "accent-color-300"
             }
           }
         },
@@ -1296,8 +1184,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a249e4b1-e6f9-4ef3-96c6-1559059839a7",
-              "name": "accent-color-400",
-              "constant-token-duplicate": true
+              "name": "accent-color-400"
             }
           }
         },
@@ -1307,8 +1194,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c1c0e6fb-ce21-49d7-91bb-73ce873aa69f",
-              "name": "accent-color-500",
-              "constant-token-duplicate": true
+              "name": "accent-color-500"
             }
           }
         },
@@ -1318,8 +1204,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "5a2000be-5640-4389-a128-b2c164ad2253",
-              "name": "accent-color-600",
-              "constant-token-duplicate": true
+              "name": "accent-color-600"
             }
           }
         },
@@ -1329,8 +1214,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a8fbe39b-db6d-4bb4-a7c5-8a235060d2ae",
-              "name": "accent-color-700",
-              "constant-token-duplicate": true
+              "name": "accent-color-700"
             }
           }
         },
@@ -1340,8 +1224,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "87a2c8f0-54fd-4939-8f42-3124fde1e49e",
-              "name": "accent-color-800",
-              "constant-token-duplicate": true
+              "name": "accent-color-800"
             }
           }
         },
@@ -1351,8 +1234,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "90d82778-1cbb-47c0-aab9-b6e38a9cdc54",
-              "name": "accent-color-900",
-              "constant-token-duplicate": true
+              "name": "accent-color-900"
             }
           }
         },
@@ -1362,8 +1244,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "9bf3fa2f-75d3-44d3-ae30-d88893665366",
-              "name": "accent-color-1000",
-              "constant-token-duplicate": true
+              "name": "accent-color-1000"
             }
           }
         },
@@ -1373,8 +1254,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f7f853a5-f091-4a7e-8aea-68d060c840f0",
-              "name": "accent-color-1100",
-              "constant-token-duplicate": true
+              "name": "accent-color-1100"
             }
           }
         },
@@ -1384,8 +1264,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "7c141cdb-1e5e-468a-ba48-0df01b275402",
-              "name": "accent-color-1200",
-              "constant-token-duplicate": true
+              "name": "accent-color-1200"
             }
           }
         },
@@ -1395,8 +1274,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f7307eba-e311-41a8-bb50-0b1e96833dfa",
-              "name": "accent-color-1300",
-              "constant-token-duplicate": true
+              "name": "accent-color-1300"
             }
           }
         },
@@ -1406,8 +1284,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "06585cf4-a924-49b2-b6c8-f0e80b57c576",
-              "name": "accent-color-1400",
-              "constant-token-duplicate": true
+              "name": "accent-color-1400"
             }
           }
         },
@@ -1417,8 +1294,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c43d9991-8929-4b1c-8631-670eef6bde83",
-              "name": "accent-color-1500",
-              "constant-token-duplicate": true
+              "name": "accent-color-1500"
             }
           }
         },
@@ -1428,8 +1304,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4b70c929-f48d-403d-9607-5963203433dc",
-              "name": "accent-color-1600",
-              "constant-token-duplicate": true
+              "name": "accent-color-1600"
             }
           }
         }
@@ -1441,8 +1316,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b9fc8b82-275a-49fe-98d7-95f136b48772",
-              "name": "informative-color-100",
-              "constant-token-duplicate": true
+              "name": "informative-color-100"
             }
           }
         },
@@ -1452,8 +1326,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "df4ceb7f-aa84-4d71-ab3f-a56146ef146c",
-              "name": "informative-color-200",
-              "constant-token-duplicate": true
+              "name": "informative-color-200"
             }
           }
         },
@@ -1463,8 +1336,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "0caae9f7-cad1-4cd6-b4a3-d47ac090d40a",
-              "name": "informative-color-300",
-              "constant-token-duplicate": true
+              "name": "informative-color-300"
             }
           }
         },
@@ -1474,8 +1346,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "46f3f214-5211-452b-8dc0-ffb7e9f9712b",
-              "name": "informative-color-400",
-              "constant-token-duplicate": true
+              "name": "informative-color-400"
             }
           }
         },
@@ -1485,8 +1356,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "546f860f-4e17-455a-a6eb-f7a6a3b37128",
-              "name": "informative-color-500",
-              "constant-token-duplicate": true
+              "name": "informative-color-500"
             }
           }
         },
@@ -1496,8 +1366,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "79a0fe09-63fb-4c96-a3bf-a8e126e7838c",
-              "name": "informative-color-600",
-              "constant-token-duplicate": true
+              "name": "informative-color-600"
             }
           }
         },
@@ -1507,8 +1376,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "04a018bd-229c-47da-99e9-d338d05f0fb6",
-              "name": "informative-color-700",
-              "constant-token-duplicate": true
+              "name": "informative-color-700"
             }
           }
         },
@@ -1518,8 +1386,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b4efe4b2-3787-47df-a7a0-5d89c3641f9f",
-              "name": "informative-color-800",
-              "constant-token-duplicate": true
+              "name": "informative-color-800"
             }
           }
         },
@@ -1529,8 +1396,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "41b73196-0bc1-493e-9b5d-49f608914f5a",
-              "name": "informative-color-900",
-              "constant-token-duplicate": true
+              "name": "informative-color-900"
             }
           }
         },
@@ -1540,8 +1406,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "6b609325-2bcf-491a-ad38-1409025caae0",
-              "name": "informative-color-1000",
-              "constant-token-duplicate": true
+              "name": "informative-color-1000"
             }
           }
         },
@@ -1551,8 +1416,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "7bf54313-58b6-4581-b5ac-a2e51df4a9ed",
-              "name": "informative-color-1100",
-              "constant-token-duplicate": true
+              "name": "informative-color-1100"
             }
           }
         },
@@ -1562,8 +1426,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4504d6a9-87f7-48ea-94a0-d075f28bbcff",
-              "name": "informative-color-1200",
-              "constant-token-duplicate": true
+              "name": "informative-color-1200"
             }
           }
         },
@@ -1573,8 +1436,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f7a736c2-db44-4668-90a8-c27778ae9892",
-              "name": "informative-color-1300",
-              "constant-token-duplicate": true
+              "name": "informative-color-1300"
             }
           }
         },
@@ -1584,8 +1446,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b178b13b-93ee-422c-af98-3bf89105754b",
-              "name": "informative-color-1400",
-              "constant-token-duplicate": true
+              "name": "informative-color-1400"
             }
           }
         },
@@ -1595,8 +1456,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "beeee44c-dc6b-4892-949e-67f069fc4a94",
-              "name": "informative-color-1500",
-              "constant-token-duplicate": true
+              "name": "informative-color-1500"
             }
           }
         },
@@ -1606,8 +1466,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "68aa069d-d8a6-413a-b330-0ec6af905e6d",
-              "name": "informative-color-1600",
-              "constant-token-duplicate": true
+              "name": "informative-color-1600"
             }
           }
         }
@@ -1619,8 +1478,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "09503086-ccd2-4dfb-9bc1-6b86cf595976",
-              "name": "positive-color-100",
-              "constant-token-duplicate": true
+              "name": "positive-color-100"
             }
           }
         },
@@ -1630,8 +1488,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "00a2adcc-7b8a-4e94-97d2-51a647016265",
-              "name": "positive-color-200",
-              "constant-token-duplicate": true
+              "name": "positive-color-200"
             }
           }
         },
@@ -1641,8 +1498,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "2c75e63f-e628-487d-a143-e03de065d5ee",
-              "name": "positive-color-300",
-              "constant-token-duplicate": true
+              "name": "positive-color-300"
             }
           }
         },
@@ -1652,8 +1508,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "906a05ca-0b2f-4ada-9e71-507d9f0653be",
-              "name": "positive-color-400",
-              "constant-token-duplicate": true
+              "name": "positive-color-400"
             }
           }
         },
@@ -1663,8 +1518,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b2e94182-57ae-479d-ab91-717edc0ec3f6",
-              "name": "positive-color-500",
-              "constant-token-duplicate": true
+              "name": "positive-color-500"
             }
           }
         },
@@ -1674,8 +1528,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "d3a018bf-0abe-4031-8c38-80a94b0d62ae",
-              "name": "positive-color-600",
-              "constant-token-duplicate": true
+              "name": "positive-color-600"
             }
           }
         },
@@ -1685,8 +1538,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "ffdde321-5c1d-489e-8a0f-afc582248594",
-              "name": "positive-color-700",
-              "constant-token-duplicate": true
+              "name": "positive-color-700"
             }
           }
         },
@@ -1696,8 +1548,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "ee02d9d5-b840-44af-be8a-0f10086e8f7e",
-              "name": "positive-color-800",
-              "constant-token-duplicate": true
+              "name": "positive-color-800"
             }
           }
         },
@@ -1707,8 +1558,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "1cd86108-ff79-4ccf-911e-8de9986c9053",
-              "name": "positive-color-900",
-              "constant-token-duplicate": true
+              "name": "positive-color-900"
             }
           }
         },
@@ -1718,8 +1568,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "82d9fc42-d750-43d2-b227-b8df29abaca4",
-              "name": "positive-color-1000",
-              "constant-token-duplicate": true
+              "name": "positive-color-1000"
             }
           }
         },
@@ -1729,8 +1578,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "05f42672-455e-421c-8a7e-cb187355d23d",
-              "name": "positive-color-1100",
-              "constant-token-duplicate": true
+              "name": "positive-color-1100"
             }
           }
         },
@@ -1740,8 +1588,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c4f84a4a-cfc4-42a6-81d4-11f27e1b38eb",
-              "name": "positive-color-1200",
-              "constant-token-duplicate": true
+              "name": "positive-color-1200"
             }
           }
         },
@@ -1751,8 +1598,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "7d2d9fe7-5498-4f73-be6a-3a4ac91b6e15",
-              "name": "positive-color-1300",
-              "constant-token-duplicate": true
+              "name": "positive-color-1300"
             }
           }
         },
@@ -1762,8 +1608,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "eb2fdab7-ea9e-42a3-a3d1-f9beec0c7b66",
-              "name": "positive-color-1400",
-              "constant-token-duplicate": true
+              "name": "positive-color-1400"
             }
           }
         },
@@ -1773,8 +1618,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "2381ba55-11ff-4ef0-a770-dfd402650d5d",
-              "name": "positive-color-1500",
-              "constant-token-duplicate": true
+              "name": "positive-color-1500"
             }
           }
         },
@@ -1784,8 +1628,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "de206438-991f-4580-8aa1-1488acb03a09",
-              "name": "positive-color-1600",
-              "constant-token-duplicate": true
+              "name": "positive-color-1600"
             }
           }
         }
@@ -1797,8 +1640,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "d0382c45-0cf7-4c3b-89fb-3536459cbc31",
-              "name": "notice-color-100",
-              "constant-token-duplicate": true
+              "name": "notice-color-100"
             }
           }
         },
@@ -1808,8 +1650,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b9218264-6bd0-4fee-8ab7-346428c9bbaa",
-              "name": "notice-color-200",
-              "constant-token-duplicate": true
+              "name": "notice-color-200"
             }
           }
         },
@@ -1819,8 +1660,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "f1e8d13d-d9d2-46ea-befe-ebf1927e08dd",
-              "name": "notice-color-300",
-              "constant-token-duplicate": true
+              "name": "notice-color-300"
             }
           }
         },
@@ -1830,8 +1670,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "77535709-6e67-4d7c-aaeb-d2dea1918430",
-              "name": "notice-color-400",
-              "constant-token-duplicate": true
+              "name": "notice-color-400"
             }
           }
         },
@@ -1841,8 +1680,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "ab679012-b7cb-4f24-b401-b02e523d7c99",
-              "name": "notice-color-500",
-              "constant-token-duplicate": true
+              "name": "notice-color-500"
             }
           }
         },
@@ -1852,8 +1690,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "716af828-c64d-465d-8476-d142892ca59c",
-              "name": "notice-color-600",
-              "constant-token-duplicate": true
+              "name": "notice-color-600"
             }
           }
         },
@@ -1863,8 +1700,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "adb5159c-654f-4b9a-a101-3afa90328c42",
-              "name": "notice-color-700",
-              "constant-token-duplicate": true
+              "name": "notice-color-700"
             }
           }
         },
@@ -1874,8 +1710,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "a83cdd4d-b8a9-42af-98c4-459f721abbff",
-              "name": "notice-color-800",
-              "constant-token-duplicate": true
+              "name": "notice-color-800"
             }
           }
         },
@@ -1885,8 +1720,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "df87ca09-ff38-485e-90f7-6d9cbfbb6714",
-              "name": "notice-color-900",
-              "constant-token-duplicate": true
+              "name": "notice-color-900"
             }
           }
         },
@@ -1896,8 +1730,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "d6fdcf63-c135-48a0-a767-e8f1e93e8190",
-              "name": "notice-color-1000",
-              "constant-token-duplicate": true
+              "name": "notice-color-1000"
             }
           }
         },
@@ -1907,8 +1740,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c30c4ce0-ed40-44eb-ae0b-3549523d5bc9",
-              "name": "notice-color-1100",
-              "constant-token-duplicate": true
+              "name": "notice-color-1100"
             }
           }
         },
@@ -1918,8 +1750,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "7e22e4fe-bd28-4dac-b518-e35ec6900da3",
-              "name": "notice-color-1200",
-              "constant-token-duplicate": true
+              "name": "notice-color-1200"
             }
           }
         },
@@ -1929,8 +1760,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "197c8ecc-3d6a-46e5-82f2-c315a52169fb",
-              "name": "notice-color-1300",
-              "constant-token-duplicate": true
+              "name": "notice-color-1300"
             }
           }
         },
@@ -1940,8 +1770,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4eccc44a-1cd5-4d9e-8627-18f7a363d3c8",
-              "name": "notice-color-1400",
-              "constant-token-duplicate": true
+              "name": "notice-color-1400"
             }
           }
         },
@@ -1951,8 +1780,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "3da89d37-cf33-4408-b316-05bb61c25759",
-              "name": "notice-color-1500",
-              "constant-token-duplicate": true
+              "name": "notice-color-1500"
             }
           }
         },
@@ -1962,8 +1790,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "67e534f5-5421-493c-9324-624f0fd491f3",
-              "name": "notice-color-1600",
-              "constant-token-duplicate": true
+              "name": "notice-color-1600"
             }
           }
         }
@@ -1975,8 +1802,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "c37f795e-e338-4220-b0ab-5cf899f114c0",
-              "name": "negative-color-100",
-              "constant-token-duplicate": true
+              "name": "negative-color-100"
             }
           }
         },
@@ -1986,8 +1812,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "14919f0c-a40f-48d1-adfd-55826de8e600",
-              "name": "negative-color-200",
-              "constant-token-duplicate": true
+              "name": "negative-color-200"
             }
           }
         },
@@ -1997,8 +1822,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "53486ec0-79f7-4853-ad5b-dacc5a904f8a",
-              "name": "negative-color-300",
-              "constant-token-duplicate": true
+              "name": "negative-color-300"
             }
           }
         },
@@ -2008,8 +1832,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "de87c624-7f43-406e-8cdf-584343a55edc",
-              "name": "negative-color-400",
-              "constant-token-duplicate": true
+              "name": "negative-color-400"
             }
           }
         },
@@ -2019,8 +1842,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "67d09223-03a0-444a-95b6-645a2d66f8c7",
-              "name": "negative-color-500",
-              "constant-token-duplicate": true
+              "name": "negative-color-500"
             }
           }
         },
@@ -2030,8 +1852,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "4a0c11a4-4e77-43e0-a2cd-9931ac51d87d",
-              "name": "negative-color-600",
-              "constant-token-duplicate": true
+              "name": "negative-color-600"
             }
           }
         },
@@ -2041,8 +1862,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b7d5d2db-0282-436b-8cb0-873e891b22a6",
-              "name": "negative-color-700",
-              "constant-token-duplicate": true
+              "name": "negative-color-700"
             }
           }
         },
@@ -2052,8 +1872,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "d858b481-8970-4547-aed1-b6388c36aba4",
-              "name": "negative-color-800",
-              "constant-token-duplicate": true
+              "name": "negative-color-800"
             }
           }
         },
@@ -2063,8 +1882,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "0b469d2e-7c66-4188-b6bf-bbc379f75538",
-              "name": "negative-color-900",
-              "constant-token-duplicate": true
+              "name": "negative-color-900"
             }
           }
         },
@@ -2074,8 +1892,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "2ea616aa-e08f-47cb-a3b0-3d7a06bd6ec2",
-              "name": "negative-color-1000",
-              "constant-token-duplicate": true
+              "name": "negative-color-1000"
             }
           }
         },
@@ -2085,8 +1902,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "8a3dacc3-93f7-4e22-8bd7-c338da1a2489",
-              "name": "negative-color-1100",
-              "constant-token-duplicate": true
+              "name": "negative-color-1100"
             }
           }
         },
@@ -2096,8 +1912,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "1b24f4e8-224c-41f9-b0eb-6a01e9261598",
-              "name": "negative-color-1200",
-              "constant-token-duplicate": true
+              "name": "negative-color-1200"
             }
           }
         },
@@ -2107,8 +1922,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "fa641bdd-0714-4ae4-9a8f-8d829a9977e5",
-              "name": "negative-color-1300",
-              "constant-token-duplicate": true
+              "name": "negative-color-1300"
             }
           }
         },
@@ -2118,8 +1932,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "58824d04-e2c0-4f0c-a3d7-9b88a01bf28d",
-              "name": "negative-color-1400",
-              "constant-token-duplicate": true
+              "name": "negative-color-1400"
             }
           }
         },
@@ -2129,8 +1942,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "b4c1f747-e665-43bb-a1a9-1bf9f252471d",
-              "name": "negative-color-1500",
-              "constant-token-duplicate": true
+              "name": "negative-color-1500"
             }
           }
         },
@@ -2140,8 +1952,7 @@
           "$extensions": {
             "spectrum-tokens": {
               "uuid": "62beb7ee-c347-4cd7-a84b-40c84fcbc135",
-              "name": "negative-color-1600",
-              "constant-token-duplicate": true
+              "name": "negative-color-1600"
             }
           }
         }
@@ -2154,8 +1965,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fe914904-a368-414b-a4ac-21c0b0340d05",
-            "name": "focus-indicator-color",
-            "constant-token-duplicate": true
+            "name": "focus-indicator-color"
           }
         }
       },
@@ -2165,8 +1975,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c6b8275b-f44e-43b4-b763-82dda94d963c",
-            "name": "static-black-focus-indicator-color",
-            "constant-token-duplicate": true
+            "name": "static-black-focus-indicator-color"
           }
         }
       },
@@ -2176,8 +1985,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1dd6dc5b-47a2-41eb-80fc-f06293ae8e13",
-            "name": "static-white-focus-indicator-color",
-            "constant-token-duplicate": true
+            "name": "static-white-focus-indicator-color"
           }
         }
       }

--- a/src/tokens-studio/spectrum2-colors/spectrum2/component/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/component/dark.json
@@ -7,8 +7,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "622c6e86-dea6-416d-9f13-bb6ef112d3cb",
-            "name": "card-selection-background-color",
-            "constant-token-duplicate": true
+            "name": "card-selection-background-color"
           }
         }
       }
@@ -20,8 +19,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f8cefe70-db2c-489e-bbbe-964050e96ab6",
-            "name": "coach-mark-pagination-color",
-            "constant-token-duplicate": true
+            "name": "coach-mark-pagination-color"
           }
         }
       }
@@ -33,8 +31,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "70fc4674-0f09-48f5-8850-48b4b38c2f01",
-            "name": "color-area-border-color",
-            "constant-token-duplicate": true
+            "name": "color-area-border-color"
           }
         }
       }
@@ -46,8 +43,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0c93f310-d7c6-474b-8f07-0e8e76e2756e",
-            "name": "color-handle-inner-border-color",
-            "constant-token-duplicate": true
+            "name": "color-handle-inner-border-color"
           }
         }
       },
@@ -57,8 +53,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e4733356-090e-4bb7-b32d-ab9df30fb785",
-            "name": "color-handle-outer-border-color",
-            "constant-token-duplicate": true
+            "name": "color-handle-outer-border-color"
           }
         }
       }
@@ -70,8 +65,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "918b8089-d89f-45d2-8c9c-f3f13f81b0b9",
-            "name": "color-loupe-drop-shadow-color",
-            "constant-token-duplicate": true
+            "name": "color-loupe-drop-shadow-color"
           }
         }
       },
@@ -81,8 +75,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d2c4cb48-8a90-461d-95bc-d882ba01472b",
-            "name": "color-loupe-inner-border",
-            "constant-token-duplicate": true
+            "name": "color-loupe-inner-border"
           }
         }
       },
@@ -92,8 +85,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4e1d1cc5-736e-4e82-9054-5c1a74ac1aca",
-            "name": "color-loupe-outer-border",
-            "constant-token-duplicate": true
+            "name": "color-loupe-outer-border"
           }
         }
       }
@@ -105,8 +97,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0c85e7fa-f950-436c-a68a-dd7fb8dfac9e",
-            "name": "color-slider-border-color",
-            "constant-token-duplicate": true
+            "name": "color-slider-border-color"
           }
         }
       }
@@ -118,8 +109,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "866f3613-c12f-4475-87b1-ad86ef2ce153",
-            "name": "drop-zone-background-color",
-            "constant-token-duplicate": true
+            "name": "drop-zone-background-color"
           }
         }
       }
@@ -131,8 +121,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d66d3a56-1ba0-4ce7-a263-eb46a4d17af0",
-            "name": "floating-action-button-drop-shadow-color",
-            "constant-token-duplicate": true
+            "name": "floating-action-button-drop-shadow-color"
           }
         }
       }
@@ -144,8 +133,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f783b8cb-d31f-46c2-b550-990639752510",
-            "name": "opacity-checkerboard-square-dark",
-            "constant-token-duplicate": false
+            "name": "opacity-checkerboard-square-dark"
           }
         }
       },
@@ -155,8 +143,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c7e50676-3f61-49c3-a35f-2532fdb02360",
-            "name": "opacity-checkerboard-square-light",
-            "constant-token-duplicate": true
+            "name": "opacity-checkerboard-square-light"
           }
         }
       }
@@ -168,8 +155,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7da5157d-7f25-405b-8de0-f3669565fb48",
-            "name": "swatch-border-color",
-            "constant-token-duplicate": true
+            "name": "swatch-border-color"
           }
         }
       },
@@ -179,8 +165,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c49cd7ae-7657-458b-871a-6b4f28bca535",
-            "name": "swatch-disabled-icon-border-color",
-            "constant-token-duplicate": true
+            "name": "swatch-disabled-icon-border-color"
           }
         }
       }
@@ -192,8 +177,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8578067a-6ce0-4059-84ad-4688c71df156",
-            "name": "table-selected-row-background-color-non-emphasized",
-            "constant-token-duplicate": true
+            "name": "table-selected-row-background-color-non-emphasized"
           }
         }
       },
@@ -203,8 +187,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "44aedb76-5483-4ac3-a6f5-8cf71c2bd376",
-            "name": "table-row-hover-color",
-            "constant-token-duplicate": true
+            "name": "table-row-hover-color"
           }
         }
       },
@@ -214,8 +197,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b7537f50-bd49-44b6-a171-19943d443d24",
-            "name": "table-selected-row-background-color",
-            "constant-token-duplicate": true
+            "name": "table-selected-row-background-color"
           }
         }
       }
@@ -227,8 +209,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5bd226f1-0a6b-42bc-80af-4a9dde99e9e9",
-            "name": "thumbnail-border-color",
-            "constant-token-duplicate": true
+            "name": "thumbnail-border-color"
           }
         }
       }

--- a/src/tokens-studio/spectrum2-colors/spectrum2/component/light.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/component/light.json
@@ -7,8 +7,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "622c6e86-dea6-416d-9f13-bb6ef112d3cb",
-            "name": "card-selection-background-color",
-            "constant-token-duplicate": true
+            "name": "card-selection-background-color"
           }
         }
       }
@@ -20,8 +19,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f8cefe70-db2c-489e-bbbe-964050e96ab6",
-            "name": "coach-mark-pagination-color",
-            "constant-token-duplicate": true
+            "name": "coach-mark-pagination-color"
           }
         }
       }
@@ -33,8 +31,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "70fc4674-0f09-48f5-8850-48b4b38c2f01",
-            "name": "color-area-border-color",
-            "constant-token-duplicate": true
+            "name": "color-area-border-color"
           }
         }
       }
@@ -46,8 +43,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0c93f310-d7c6-474b-8f07-0e8e76e2756e",
-            "name": "color-handle-inner-border-color",
-            "constant-token-duplicate": true
+            "name": "color-handle-inner-border-color"
           }
         }
       },
@@ -57,8 +53,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e4733356-090e-4bb7-b32d-ab9df30fb785",
-            "name": "color-handle-outer-border-color",
-            "constant-token-duplicate": true
+            "name": "color-handle-outer-border-color"
           }
         }
       }
@@ -70,8 +65,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "918b8089-d89f-45d2-8c9c-f3f13f81b0b9",
-            "name": "color-loupe-drop-shadow-color",
-            "constant-token-duplicate": true
+            "name": "color-loupe-drop-shadow-color"
           }
         }
       },
@@ -81,8 +75,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d2c4cb48-8a90-461d-95bc-d882ba01472b",
-            "name": "color-loupe-inner-border",
-            "constant-token-duplicate": true
+            "name": "color-loupe-inner-border"
           }
         }
       },
@@ -92,8 +85,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4e1d1cc5-736e-4e82-9054-5c1a74ac1aca",
-            "name": "color-loupe-outer-border",
-            "constant-token-duplicate": true
+            "name": "color-loupe-outer-border"
           }
         }
       }
@@ -105,8 +97,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0c85e7fa-f950-436c-a68a-dd7fb8dfac9e",
-            "name": "color-slider-border-color",
-            "constant-token-duplicate": true
+            "name": "color-slider-border-color"
           }
         }
       }
@@ -118,8 +109,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "866f3613-c12f-4475-87b1-ad86ef2ce153",
-            "name": "drop-zone-background-color",
-            "constant-token-duplicate": true
+            "name": "drop-zone-background-color"
           }
         }
       }
@@ -131,8 +121,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d66d3a56-1ba0-4ce7-a263-eb46a4d17af0",
-            "name": "floating-action-button-drop-shadow-color",
-            "constant-token-duplicate": true
+            "name": "floating-action-button-drop-shadow-color"
           }
         }
       }
@@ -144,8 +133,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "84a7cd5e-bb2b-4bb5-bb5f-f5839ae3a761",
-            "name": "opacity-checkerboard-square-dark",
-            "constant-token-duplicate": false
+            "name": "opacity-checkerboard-square-dark"
           }
         }
       },
@@ -155,8 +143,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c7e50676-3f61-49c3-a35f-2532fdb02360",
-            "name": "opacity-checkerboard-square-light",
-            "constant-token-duplicate": true
+            "name": "opacity-checkerboard-square-light"
           }
         }
       }
@@ -168,8 +155,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7da5157d-7f25-405b-8de0-f3669565fb48",
-            "name": "swatch-border-color",
-            "constant-token-duplicate": true
+            "name": "swatch-border-color"
           }
         }
       },
@@ -179,8 +165,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c49cd7ae-7657-458b-871a-6b4f28bca535",
-            "name": "swatch-disabled-icon-border-color",
-            "constant-token-duplicate": true
+            "name": "swatch-disabled-icon-border-color"
           }
         }
       }
@@ -192,8 +177,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8578067a-6ce0-4059-84ad-4688c71df156",
-            "name": "table-selected-row-background-color-non-emphasized",
-            "constant-token-duplicate": true
+            "name": "table-selected-row-background-color-non-emphasized"
           }
         }
       },
@@ -203,8 +187,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "44aedb76-5483-4ac3-a6f5-8cf71c2bd376",
-            "name": "table-row-hover-color",
-            "constant-token-duplicate": true
+            "name": "table-row-hover-color"
           }
         }
       },
@@ -214,8 +197,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b7537f50-bd49-44b6-a171-19943d443d24",
-            "name": "table-selected-row-background-color",
-            "constant-token-duplicate": true
+            "name": "table-selected-row-background-color"
           }
         }
       }
@@ -227,8 +209,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5bd226f1-0a6b-42bc-80af-4a9dde99e9e9",
-            "name": "thumbnail-border-color",
-            "constant-token-duplicate": true
+            "name": "thumbnail-border-color"
           }
         }
       }

--- a/src/tokens-studio/spectrum2-colors/spectrum2/icon/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/icon/dark.json
@@ -6,8 +6,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "d143f2f2-e0d8-4eb3-b06c-86233321fb61",
-          "name": "icon-color-primary-default",
-          "constant-token-duplicate": true
+          "name": "icon-color-primary-default"
         }
       }
     },
@@ -17,8 +16,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "9e04025f-b58c-491a-8569-1965ae074f7b",
-          "name": "icon-color-inverse",
-          "constant-token-duplicate": true
+          "name": "icon-color-inverse"
         }
       }
     },
@@ -28,8 +26,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "1bac9a3f-4bc8-4a4d-8dfd-53c542b1d1d8",
-          "name": "icon-color-blue-primary-default",
-          "constant-token-duplicate": false
+          "name": "icon-color-blue-primary-default"
         }
       }
     },
@@ -39,8 +36,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "260ff567-2bdb-48cc-9576-f4f7629d3a8f",
-          "name": "icon-color-green-primary-default",
-          "constant-token-duplicate": false
+          "name": "icon-color-green-primary-default"
         }
       }
     },
@@ -50,8 +46,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "a60f2744-ad15-4cf7-b9dc-89ca307ed444",
-          "name": "icon-color-red-primary-default",
-          "constant-token-duplicate": false
+          "name": "icon-color-red-primary-default"
         }
       }
     },
@@ -61,8 +56,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "5ebf8291-23f8-4806-865d-4ebab38ff03c",
-          "name": "icon-color-yellow-primary-default",
-          "constant-token-duplicate": false
+          "name": "icon-color-yellow-primary-default"
         }
       }
     }

--- a/src/tokens-studio/spectrum2-colors/spectrum2/icon/light.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/icon/light.json
@@ -6,8 +6,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "d143f2f2-e0d8-4eb3-b06c-86233321fb61",
-          "name": "icon-color-primary-default",
-          "constant-token-duplicate": true
+          "name": "icon-color-primary-default"
         }
       }
     },
@@ -17,8 +16,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "9e04025f-b58c-491a-8569-1965ae074f7b",
-          "name": "icon-color-inverse",
-          "constant-token-duplicate": true
+          "name": "icon-color-inverse"
         }
       }
     },
@@ -28,8 +26,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "f53f030b-755f-46ca-b411-7d62f4eb901e",
-          "name": "icon-color-blue-primary-default",
-          "constant-token-duplicate": false
+          "name": "icon-color-blue-primary-default"
         }
       }
     },
@@ -39,8 +36,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "a0717159-cc62-4ba1-b1f1-a69dfb88c6ee",
-          "name": "icon-color-green-primary-default",
-          "constant-token-duplicate": false
+          "name": "icon-color-green-primary-default"
         }
       }
     },
@@ -50,8 +46,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "89656cae-d490-4b9f-93eb-75912b29ecf5",
-          "name": "icon-color-red-primary-default",
-          "constant-token-duplicate": false
+          "name": "icon-color-red-primary-default"
         }
       }
     },
@@ -61,8 +56,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "59cd6057-b3d8-4bdf-b752-7df17c2c4a95",
-          "name": "icon-color-yellow-primary-default",
-          "constant-token-duplicate": false
+          "name": "icon-color-yellow-primary-default"
         }
       }
     }

--- a/src/tokens-studio/spectrum2-colors/spectrum2/palette/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/palette/dark.json
@@ -6,8 +6,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
-          "name": "black",
-          "constant-token-duplicate": true
+          "name": "black"
         }
       }
     },
@@ -17,8 +16,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "9b799da8-2130-417e-b7ee-5e1154a89837",
-          "name": "white",
-          "constant-token-duplicate": true
+          "name": "white"
         }
       }
     },
@@ -29,8 +27,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ac61b090-d356-4f7f-ac6d-b4f20617c9e3",
-            "name": "gray-25",
-            "constant-token-duplicate": false
+            "name": "gray-25"
           }
         }
       },
@@ -40,8 +37,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0913be1e-b648-4b80-9976-fd8e5e53f4fc",
-            "name": "gray-50",
-            "constant-token-duplicate": false
+            "name": "gray-50"
           }
         }
       },
@@ -51,8 +47,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1666d544-ad1b-445a-9a57-d2277fb752eb",
-            "name": "gray-75",
-            "constant-token-duplicate": false
+            "name": "gray-75"
           }
         }
       },
@@ -62,8 +57,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "abd011c4-87a5-4b1f-82e2-e94d118f417f",
-            "name": "gray-100",
-            "constant-token-duplicate": false
+            "name": "gray-100"
           }
         }
       },
@@ -73,8 +67,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0a676e7a-8a89-4607-a918-3abcfb0234a2",
-            "name": "gray-200",
-            "constant-token-duplicate": false
+            "name": "gray-200"
           }
         }
       },
@@ -84,8 +77,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "cc8c4299-c40d-4e93-80b2-c052ee8aaf40",
-            "name": "gray-300",
-            "constant-token-duplicate": false
+            "name": "gray-300"
           }
         }
       },
@@ -95,8 +87,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c34dd99f-e576-4c98-a89d-86dd47514c55",
-            "name": "gray-400",
-            "constant-token-duplicate": false
+            "name": "gray-400"
           }
         }
       },
@@ -106,8 +97,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "05808575-f14b-49d1-aefb-e3667ec0f5a4",
-            "name": "gray-500",
-            "constant-token-duplicate": false
+            "name": "gray-500"
           }
         }
       },
@@ -117,8 +107,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8880b8f1-7850-49ef-a7ab-fd4e16cb37a6",
-            "name": "gray-600",
-            "constant-token-duplicate": false
+            "name": "gray-600"
           }
         }
       },
@@ -128,8 +117,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3cc563c6-386e-4b08-850d-68d4a292e559",
-            "name": "gray-700",
-            "constant-token-duplicate": false
+            "name": "gray-700"
           }
         }
       },
@@ -139,8 +127,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d39fc368-ec71-40cd-85e9-afb07862f2b7",
-            "name": "gray-800",
-            "constant-token-duplicate": false
+            "name": "gray-800"
           }
         }
       },
@@ -150,8 +137,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "90d25d68-afb1-4b2a-9dba-3fe22d44976f",
-            "name": "gray-900",
-            "constant-token-duplicate": false
+            "name": "gray-900"
           }
         }
       },
@@ -161,8 +147,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5ce8c477-ae6e-427a-ac5c-79d15c8056ab",
-            "name": "gray-1000",
-            "constant-token-duplicate": false
+            "name": "gray-1000"
           }
         }
       }
@@ -174,8 +159,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7d56ac58-fd58-41b3-9bbd-448ae0a7dd85",
-            "name": "blue-100",
-            "constant-token-duplicate": false
+            "name": "blue-100"
           }
         }
       },
@@ -185,8 +169,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7b7d1fd8-cc1e-4053-b320-e481b8f64c46",
-            "name": "blue-200",
-            "constant-token-duplicate": false
+            "name": "blue-200"
           }
         }
       },
@@ -196,8 +179,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d88d1685-29dc-486b-a0b9-9c90f60b8cde",
-            "name": "blue-300",
-            "constant-token-duplicate": false
+            "name": "blue-300"
           }
         }
       },
@@ -207,8 +189,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "29d339bb-ef80-40f8-a69b-afa778b60805",
-            "name": "blue-400",
-            "constant-token-duplicate": false
+            "name": "blue-400"
           }
         }
       },
@@ -218,8 +199,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a61ed901-7f77-4667-9d19-fff6bab20623",
-            "name": "blue-500",
-            "constant-token-duplicate": false
+            "name": "blue-500"
           }
         }
       },
@@ -229,8 +209,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7e770996-780a-4494-91ea-08c1ae6cfa80",
-            "name": "blue-600",
-            "constant-token-duplicate": false
+            "name": "blue-600"
           }
         }
       },
@@ -240,8 +219,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5cc66280-e13a-459d-8529-c3f531aa5e4e",
-            "name": "blue-700",
-            "constant-token-duplicate": false
+            "name": "blue-700"
           }
         }
       },
@@ -251,8 +229,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "cf0bafc5-f5c6-4986-a17a-6660dc542b71",
-            "name": "blue-800",
-            "constant-token-duplicate": false
+            "name": "blue-800"
           }
         }
       },
@@ -262,8 +239,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "82b09b04-6a70-4a95-9eb5-a321a66a6465",
-            "name": "blue-900",
-            "constant-token-duplicate": false
+            "name": "blue-900"
           }
         }
       },
@@ -273,8 +249,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "147ed079-b4f0-4cd7-89cd-7ec93750d688",
-            "name": "blue-1000",
-            "constant-token-duplicate": false
+            "name": "blue-1000"
           }
         }
       },
@@ -284,8 +259,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2a5d2e32-930d-4c50-b1fd-6781a1dc1db5",
-            "name": "blue-1100",
-            "constant-token-duplicate": false
+            "name": "blue-1100"
           }
         }
       },
@@ -295,8 +269,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ce7da4ba-77ed-4bdd-a154-90f389af6c2a",
-            "name": "blue-1200",
-            "constant-token-duplicate": false
+            "name": "blue-1200"
           }
         }
       },
@@ -306,8 +279,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2bc63c0d-691c-4cc4-95b6-b4e530a44978",
-            "name": "blue-1300",
-            "constant-token-duplicate": false
+            "name": "blue-1300"
           }
         }
       },
@@ -317,8 +289,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "eb86d777-ec23-47e4-adc6-1203709dc00d",
-            "name": "blue-1400",
-            "constant-token-duplicate": false
+            "name": "blue-1400"
           }
         }
       },
@@ -328,8 +299,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "616c28b4-d9bf-4ff3-9075-6acaad6c112c",
-            "name": "blue-1500",
-            "constant-token-duplicate": false
+            "name": "blue-1500"
           }
         }
       },
@@ -339,8 +309,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7e8a7cd3-c803-41a9-9178-b43f9eb2e735",
-            "name": "blue-1600",
-            "constant-token-duplicate": false
+            "name": "blue-1600"
           }
         }
       }
@@ -352,8 +321,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e5a14d4a-47c5-4a53-84c5-589a0749d906",
-            "name": "green-100",
-            "constant-token-duplicate": false
+            "name": "green-100"
           }
         }
       },
@@ -363,8 +331,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e8f294f5-cb17-4fdc-b370-ca2e3f95d342",
-            "name": "green-200",
-            "constant-token-duplicate": false
+            "name": "green-200"
           }
         }
       },
@@ -374,8 +341,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "cd5e0471-a8c0-46cd-b98c-be3a74c2b6d2",
-            "name": "green-300",
-            "constant-token-duplicate": false
+            "name": "green-300"
           }
         }
       },
@@ -385,8 +351,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c5e88879-9773-446c-883e-96531bcb8fad",
-            "name": "green-400",
-            "constant-token-duplicate": false
+            "name": "green-400"
           }
         }
       },
@@ -396,8 +361,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "27649ccc-69a8-48d6-9d52-6d6e2e28ae17",
-            "name": "green-500",
-            "constant-token-duplicate": false
+            "name": "green-500"
           }
         }
       },
@@ -407,8 +371,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a0513e49-8483-40f8-8b8f-41fdc222f13d",
-            "name": "green-600",
-            "constant-token-duplicate": false
+            "name": "green-600"
           }
         }
       },
@@ -418,8 +381,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9c24175e-34a5-46c8-b646-f70c08292776",
-            "name": "green-700",
-            "constant-token-duplicate": false
+            "name": "green-700"
           }
         }
       },
@@ -429,8 +391,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "412da16e-4db2-47d8-84d4-583ae35534f9",
-            "name": "green-800",
-            "constant-token-duplicate": false
+            "name": "green-800"
           }
         }
       },
@@ -440,8 +401,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5afee2ee-a5d5-4dcf-a917-11dfdd0c3691",
-            "name": "green-900",
-            "constant-token-duplicate": false
+            "name": "green-900"
           }
         }
       },
@@ -451,8 +411,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3d6732a1-a1f9-4e18-927b-93cebaae3895",
-            "name": "green-1000",
-            "constant-token-duplicate": false
+            "name": "green-1000"
           }
         }
       },
@@ -462,8 +421,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a2f8f6c6-07b4-43a4-8f59-995ea2bf4e82",
-            "name": "green-1100",
-            "constant-token-duplicate": false
+            "name": "green-1100"
           }
         }
       },
@@ -473,8 +431,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "07fa1b72-bf84-4fd5-9565-28373fae6a1f",
-            "name": "green-1200",
-            "constant-token-duplicate": false
+            "name": "green-1200"
           }
         }
       },
@@ -484,8 +441,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c5ec27ed-3a16-44fe-bb8d-a21edd2f4d73",
-            "name": "green-1300",
-            "constant-token-duplicate": false
+            "name": "green-1300"
           }
         }
       },
@@ -495,8 +451,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "df5458e5-891b-4a88-a96c-748a812978a7",
-            "name": "green-1400",
-            "constant-token-duplicate": false
+            "name": "green-1400"
           }
         }
       },
@@ -506,8 +461,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8efbb45d-4d6d-423e-8a3d-cb7117f9fbf8",
-            "name": "green-1500",
-            "constant-token-duplicate": false
+            "name": "green-1500"
           }
         }
       },
@@ -517,8 +471,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ce6f19ce-d3fe-4bad-a4fc-7863ea9fd186",
-            "name": "green-1600",
-            "constant-token-duplicate": false
+            "name": "green-1600"
           }
         }
       }
@@ -530,8 +483,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "974ab8ec-6691-4696-b38c-77e16fb3df88",
-            "name": "orange-100",
-            "constant-token-duplicate": false
+            "name": "orange-100"
           }
         }
       },
@@ -541,8 +493,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "587d4ce3-4275-4d2a-916c-2b1bf78c38ea",
-            "name": "orange-200",
-            "constant-token-duplicate": false
+            "name": "orange-200"
           }
         }
       },
@@ -552,8 +503,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "74f40bbb-5afd-4c88-89d3-e69de9e2b604",
-            "name": "orange-300",
-            "constant-token-duplicate": false
+            "name": "orange-300"
           }
         }
       },
@@ -563,8 +513,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b912089a-b6c9-49ef-8a4b-0a1f6fbbe963",
-            "name": "orange-400",
-            "constant-token-duplicate": false
+            "name": "orange-400"
           }
         }
       },
@@ -574,8 +523,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8a56b352-d7d4-45d4-b403-448557656dab",
-            "name": "orange-500",
-            "constant-token-duplicate": false
+            "name": "orange-500"
           }
         }
       },
@@ -585,8 +533,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "27b198b5-bf02-476a-a440-84c9a5bd2ce3",
-            "name": "orange-600",
-            "constant-token-duplicate": false
+            "name": "orange-600"
           }
         }
       },
@@ -596,8 +543,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f9e84513-57d6-4786-b8db-c86055cebfc6",
-            "name": "orange-700",
-            "constant-token-duplicate": false
+            "name": "orange-700"
           }
         }
       },
@@ -607,8 +553,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5a88ed4e-94f9-4533-ab13-3995b5a60a5a",
-            "name": "orange-800",
-            "constant-token-duplicate": false
+            "name": "orange-800"
           }
         }
       },
@@ -618,8 +563,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0fbe4f46-02a8-444d-ace5-c245c6f15112",
-            "name": "orange-900",
-            "constant-token-duplicate": false
+            "name": "orange-900"
           }
         }
       },
@@ -629,8 +573,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "92e06ff6-8347-4320-9a98-3054ba458d0e",
-            "name": "orange-1000",
-            "constant-token-duplicate": false
+            "name": "orange-1000"
           }
         }
       },
@@ -640,8 +583,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a571e2cd-2aff-4344-b608-45a48162cb61",
-            "name": "orange-1100",
-            "constant-token-duplicate": false
+            "name": "orange-1100"
           }
         }
       },
@@ -651,8 +593,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8e3fe8e0-2b14-4331-869f-de2680ea60ac",
-            "name": "orange-1200",
-            "constant-token-duplicate": false
+            "name": "orange-1200"
           }
         }
       },
@@ -662,8 +603,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "06afaefe-7e0a-42e2-99b5-e62674e1185d",
-            "name": "orange-1300",
-            "constant-token-duplicate": false
+            "name": "orange-1300"
           }
         }
       },
@@ -673,8 +613,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9f2f551f-b606-48ce-9493-888587d3ccb6",
-            "name": "orange-1400",
-            "constant-token-duplicate": false
+            "name": "orange-1400"
           }
         }
       },
@@ -684,8 +623,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "48b0167c-d675-4fc5-9130-1b36a94fd163",
-            "name": "orange-1500",
-            "constant-token-duplicate": false
+            "name": "orange-1500"
           }
         }
       },
@@ -695,8 +633,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b2f21ea2-e546-4b1a-a72d-e840172857b4",
-            "name": "orange-1600",
-            "constant-token-duplicate": false
+            "name": "orange-1600"
           }
         }
       }
@@ -708,8 +645,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "04f6044b-d0fa-4705-858c-2dc5721ec30f",
-            "name": "red-100",
-            "constant-token-duplicate": false
+            "name": "red-100"
           }
         }
       },
@@ -719,8 +655,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b18ca77b-898e-4e09-88e2-8901de3e9172",
-            "name": "red-200",
-            "constant-token-duplicate": false
+            "name": "red-200"
           }
         }
       },
@@ -730,8 +665,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fcfcf026-be31-4a05-b833-6757cacb8b05",
-            "name": "red-300",
-            "constant-token-duplicate": false
+            "name": "red-300"
           }
         }
       },
@@ -741,8 +675,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8f9fa135-5aca-4e42-b247-fdfbf74bc07b",
-            "name": "red-400",
-            "constant-token-duplicate": false
+            "name": "red-400"
           }
         }
       },
@@ -752,8 +685,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ec50a21c-88aa-41a8-b607-c8b1c407ac4f",
-            "name": "red-500",
-            "constant-token-duplicate": false
+            "name": "red-500"
           }
         }
       },
@@ -763,8 +695,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ff0fa040-17d6-4570-84b5-7a88c5bb9f45",
-            "name": "red-600",
-            "constant-token-duplicate": false
+            "name": "red-600"
           }
         }
       },
@@ -774,8 +705,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "cb2486de-b2be-45e5-b459-6e371b29d357",
-            "name": "red-700",
-            "constant-token-duplicate": false
+            "name": "red-700"
           }
         }
       },
@@ -785,8 +715,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9ff36ad0-608e-46a7-ab56-00af3d307d83",
-            "name": "red-800",
-            "constant-token-duplicate": false
+            "name": "red-800"
           }
         }
       },
@@ -796,8 +725,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ccb79099-59f4-4bf2-b149-0de72f556a45",
-            "name": "red-900",
-            "constant-token-duplicate": false
+            "name": "red-900"
           }
         }
       },
@@ -807,8 +735,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "95621c5a-1768-4707-a2ce-bd15c61c89f4",
-            "name": "red-1000",
-            "constant-token-duplicate": false
+            "name": "red-1000"
           }
         }
       },
@@ -818,8 +745,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "53617d38-1075-4b47-87c7-4695b385a2d7",
-            "name": "red-1100",
-            "constant-token-duplicate": false
+            "name": "red-1100"
           }
         }
       },
@@ -829,8 +755,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e7820c1c-ff58-431d-b521-b81ee3281db0",
-            "name": "red-1200",
-            "constant-token-duplicate": false
+            "name": "red-1200"
           }
         }
       },
@@ -840,8 +765,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7691bca6-3749-4cb7-a950-a94fe3d2910f",
-            "name": "red-1300",
-            "constant-token-duplicate": false
+            "name": "red-1300"
           }
         }
       },
@@ -851,8 +775,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "aaafa24c-cb3c-48cd-9cb7-e164be140ab5",
-            "name": "red-1400",
-            "constant-token-duplicate": false
+            "name": "red-1400"
           }
         }
       },
@@ -862,8 +785,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e99ac2fd-25ab-4202-a279-41808cc8dbc6",
-            "name": "red-1500",
-            "constant-token-duplicate": false
+            "name": "red-1500"
           }
         }
       },
@@ -873,8 +795,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "685778a4-bc17-4d74-a713-1776fc2516af",
-            "name": "red-1600",
-            "constant-token-duplicate": false
+            "name": "red-1600"
           }
         }
       }
@@ -886,8 +807,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "43feed9a-9a2a-44e0-9506-9bc5eb8eab1d",
-            "name": "celery-100",
-            "constant-token-duplicate": false
+            "name": "celery-100"
           }
         }
       },
@@ -897,8 +817,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "741a30fb-62a9-4c76-a78e-cc2590af9c7d",
-            "name": "celery-200",
-            "constant-token-duplicate": false
+            "name": "celery-200"
           }
         }
       },
@@ -908,8 +827,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5eda4487-8f82-48ed-8b22-aa38601bbf88",
-            "name": "celery-300",
-            "constant-token-duplicate": false
+            "name": "celery-300"
           }
         }
       },
@@ -919,8 +837,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "646d80c1-7073-4e13-bbfe-4bd0c2226079",
-            "name": "celery-400",
-            "constant-token-duplicate": false
+            "name": "celery-400"
           }
         }
       },
@@ -930,8 +847,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7d4c282b-78ce-4b2c-ab39-26bf02366e4d",
-            "name": "celery-500",
-            "constant-token-duplicate": false
+            "name": "celery-500"
           }
         }
       },
@@ -941,8 +857,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "260d8921-3810-4a5d-a20f-cd00170cf951",
-            "name": "celery-600",
-            "constant-token-duplicate": false
+            "name": "celery-600"
           }
         }
       },
@@ -952,8 +867,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7e7e6abb-a2e9-4308-ac8e-e6866ec17c64",
-            "name": "celery-700",
-            "constant-token-duplicate": false
+            "name": "celery-700"
           }
         }
       },
@@ -963,8 +877,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3b130e0d-eb9b-49e6-84db-eda6ee95eee5",
-            "name": "celery-800",
-            "constant-token-duplicate": false
+            "name": "celery-800"
           }
         }
       },
@@ -974,8 +887,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "706f3a95-ab27-497f-aab7-f4ed806eef30",
-            "name": "celery-900",
-            "constant-token-duplicate": false
+            "name": "celery-900"
           }
         }
       },
@@ -985,8 +897,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "021a55b8-26ae-4767-82fb-06b20c58762b",
-            "name": "celery-1000",
-            "constant-token-duplicate": false
+            "name": "celery-1000"
           }
         }
       },
@@ -996,8 +907,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e091babe-6e02-4393-a67e-63222ab860b4",
-            "name": "celery-1100",
-            "constant-token-duplicate": false
+            "name": "celery-1100"
           }
         }
       },
@@ -1007,8 +917,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9913e84a-4070-476f-a570-a16781a924cf",
-            "name": "celery-1200",
-            "constant-token-duplicate": false
+            "name": "celery-1200"
           }
         }
       },
@@ -1018,8 +927,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d2d8dc91-da75-4c56-a0d8-e6e9802434ad",
-            "name": "celery-1300",
-            "constant-token-duplicate": false
+            "name": "celery-1300"
           }
         }
       },
@@ -1029,8 +937,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c5c3c68c-8293-4ebb-a8d1-9f4af902906e",
-            "name": "celery-1400",
-            "constant-token-duplicate": false
+            "name": "celery-1400"
           }
         }
       },
@@ -1040,8 +947,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ad9c1278-7296-4aef-9e19-6cabc2997bfa",
-            "name": "celery-1500",
-            "constant-token-duplicate": false
+            "name": "celery-1500"
           }
         }
       },
@@ -1051,8 +957,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f1a7d5b6-4414-493a-a5d8-77d81a0121a2",
-            "name": "celery-1600",
-            "constant-token-duplicate": false
+            "name": "celery-1600"
           }
         }
       }
@@ -1064,8 +969,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "bdc6a473-3109-44c6-9e2f-198d3224d75f",
-            "name": "chartreuse-100",
-            "constant-token-duplicate": false
+            "name": "chartreuse-100"
           }
         }
       },
@@ -1075,8 +979,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b18f4550-5bbe-496c-b4a5-13df8fd0c7d7",
-            "name": "chartreuse-200",
-            "constant-token-duplicate": false
+            "name": "chartreuse-200"
           }
         }
       },
@@ -1086,8 +989,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b98dec90-df71-4593-946d-91df7918caac",
-            "name": "chartreuse-300",
-            "constant-token-duplicate": false
+            "name": "chartreuse-300"
           }
         }
       },
@@ -1097,8 +999,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6a974b7d-ccd2-4778-baae-8caf419a529c",
-            "name": "chartreuse-400",
-            "constant-token-duplicate": false
+            "name": "chartreuse-400"
           }
         }
       },
@@ -1108,8 +1009,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "46d8fd3b-0e51-4cdd-a33c-de184b82dcc5",
-            "name": "chartreuse-500",
-            "constant-token-duplicate": false
+            "name": "chartreuse-500"
           }
         }
       },
@@ -1119,8 +1019,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "965174d2-e743-41df-a8e2-570b2ae2f447",
-            "name": "chartreuse-600",
-            "constant-token-duplicate": false
+            "name": "chartreuse-600"
           }
         }
       },
@@ -1130,8 +1029,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a615bb51-0249-4201-b1c9-1c6269b82ec2",
-            "name": "chartreuse-700",
-            "constant-token-duplicate": false
+            "name": "chartreuse-700"
           }
         }
       },
@@ -1141,8 +1039,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "343f1685-2314-4a64-bc7a-5b7b3fd9fdcf",
-            "name": "chartreuse-800",
-            "constant-token-duplicate": false
+            "name": "chartreuse-800"
           }
         }
       },
@@ -1152,8 +1049,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1637c50e-88e4-4273-8a75-6e8a233a690c",
-            "name": "chartreuse-900",
-            "constant-token-duplicate": false
+            "name": "chartreuse-900"
           }
         }
       },
@@ -1163,8 +1059,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7dbedc59-e21c-4953-a7af-5e91d170604a",
-            "name": "chartreuse-1000",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1000"
           }
         }
       },
@@ -1174,8 +1069,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "90417b40-97dd-47b3-9dbc-4ac45f8e4a5f",
-            "name": "chartreuse-1100",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1100"
           }
         }
       },
@@ -1185,8 +1079,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e4b04d5d-e99d-41c5-8b24-540d653ef3ff",
-            "name": "chartreuse-1200",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1200"
           }
         }
       },
@@ -1196,8 +1089,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "615841b9-08b2-4e21-981a-b8f5247e9e89",
-            "name": "chartreuse-1300",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1300"
           }
         }
       },
@@ -1207,8 +1099,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a75188c9-02e3-4337-8056-9a6f8f39001f",
-            "name": "chartreuse-1400",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1400"
           }
         }
       },
@@ -1218,8 +1109,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d7f569e2-f91c-439e-8e5a-8c8c825367ff",
-            "name": "chartreuse-1500",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1500"
           }
         }
       },
@@ -1229,8 +1119,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "753f7aa2-6c7d-4b43-baf9-c72adbd9279d",
-            "name": "chartreuse-1600",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1600"
           }
         }
       }
@@ -1242,8 +1131,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "24a8bb5a-93c3-4dd1-9ea2-d48c11479fe7",
-            "name": "cyan-100",
-            "constant-token-duplicate": false
+            "name": "cyan-100"
           }
         }
       },
@@ -1253,8 +1141,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3445cf4b-2460-4692-acf2-71844d687da4",
-            "name": "cyan-200",
-            "constant-token-duplicate": false
+            "name": "cyan-200"
           }
         }
       },
@@ -1264,8 +1151,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e4bcf4fc-aaec-49a5-a2bb-6bb55e7fff47",
-            "name": "cyan-300",
-            "constant-token-duplicate": false
+            "name": "cyan-300"
           }
         }
       },
@@ -1275,8 +1161,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "94a5bd53-d69a-4063-b630-1976230d4f2d",
-            "name": "cyan-400",
-            "constant-token-duplicate": false
+            "name": "cyan-400"
           }
         }
       },
@@ -1286,8 +1171,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "909baeef-fd2f-4550-89ea-fb7ac9ea2db5",
-            "name": "cyan-500",
-            "constant-token-duplicate": false
+            "name": "cyan-500"
           }
         }
       },
@@ -1297,8 +1181,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d753ef33-bfc0-424b-a2ac-ea87ecbee590",
-            "name": "cyan-600",
-            "constant-token-duplicate": false
+            "name": "cyan-600"
           }
         }
       },
@@ -1308,8 +1191,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3cb348d4-14a9-43da-84c4-068cf46c8c6f",
-            "name": "cyan-700",
-            "constant-token-duplicate": false
+            "name": "cyan-700"
           }
         }
       },
@@ -1319,8 +1201,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ee8673ca-c39c-437e-b3a5-416f4e8664d3",
-            "name": "cyan-800",
-            "constant-token-duplicate": false
+            "name": "cyan-800"
           }
         }
       },
@@ -1330,8 +1211,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9c183829-4858-4908-b1ac-d89f40f2e903",
-            "name": "cyan-900",
-            "constant-token-duplicate": false
+            "name": "cyan-900"
           }
         }
       },
@@ -1341,8 +1221,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "04f3d463-9118-43d5-973d-8bf94417912d",
-            "name": "cyan-1000",
-            "constant-token-duplicate": false
+            "name": "cyan-1000"
           }
         }
       },
@@ -1352,8 +1231,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "62a7ebff-a49b-4e7a-981f-692a506b4146",
-            "name": "cyan-1100",
-            "constant-token-duplicate": false
+            "name": "cyan-1100"
           }
         }
       },
@@ -1363,8 +1241,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "36a2af99-eef4-476b-a3b8-58eade0931b7",
-            "name": "cyan-1200",
-            "constant-token-duplicate": false
+            "name": "cyan-1200"
           }
         }
       },
@@ -1374,8 +1251,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5f3df12b-1330-4482-ad34-c623bd36253c",
-            "name": "cyan-1300",
-            "constant-token-duplicate": false
+            "name": "cyan-1300"
           }
         }
       },
@@ -1385,8 +1261,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fe63b8a3-ebb9-45fe-99c2-e246b53e06a6",
-            "name": "cyan-1400",
-            "constant-token-duplicate": false
+            "name": "cyan-1400"
           }
         }
       },
@@ -1396,8 +1271,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ce687c28-38ce-4fbe-8181-060e566b4196",
-            "name": "cyan-1500",
-            "constant-token-duplicate": false
+            "name": "cyan-1500"
           }
         }
       },
@@ -1407,8 +1281,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "291e6a5c-41b3-4bf1-ad10-38d427e80e48",
-            "name": "cyan-1600",
-            "constant-token-duplicate": false
+            "name": "cyan-1600"
           }
         }
       }
@@ -1420,8 +1293,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3a434405-c4b0-40ef-b383-7cb9a9b60cab",
-            "name": "fuchsia-100",
-            "constant-token-duplicate": false
+            "name": "fuchsia-100"
           }
         }
       },
@@ -1431,8 +1303,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "779ec441-475d-41de-b207-3e139c7c3168",
-            "name": "fuchsia-200",
-            "constant-token-duplicate": false
+            "name": "fuchsia-200"
           }
         }
       },
@@ -1442,8 +1313,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5fa7110f-0c33-4139-8277-eff40921939e",
-            "name": "fuchsia-300",
-            "constant-token-duplicate": false
+            "name": "fuchsia-300"
           }
         }
       },
@@ -1453,8 +1323,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a81bfdd6-4b80-4f1a-922d-2f6e04c27e01",
-            "name": "fuchsia-400",
-            "constant-token-duplicate": false
+            "name": "fuchsia-400"
           }
         }
       },
@@ -1464,8 +1333,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7ecdb8fa-7c4b-4392-bca8-a00a9b931cb4",
-            "name": "fuchsia-500",
-            "constant-token-duplicate": false
+            "name": "fuchsia-500"
           }
         }
       },
@@ -1475,8 +1343,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0fb76488-9965-4cf9-878f-ceed7fc2be43",
-            "name": "fuchsia-600",
-            "constant-token-duplicate": false
+            "name": "fuchsia-600"
           }
         }
       },
@@ -1486,8 +1353,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5f971453-aa30-4c1f-8cbc-be45ff042fcd",
-            "name": "fuchsia-700",
-            "constant-token-duplicate": false
+            "name": "fuchsia-700"
           }
         }
       },
@@ -1497,8 +1363,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5848fed6-5b42-42ef-9800-8f32e42cf6ba",
-            "name": "fuchsia-800",
-            "constant-token-duplicate": false
+            "name": "fuchsia-800"
           }
         }
       },
@@ -1508,8 +1373,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3c6d42c9-4cba-4373-a61c-c8617c509f92",
-            "name": "fuchsia-900",
-            "constant-token-duplicate": false
+            "name": "fuchsia-900"
           }
         }
       },
@@ -1519,8 +1383,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a13d5f15-e4cc-4f7c-928f-aaccbf0d590e",
-            "name": "fuchsia-1000",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1000"
           }
         }
       },
@@ -1530,8 +1393,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0a4eb3af-d067-4d9f-af91-66c676e49e26",
-            "name": "fuchsia-1100",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1100"
           }
         }
       },
@@ -1541,8 +1403,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0d93ff9f-63e8-4caf-9e7b-714e56d968d4",
-            "name": "fuchsia-1200",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1200"
           }
         }
       },
@@ -1552,8 +1413,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "abd44b32-b837-4e11-95c7-4ba1c34db44b",
-            "name": "fuchsia-1300",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1300"
           }
         }
       },
@@ -1563,8 +1423,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7c819391-d74c-4326-ae0d-fe3534eb44e3",
-            "name": "fuchsia-1400",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1400"
           }
         }
       },
@@ -1574,8 +1433,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ff510e34-7c7c-4795-a224-b1e1c5cc25e0",
-            "name": "fuchsia-1500",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1500"
           }
         }
       },
@@ -1585,8 +1443,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c06ab95f-6471-4840-99cc-710851d25de4",
-            "name": "fuchsia-1600",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1600"
           }
         }
       }
@@ -1598,8 +1455,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e60cb247-c265-4009-9f0a-bcbbbb801dd4",
-            "name": "indigo-100",
-            "constant-token-duplicate": false
+            "name": "indigo-100"
           }
         }
       },
@@ -1609,8 +1465,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "56c709dd-b41e-478a-8098-21014e3f9ec8",
-            "name": "indigo-200",
-            "constant-token-duplicate": false
+            "name": "indigo-200"
           }
         }
       },
@@ -1620,8 +1475,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "716f244e-67c5-4566-b824-ed7f2192b585",
-            "name": "indigo-300",
-            "constant-token-duplicate": false
+            "name": "indigo-300"
           }
         }
       },
@@ -1631,8 +1485,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c256e06e-07bc-4dcd-9239-48841916c93b",
-            "name": "indigo-400",
-            "constant-token-duplicate": false
+            "name": "indigo-400"
           }
         }
       },
@@ -1642,8 +1495,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1ea0564b-6e88-456e-a796-4620d57b8771",
-            "name": "indigo-500",
-            "constant-token-duplicate": false
+            "name": "indigo-500"
           }
         }
       },
@@ -1653,8 +1505,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "df590853-ce16-4ddf-bbe9-a912695eae17",
-            "name": "indigo-600",
-            "constant-token-duplicate": false
+            "name": "indigo-600"
           }
         }
       },
@@ -1664,8 +1515,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0ea3a7e0-35c5-46ec-ae9d-500c5ee06a16",
-            "name": "indigo-700",
-            "constant-token-duplicate": false
+            "name": "indigo-700"
           }
         }
       },
@@ -1675,8 +1525,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "97e84a30-1de4-4e84-8d59-e625f9ec9ab1",
-            "name": "indigo-800",
-            "constant-token-duplicate": false
+            "name": "indigo-800"
           }
         }
       },
@@ -1686,8 +1535,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5cb7ff5e-ec53-4df8-b59d-a1419190a6cf",
-            "name": "indigo-900",
-            "constant-token-duplicate": false
+            "name": "indigo-900"
           }
         }
       },
@@ -1697,8 +1545,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0bf6170c-50d7-4600-96fe-2d1af93f173a",
-            "name": "indigo-1000",
-            "constant-token-duplicate": false
+            "name": "indigo-1000"
           }
         }
       },
@@ -1708,8 +1555,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c85ea1d9-e28d-46c5-abd0-c053858770e0",
-            "name": "indigo-1100",
-            "constant-token-duplicate": false
+            "name": "indigo-1100"
           }
         }
       },
@@ -1719,8 +1565,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "91f9622a-03b4-47b0-b380-5f6d64c13b5d",
-            "name": "indigo-1200",
-            "constant-token-duplicate": false
+            "name": "indigo-1200"
           }
         }
       },
@@ -1730,8 +1575,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c0bfd081-7859-4ed5-aa4c-c1f547dab8f3",
-            "name": "indigo-1300",
-            "constant-token-duplicate": false
+            "name": "indigo-1300"
           }
         }
       },
@@ -1741,8 +1585,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "080f9ea4-1d87-4691-adb7-3875a7708555",
-            "name": "indigo-1400",
-            "constant-token-duplicate": false
+            "name": "indigo-1400"
           }
         }
       },
@@ -1752,8 +1595,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "498d2f9c-7304-406d-a3f8-802a2cbd3502",
-            "name": "indigo-1500",
-            "constant-token-duplicate": false
+            "name": "indigo-1500"
           }
         }
       },
@@ -1763,8 +1605,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c498c300-86e8-4c71-bd3e-5a344324b9c1",
-            "name": "indigo-1600",
-            "constant-token-duplicate": false
+            "name": "indigo-1600"
           }
         }
       }
@@ -1776,8 +1617,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9149371a-1978-4136-a89c-8895edd35e7d",
-            "name": "magenta-100",
-            "constant-token-duplicate": false
+            "name": "magenta-100"
           }
         }
       },
@@ -1787,8 +1627,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f5ffc5b3-d3e6-4d7e-b8a8-850324b5d9b8",
-            "name": "magenta-200",
-            "constant-token-duplicate": false
+            "name": "magenta-200"
           }
         }
       },
@@ -1798,8 +1637,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "673ab9b4-e296-4472-b0b5-15adf9f1f762",
-            "name": "magenta-300",
-            "constant-token-duplicate": false
+            "name": "magenta-300"
           }
         }
       },
@@ -1809,8 +1647,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "60560de2-28e6-44b4-bcff-f357fe13a4a7",
-            "name": "magenta-400",
-            "constant-token-duplicate": false
+            "name": "magenta-400"
           }
         }
       },
@@ -1820,8 +1657,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "830123a6-0e42-4c4f-9b20-2f4204d37af8",
-            "name": "magenta-500",
-            "constant-token-duplicate": false
+            "name": "magenta-500"
           }
         }
       },
@@ -1831,8 +1667,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e6b14a1d-e26e-41c4-b386-7fb3f95b8c93",
-            "name": "magenta-600",
-            "constant-token-duplicate": false
+            "name": "magenta-600"
           }
         }
       },
@@ -1842,8 +1677,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "11055a6b-7e81-4b59-9feb-8b0b6352be07",
-            "name": "magenta-700",
-            "constant-token-duplicate": false
+            "name": "magenta-700"
           }
         }
       },
@@ -1853,8 +1687,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6676db79-7b7e-4fcf-868b-321f9372517a",
-            "name": "magenta-800",
-            "constant-token-duplicate": false
+            "name": "magenta-800"
           }
         }
       },
@@ -1864,8 +1697,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fa5e523e-7ee3-46d0-971f-4ee95c7222b8",
-            "name": "magenta-900",
-            "constant-token-duplicate": false
+            "name": "magenta-900"
           }
         }
       },
@@ -1875,8 +1707,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "bdabbfb5-1ae6-44a7-bc2e-55e11f4e5154",
-            "name": "magenta-1000",
-            "constant-token-duplicate": false
+            "name": "magenta-1000"
           }
         }
       },
@@ -1886,8 +1717,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "548a74eb-4401-44f4-85b4-921287d84ac9",
-            "name": "magenta-1100",
-            "constant-token-duplicate": false
+            "name": "magenta-1100"
           }
         }
       },
@@ -1897,8 +1727,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9c634688-1ad5-438b-bd44-a92c64ef9934",
-            "name": "magenta-1200",
-            "constant-token-duplicate": false
+            "name": "magenta-1200"
           }
         }
       },
@@ -1908,8 +1737,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6c441ca7-0294-462f-ac18-7b28ff20d7ff",
-            "name": "magenta-1300",
-            "constant-token-duplicate": false
+            "name": "magenta-1300"
           }
         }
       },
@@ -1919,8 +1747,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "15f36ded-01af-4c5d-8b11-45523e7d908e",
-            "name": "magenta-1400",
-            "constant-token-duplicate": false
+            "name": "magenta-1400"
           }
         }
       },
@@ -1930,8 +1757,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d2814529-9c64-47fd-a317-8669d565cf67",
-            "name": "magenta-1500",
-            "constant-token-duplicate": false
+            "name": "magenta-1500"
           }
         }
       },
@@ -1941,8 +1767,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c24954cd-f17c-47b4-8a3e-8cb019a3e330",
-            "name": "magenta-1600",
-            "constant-token-duplicate": false
+            "name": "magenta-1600"
           }
         }
       }
@@ -1954,8 +1779,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ffc5aa7a-c339-4583-a586-3e8b1329d16d",
-            "name": "purple-100",
-            "constant-token-duplicate": false
+            "name": "purple-100"
           }
         }
       },
@@ -1965,8 +1789,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2d67627b-372c-46af-b015-6c95bd027664",
-            "name": "purple-200",
-            "constant-token-duplicate": false
+            "name": "purple-200"
           }
         }
       },
@@ -1976,8 +1799,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "be628028-f41d-4ace-abf3-f7f38ecb2e01",
-            "name": "purple-300",
-            "constant-token-duplicate": false
+            "name": "purple-300"
           }
         }
       },
@@ -1987,8 +1809,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "474fed30-921a-4795-8999-2310521c64c5",
-            "name": "purple-400",
-            "constant-token-duplicate": false
+            "name": "purple-400"
           }
         }
       },
@@ -1998,8 +1819,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b912e8ba-ed77-4179-9b80-7448f9e37193",
-            "name": "purple-500",
-            "constant-token-duplicate": false
+            "name": "purple-500"
           }
         }
       },
@@ -2009,8 +1829,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "05638159-aaf7-4f3e-849e-a46e80cd9ee6",
-            "name": "purple-600",
-            "constant-token-duplicate": false
+            "name": "purple-600"
           }
         }
       },
@@ -2020,8 +1839,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fb186f5e-72a8-4a27-8ba2-d2fdf53d5a5c",
-            "name": "purple-700",
-            "constant-token-duplicate": false
+            "name": "purple-700"
           }
         }
       },
@@ -2031,8 +1849,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "30aae683-83e3-47a1-bdcb-ebe658e110a3",
-            "name": "purple-800",
-            "constant-token-duplicate": false
+            "name": "purple-800"
           }
         }
       },
@@ -2042,8 +1859,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "12d86845-fd54-4d30-aac8-bb9451560ba5",
-            "name": "purple-900",
-            "constant-token-duplicate": false
+            "name": "purple-900"
           }
         }
       },
@@ -2053,8 +1869,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e527a3bd-3543-4b40-8a9c-eb465695bdb9",
-            "name": "purple-1000",
-            "constant-token-duplicate": false
+            "name": "purple-1000"
           }
         }
       },
@@ -2064,8 +1879,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "18265c0a-e466-4575-a364-3dfda9e71bd4",
-            "name": "purple-1100",
-            "constant-token-duplicate": false
+            "name": "purple-1100"
           }
         }
       },
@@ -2075,8 +1889,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ae071768-dcdd-4e30-8f72-d066abac97af",
-            "name": "purple-1200",
-            "constant-token-duplicate": false
+            "name": "purple-1200"
           }
         }
       },
@@ -2086,8 +1899,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fbaaff02-da93-4f45-830a-5fc449a58f0b",
-            "name": "purple-1300",
-            "constant-token-duplicate": false
+            "name": "purple-1300"
           }
         }
       },
@@ -2097,8 +1909,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9ae063c9-5817-45b4-9f57-4b2196c845b9",
-            "name": "purple-1400",
-            "constant-token-duplicate": false
+            "name": "purple-1400"
           }
         }
       },
@@ -2108,8 +1919,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d96c8fa3-5872-4bd2-81a3-0109ddf0bf18",
-            "name": "purple-1500",
-            "constant-token-duplicate": false
+            "name": "purple-1500"
           }
         }
       },
@@ -2119,8 +1929,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0f10b720-c0f8-46db-9205-fdde265d05f7",
-            "name": "purple-1600",
-            "constant-token-duplicate": false
+            "name": "purple-1600"
           }
         }
       }
@@ -2132,8 +1941,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "080b56a3-6f95-422a-9f4b-d850966c4984",
-            "name": "seafoam-100",
-            "constant-token-duplicate": false
+            "name": "seafoam-100"
           }
         }
       },
@@ -2143,8 +1951,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2876bdd7-af97-4cd6-89cc-bdb9c2110946",
-            "name": "seafoam-200",
-            "constant-token-duplicate": false
+            "name": "seafoam-200"
           }
         }
       },
@@ -2154,8 +1961,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d90b7496-0f54-41ce-96eb-c973457661ae",
-            "name": "seafoam-300",
-            "constant-token-duplicate": false
+            "name": "seafoam-300"
           }
         }
       },
@@ -2165,8 +1971,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ec603c2c-b2b2-4769-a889-ba7c91a458eb",
-            "name": "seafoam-400",
-            "constant-token-duplicate": false
+            "name": "seafoam-400"
           }
         }
       },
@@ -2176,8 +1981,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c24b866c-5ac0-49de-857b-48c655fa9990",
-            "name": "seafoam-500",
-            "constant-token-duplicate": false
+            "name": "seafoam-500"
           }
         }
       },
@@ -2187,8 +1991,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "73b58f7e-008b-44ae-8969-19d981d444d6",
-            "name": "seafoam-600",
-            "constant-token-duplicate": false
+            "name": "seafoam-600"
           }
         }
       },
@@ -2198,8 +2001,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0b8528e6-ceea-47a5-9727-24e97d7bc138",
-            "name": "seafoam-700",
-            "constant-token-duplicate": false
+            "name": "seafoam-700"
           }
         }
       },
@@ -2209,8 +2011,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "df8f47d4-5c3b-4ecb-b9fb-5d2dbd39d696",
-            "name": "seafoam-800",
-            "constant-token-duplicate": false
+            "name": "seafoam-800"
           }
         }
       },
@@ -2220,8 +2021,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "dca23a18-2b19-48bf-9894-2f0948f6c05e",
-            "name": "seafoam-900",
-            "constant-token-duplicate": false
+            "name": "seafoam-900"
           }
         }
       },
@@ -2231,8 +2031,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c416b5c5-0506-419f-88ca-f722f12a9d86",
-            "name": "seafoam-1000",
-            "constant-token-duplicate": false
+            "name": "seafoam-1000"
           }
         }
       },
@@ -2242,8 +2041,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4a853bfc-f1b0-4e39-8cd8-da0350c99cd5",
-            "name": "seafoam-1100",
-            "constant-token-duplicate": false
+            "name": "seafoam-1100"
           }
         }
       },
@@ -2253,8 +2051,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8e4c65b7-d819-4ffd-9398-71e9d294ba63",
-            "name": "seafoam-1200",
-            "constant-token-duplicate": false
+            "name": "seafoam-1200"
           }
         }
       },
@@ -2264,8 +2061,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ef35ace8-870d-42e0-8ce6-2df61415431f",
-            "name": "seafoam-1300",
-            "constant-token-duplicate": false
+            "name": "seafoam-1300"
           }
         }
       },
@@ -2275,8 +2071,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9499384b-336c-4a41-af05-645a92ae40d4",
-            "name": "seafoam-1400",
-            "constant-token-duplicate": false
+            "name": "seafoam-1400"
           }
         }
       },
@@ -2286,8 +2081,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6e538a2b-05f7-41f5-af4b-89bc3039c25a",
-            "name": "seafoam-1500",
-            "constant-token-duplicate": false
+            "name": "seafoam-1500"
           }
         }
       },
@@ -2297,8 +2091,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "29aae26e-f4a4-4e5a-acd2-02df01f6cc90",
-            "name": "seafoam-1600",
-            "constant-token-duplicate": false
+            "name": "seafoam-1600"
           }
         }
       }
@@ -2310,8 +2103,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7bef094a-1523-4392-a0ca-59c48409f17a",
-            "name": "yellow-100",
-            "constant-token-duplicate": false
+            "name": "yellow-100"
           }
         }
       },
@@ -2321,8 +2113,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f4fdc925-63b3-4670-9f2b-a057c27c834a",
-            "name": "yellow-200",
-            "constant-token-duplicate": false
+            "name": "yellow-200"
           }
         }
       },
@@ -2332,8 +2123,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "238147c6-0302-4d43-b3a3-42df832c7857",
-            "name": "yellow-300",
-            "constant-token-duplicate": false
+            "name": "yellow-300"
           }
         }
       },
@@ -2343,8 +2133,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "62ab6892-66ea-4b55-8c1a-fcc191d29717",
-            "name": "yellow-400",
-            "constant-token-duplicate": false
+            "name": "yellow-400"
           }
         }
       },
@@ -2354,8 +2143,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "efa1fdd8-4478-411a-892c-0ecf23939489",
-            "name": "yellow-500",
-            "constant-token-duplicate": false
+            "name": "yellow-500"
           }
         }
       },
@@ -2365,8 +2153,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8ae3c5ec-aabe-47a0-b822-ba0907e67ed4",
-            "name": "yellow-600",
-            "constant-token-duplicate": false
+            "name": "yellow-600"
           }
         }
       },
@@ -2376,8 +2163,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ac3e5d40-51eb-45aa-b4e0-87d3f6e8e359",
-            "name": "yellow-700",
-            "constant-token-duplicate": false
+            "name": "yellow-700"
           }
         }
       },
@@ -2387,8 +2173,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "67e8d9aa-d843-4536-9c97-bd51e62da8ee",
-            "name": "yellow-800",
-            "constant-token-duplicate": false
+            "name": "yellow-800"
           }
         }
       },
@@ -2398,8 +2183,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a12f6cac-7fdc-4fd4-8120-ad957823ff6b",
-            "name": "yellow-900",
-            "constant-token-duplicate": false
+            "name": "yellow-900"
           }
         }
       },
@@ -2409,8 +2193,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4cf4a500-37a2-4dd8-a243-14f6c012b53c",
-            "name": "yellow-1000",
-            "constant-token-duplicate": false
+            "name": "yellow-1000"
           }
         }
       },
@@ -2420,8 +2203,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4eee9daf-e19d-4e0b-b12d-4fdcc4852956",
-            "name": "yellow-1100",
-            "constant-token-duplicate": false
+            "name": "yellow-1100"
           }
         }
       },
@@ -2431,8 +2213,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "69059dfa-e2e1-4f8d-b06b-058a8724e071",
-            "name": "yellow-1200",
-            "constant-token-duplicate": false
+            "name": "yellow-1200"
           }
         }
       },
@@ -2442,8 +2223,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b2a1039c-cbfe-44bf-a0fe-822c5f576f52",
-            "name": "yellow-1300",
-            "constant-token-duplicate": false
+            "name": "yellow-1300"
           }
         }
       },
@@ -2453,8 +2233,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "dfd355e7-82fd-4fdb-96bd-b584d7268ee9",
-            "name": "yellow-1400",
-            "constant-token-duplicate": false
+            "name": "yellow-1400"
           }
         }
       },
@@ -2464,8 +2243,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "166ee2cc-b727-4f3c-9c08-5c586a0f6c11",
-            "name": "yellow-1500",
-            "constant-token-duplicate": false
+            "name": "yellow-1500"
           }
         }
       },
@@ -2475,8 +2253,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3df0b31f-656a-4400-99c4-d559da586714",
-            "name": "yellow-1600",
-            "constant-token-duplicate": false
+            "name": "yellow-1600"
           }
         }
       }
@@ -2488,8 +2265,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "bd616b1d-fe15-498b-b8c3-02b3ec12917c",
-            "name": "pink-100",
-            "constant-token-duplicate": false
+            "name": "pink-100"
           }
         }
       },
@@ -2499,8 +2275,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b27db3ca-2a1d-40f0-aa6b-d7256262a70c",
-            "name": "pink-200",
-            "constant-token-duplicate": false
+            "name": "pink-200"
           }
         }
       },
@@ -2510,8 +2285,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b4a885e9-96d3-498f-b8a9-87c448723198",
-            "name": "pink-300",
-            "constant-token-duplicate": false
+            "name": "pink-300"
           }
         }
       },
@@ -2521,8 +2295,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3a4e3a24-0f21-44a4-ad80-f721ad6acb38",
-            "name": "pink-400",
-            "constant-token-duplicate": false
+            "name": "pink-400"
           }
         }
       },
@@ -2532,8 +2305,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "14b4ffb1-3dcb-4155-b470-1006982eec4c",
-            "name": "pink-500",
-            "constant-token-duplicate": false
+            "name": "pink-500"
           }
         }
       },
@@ -2543,8 +2315,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "77da83cc-1a57-486b-bb43-e74e6b5ac041",
-            "name": "pink-600",
-            "constant-token-duplicate": false
+            "name": "pink-600"
           }
         }
       },
@@ -2554,8 +2325,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6c1ae7db-8ca1-4dbe-9d1e-2b3f5ab28a5c",
-            "name": "pink-700",
-            "constant-token-duplicate": false
+            "name": "pink-700"
           }
         }
       },
@@ -2565,8 +2335,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "86b686e1-d580-4fc0-9246-8b94ad2fed96",
-            "name": "pink-800",
-            "constant-token-duplicate": false
+            "name": "pink-800"
           }
         }
       },
@@ -2576,8 +2345,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fb259e11-a051-4116-a7cb-f567cf814df5",
-            "name": "pink-900",
-            "constant-token-duplicate": false
+            "name": "pink-900"
           }
         }
       },
@@ -2587,8 +2355,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "89cc3b46-c438-4e65-bf43-c373cb6af83f",
-            "name": "pink-1000",
-            "constant-token-duplicate": false
+            "name": "pink-1000"
           }
         }
       },
@@ -2598,8 +2365,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ee41ab95-9c22-4523-94ce-efab466cc261",
-            "name": "pink-1100",
-            "constant-token-duplicate": false
+            "name": "pink-1100"
           }
         }
       },
@@ -2609,8 +2375,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "670f5ea8-1435-4dd6-9ee9-f1886378b18f",
-            "name": "pink-1200",
-            "constant-token-duplicate": false
+            "name": "pink-1200"
           }
         }
       },
@@ -2620,8 +2385,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c70eb5b9-80fa-4e03-9589-88001bbed4e2",
-            "name": "pink-1300",
-            "constant-token-duplicate": false
+            "name": "pink-1300"
           }
         }
       },
@@ -2631,8 +2395,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "bb85af92-a0c8-4b12-b651-a2a084d6d1cc",
-            "name": "pink-1400",
-            "constant-token-duplicate": false
+            "name": "pink-1400"
           }
         }
       },
@@ -2642,8 +2405,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0344a02f-ae86-4c77-bb36-480da43b3be1",
-            "name": "pink-1500",
-            "constant-token-duplicate": false
+            "name": "pink-1500"
           }
         }
       },
@@ -2653,8 +2415,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fd715951-5fb7-433c-8a9d-2d10707893e5",
-            "name": "pink-1600",
-            "constant-token-duplicate": false
+            "name": "pink-1600"
           }
         }
       }
@@ -2666,8 +2427,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7be82e76-2525-4496-9425-c180746f12df",
-            "name": "turquoise-100",
-            "constant-token-duplicate": false
+            "name": "turquoise-100"
           }
         }
       },
@@ -2677,8 +2437,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f70fdb17-da0b-4163-8af6-2daa65327e3a",
-            "name": "turquoise-200",
-            "constant-token-duplicate": false
+            "name": "turquoise-200"
           }
         }
       },
@@ -2688,8 +2447,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "eb6f8d2a-1a82-42ef-b668-0aac077d4053",
-            "name": "turquoise-300",
-            "constant-token-duplicate": false
+            "name": "turquoise-300"
           }
         }
       },
@@ -2699,8 +2457,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e354eda3-17c2-4f07-b64b-3620692a12f3",
-            "name": "turquoise-400",
-            "constant-token-duplicate": false
+            "name": "turquoise-400"
           }
         }
       },
@@ -2710,8 +2467,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "de4d07fb-1d63-44cc-a9bf-1cd2e2ed4e59",
-            "name": "turquoise-500",
-            "constant-token-duplicate": false
+            "name": "turquoise-500"
           }
         }
       },
@@ -2721,8 +2477,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ae1d9dc7-e778-4c78-b12d-ab187cc3c254",
-            "name": "turquoise-600",
-            "constant-token-duplicate": false
+            "name": "turquoise-600"
           }
         }
       },
@@ -2732,8 +2487,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "08f4307e-74f1-446d-9051-8a4c11546289",
-            "name": "turquoise-700",
-            "constant-token-duplicate": false
+            "name": "turquoise-700"
           }
         }
       },
@@ -2743,8 +2497,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "69ae2217-ba32-41ca-a38f-8f19dcc5cf76",
-            "name": "turquoise-800",
-            "constant-token-duplicate": false
+            "name": "turquoise-800"
           }
         }
       },
@@ -2754,8 +2507,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2ce15c64-8c38-4935-bc65-7580df395231",
-            "name": "turquoise-900",
-            "constant-token-duplicate": false
+            "name": "turquoise-900"
           }
         }
       },
@@ -2765,8 +2517,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "89d12308-9718-40d6-a089-73b9fcf1185b",
-            "name": "turquoise-1000",
-            "constant-token-duplicate": false
+            "name": "turquoise-1000"
           }
         }
       },
@@ -2776,8 +2527,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7f0dafc6-6863-4542-b58c-610bd97f79fa",
-            "name": "turquoise-1100",
-            "constant-token-duplicate": false
+            "name": "turquoise-1100"
           }
         }
       },
@@ -2787,8 +2537,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "70ca07eb-a370-4059-9d5a-b55f6a9c9f31",
-            "name": "turquoise-1200",
-            "constant-token-duplicate": false
+            "name": "turquoise-1200"
           }
         }
       },
@@ -2798,8 +2547,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c1f51874-6699-4250-bcd3-9d15add56a86",
-            "name": "turquoise-1300",
-            "constant-token-duplicate": false
+            "name": "turquoise-1300"
           }
         }
       },
@@ -2809,8 +2557,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f2f63354-d6fb-4687-abf8-554c4ab95fbf",
-            "name": "turquoise-1400",
-            "constant-token-duplicate": false
+            "name": "turquoise-1400"
           }
         }
       },
@@ -2820,8 +2567,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d4b79c34-286d-40f0-87ce-bbfb6b217dba",
-            "name": "turquoise-1500",
-            "constant-token-duplicate": false
+            "name": "turquoise-1500"
           }
         }
       },
@@ -2831,8 +2577,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4ae14c01-10b1-4daf-a064-dab9f6fdea9d",
-            "name": "turquoise-1600",
-            "constant-token-duplicate": false
+            "name": "turquoise-1600"
           }
         }
       }
@@ -2844,8 +2589,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "478633c7-4a14-4e39-a05c-bfa07aeb4a85",
-            "name": "brown-100",
-            "constant-token-duplicate": false
+            "name": "brown-100"
           }
         }
       },
@@ -2855,8 +2599,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ec81816f-120e-46f9-a5b0-adb94814d1eb",
-            "name": "brown-200",
-            "constant-token-duplicate": false
+            "name": "brown-200"
           }
         }
       },
@@ -2866,8 +2609,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3c253e65-bd9a-4e52-ad68-83aca3b197e6",
-            "name": "brown-300",
-            "constant-token-duplicate": false
+            "name": "brown-300"
           }
         }
       },
@@ -2877,8 +2619,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a9daa02d-c0aa-4c05-80ee-2bf55165dd36",
-            "name": "brown-400",
-            "constant-token-duplicate": false
+            "name": "brown-400"
           }
         }
       },
@@ -2888,8 +2629,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f455957b-e647-44b3-a917-7d6e19807d40",
-            "name": "brown-500",
-            "constant-token-duplicate": false
+            "name": "brown-500"
           }
         }
       },
@@ -2899,8 +2639,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "41f83cff-cdd4-4760-a4bd-0bb1ceb46854",
-            "name": "brown-600",
-            "constant-token-duplicate": false
+            "name": "brown-600"
           }
         }
       },
@@ -2910,8 +2649,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "dc738913-4af6-446e-8a1b-09c84993c8e5",
-            "name": "brown-700",
-            "constant-token-duplicate": false
+            "name": "brown-700"
           }
         }
       },
@@ -2921,8 +2659,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e21a0edf-a81a-46a0-a849-11111cb89516",
-            "name": "brown-800",
-            "constant-token-duplicate": false
+            "name": "brown-800"
           }
         }
       },
@@ -2932,8 +2669,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "79d7de9d-7bab-4762-acd9-ecf28556906a",
-            "name": "brown-900",
-            "constant-token-duplicate": false
+            "name": "brown-900"
           }
         }
       },
@@ -2943,8 +2679,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6fd7a375-e670-4bde-8061-b1b2ba5116be",
-            "name": "brown-1000",
-            "constant-token-duplicate": false
+            "name": "brown-1000"
           }
         }
       },
@@ -2954,8 +2689,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "26df5572-cbdb-4988-8847-672ee1669acd",
-            "name": "brown-1100",
-            "constant-token-duplicate": false
+            "name": "brown-1100"
           }
         }
       },
@@ -2965,8 +2699,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c1965544-ed0e-438f-aed0-b1f31836950c",
-            "name": "brown-1200",
-            "constant-token-duplicate": false
+            "name": "brown-1200"
           }
         }
       },
@@ -2976,8 +2709,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "41d1432f-1b3a-4e93-8b57-2e48d0e66096",
-            "name": "brown-1300",
-            "constant-token-duplicate": false
+            "name": "brown-1300"
           }
         }
       },
@@ -2987,8 +2719,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "91db9b52-530b-4147-be4f-c4d73a82eac3",
-            "name": "brown-1400",
-            "constant-token-duplicate": false
+            "name": "brown-1400"
           }
         }
       },
@@ -2998,8 +2729,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d4d71d28-ce37-4f3f-8487-807cd1c42b9a",
-            "name": "brown-1500",
-            "constant-token-duplicate": false
+            "name": "brown-1500"
           }
         }
       },
@@ -3009,8 +2739,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "bca1e3d9-9242-4b81-95ab-08735905047b",
-            "name": "brown-1600",
-            "constant-token-duplicate": false
+            "name": "brown-1600"
           }
         }
       }
@@ -3022,8 +2751,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4d68b861-ba0c-438b-b10b-c209d4943206",
-            "name": "cinnamon-100",
-            "constant-token-duplicate": false
+            "name": "cinnamon-100"
           }
         }
       },
@@ -3033,8 +2761,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "bd680dfb-0c2f-45e8-b814-627b496a986c",
-            "name": "cinnamon-200",
-            "constant-token-duplicate": false
+            "name": "cinnamon-200"
           }
         }
       },
@@ -3044,8 +2771,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4d086a5c-1b70-4750-be79-db934e7bc010",
-            "name": "cinnamon-300",
-            "constant-token-duplicate": false
+            "name": "cinnamon-300"
           }
         }
       },
@@ -3055,8 +2781,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e5ab12a9-84b3-4bfe-94be-f734ae39f10d",
-            "name": "cinnamon-400",
-            "constant-token-duplicate": false
+            "name": "cinnamon-400"
           }
         }
       },
@@ -3066,8 +2791,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "641a2424-c699-4920-8a27-68bc1bb178a1",
-            "name": "cinnamon-500",
-            "constant-token-duplicate": false
+            "name": "cinnamon-500"
           }
         }
       },
@@ -3077,8 +2801,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6ccccd38-af76-4045-8ffb-a70bed76b365",
-            "name": "cinnamon-600",
-            "constant-token-duplicate": false
+            "name": "cinnamon-600"
           }
         }
       },
@@ -3088,8 +2811,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "74c0ef96-2f6e-434a-bd89-69c6d9745a45",
-            "name": "cinnamon-700",
-            "constant-token-duplicate": false
+            "name": "cinnamon-700"
           }
         }
       },
@@ -3099,8 +2821,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "58777c5b-8e62-49fe-8e0b-0f8b5127225c",
-            "name": "cinnamon-800",
-            "constant-token-duplicate": false
+            "name": "cinnamon-800"
           }
         }
       },
@@ -3110,8 +2831,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7b65cc42-f559-42de-8077-d808c9e096b6",
-            "name": "cinnamon-900",
-            "constant-token-duplicate": false
+            "name": "cinnamon-900"
           }
         }
       },
@@ -3121,8 +2841,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "40d50298-0ea6-4c7f-8349-2e149ca288aa",
-            "name": "cinnamon-1000",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1000"
           }
         }
       },
@@ -3132,8 +2851,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "219f9efa-0717-4d41-80ac-695297b92cf8",
-            "name": "cinnamon-1100",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1100"
           }
         }
       },
@@ -3143,8 +2861,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a48f0d44-c67a-4e95-b5b9-81379363aebe",
-            "name": "cinnamon-1200",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1200"
           }
         }
       },
@@ -3154,8 +2871,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4aae0490-5f12-430c-824f-f7de008a4e15",
-            "name": "cinnamon-1300",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1300"
           }
         }
       },
@@ -3165,8 +2881,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1e29a372-600e-4cda-a190-b865c5521aa6",
-            "name": "cinnamon-1400",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1400"
           }
         }
       },
@@ -3176,8 +2891,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7b880574-db1b-47ee-8c66-6504ada37f56",
-            "name": "cinnamon-1500",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1500"
           }
         }
       },
@@ -3187,8 +2901,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1d04ed6a-8efc-472b-b7c7-0fbc160ce7fd",
-            "name": "cinnamon-1600",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1600"
           }
         }
       }
@@ -3200,8 +2913,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0c4a28ee-a473-4437-924e-c46a9bc0771b",
-            "name": "silver-100",
-            "constant-token-duplicate": false
+            "name": "silver-100"
           }
         }
       },
@@ -3211,8 +2923,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "99b20fba-8fa9-414b-9119-dbaccc5af3c5",
-            "name": "silver-200",
-            "constant-token-duplicate": false
+            "name": "silver-200"
           }
         }
       },
@@ -3222,8 +2933,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "27ca065d-5baf-470f-b1aa-09e9934055d0",
-            "name": "silver-300",
-            "constant-token-duplicate": false
+            "name": "silver-300"
           }
         }
       },
@@ -3233,8 +2943,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0c4f7cca-a9fc-40d5-9503-04c505962f33",
-            "name": "silver-400",
-            "constant-token-duplicate": false
+            "name": "silver-400"
           }
         }
       },
@@ -3244,8 +2953,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "98e7bc6e-bfed-47c4-8f6e-ab1e035deef7",
-            "name": "silver-500",
-            "constant-token-duplicate": false
+            "name": "silver-500"
           }
         }
       },
@@ -3255,8 +2963,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9e46a3c3-25d1-41f5-b76d-d4d136668589",
-            "name": "silver-600",
-            "constant-token-duplicate": false
+            "name": "silver-600"
           }
         }
       },
@@ -3266,8 +2973,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d66afc23-a9aa-4a50-a094-3dfebe044a08",
-            "name": "silver-700",
-            "constant-token-duplicate": false
+            "name": "silver-700"
           }
         }
       },
@@ -3277,8 +2983,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3f481be4-bdd3-45b8-bcfe-c7577cac40d4",
-            "name": "silver-800",
-            "constant-token-duplicate": false
+            "name": "silver-800"
           }
         }
       },
@@ -3288,8 +2993,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "66efbf5e-008b-41f6-a623-ee3722e41c69",
-            "name": "silver-900",
-            "constant-token-duplicate": false
+            "name": "silver-900"
           }
         }
       },
@@ -3299,8 +3003,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ee71e6fd-283f-4ba3-a6a3-b23491ce86d0",
-            "name": "silver-1000",
-            "constant-token-duplicate": false
+            "name": "silver-1000"
           }
         }
       },
@@ -3310,8 +3013,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e1239867-313d-44f8-8ac7-ebdb9f34724e",
-            "name": "silver-1100",
-            "constant-token-duplicate": false
+            "name": "silver-1100"
           }
         }
       },
@@ -3321,8 +3023,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5ce07115-c390-4b72-b1ce-4e1f5346ac59",
-            "name": "silver-1200",
-            "constant-token-duplicate": false
+            "name": "silver-1200"
           }
         }
       },
@@ -3332,8 +3033,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "426823de-8002-4acb-a591-8ace92d1e0cd",
-            "name": "silver-1300",
-            "constant-token-duplicate": false
+            "name": "silver-1300"
           }
         }
       },
@@ -3343,8 +3043,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b4cae4c1-1075-4776-a217-940423c4297c",
-            "name": "silver-1400",
-            "constant-token-duplicate": false
+            "name": "silver-1400"
           }
         }
       },
@@ -3354,8 +3053,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "196c4205-2175-4317-82e1-c2fdeb990c4b",
-            "name": "silver-1500",
-            "constant-token-duplicate": false
+            "name": "silver-1500"
           }
         }
       },
@@ -3365,8 +3063,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8509cb0b-461b-441c-b909-0384737ca553",
-            "name": "silver-1600",
-            "constant-token-duplicate": false
+            "name": "silver-1600"
           }
         }
       }
@@ -3378,8 +3075,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d0867b86-6245-4c02-8617-ea7fd5c80288",
-            "name": "transparent-black-25",
-            "constant-token-duplicate": true
+            "name": "transparent-black-25"
           }
         }
       },
@@ -3389,8 +3085,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d6aa176c-30bd-423f-b05f-4360672bd87e",
-            "name": "transparent-black-50",
-            "constant-token-duplicate": true
+            "name": "transparent-black-50"
           }
         }
       },
@@ -3400,8 +3095,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d33a66ea-ca60-416f-9e92-967dbbb1e983",
-            "name": "transparent-black-75",
-            "constant-token-duplicate": true
+            "name": "transparent-black-75"
           }
         }
       },
@@ -3411,8 +3105,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7565eb32-d745-4fc3-8779-a717f8ba910a",
-            "name": "transparent-black-100",
-            "constant-token-duplicate": true
+            "name": "transparent-black-100"
           }
         }
       },
@@ -3422,8 +3115,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a84ecad8-8005-4ce4-add6-7f83f7e05ba0",
-            "name": "transparent-black-200",
-            "constant-token-duplicate": true
+            "name": "transparent-black-200"
           }
         }
       },
@@ -3433,8 +3125,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "16a871e1-d9df-42bb-8889-99059d70e82e",
-            "name": "transparent-black-300",
-            "constant-token-duplicate": true
+            "name": "transparent-black-300"
           }
         }
       },
@@ -3444,8 +3135,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b769453b-586c-4dd2-b3a1-ddf5964160bc",
-            "name": "transparent-black-400",
-            "constant-token-duplicate": true
+            "name": "transparent-black-400"
           }
         }
       },
@@ -3455,8 +3145,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "cebedd9f-9e4b-47cf-addb-45d8ff9c9179",
-            "name": "transparent-black-500",
-            "constant-token-duplicate": true
+            "name": "transparent-black-500"
           }
         }
       },
@@ -3466,8 +3155,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "199e19a5-bf7d-4933-8425-d7d5881e4cf5",
-            "name": "transparent-black-600",
-            "constant-token-duplicate": true
+            "name": "transparent-black-600"
           }
         }
       },
@@ -3477,8 +3165,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "56da822f-98ea-4ad1-b993-3f052de45f36",
-            "name": "transparent-black-700",
-            "constant-token-duplicate": true
+            "name": "transparent-black-700"
           }
         }
       },
@@ -3488,8 +3175,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3e89f180-b0f0-4de0-904b-c80f0210a361",
-            "name": "transparent-black-800",
-            "constant-token-duplicate": true
+            "name": "transparent-black-800"
           }
         }
       },
@@ -3499,8 +3185,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c0a331f9-53e3-4c72-b5e3-139d730a1752",
-            "name": "transparent-black-900",
-            "constant-token-duplicate": true
+            "name": "transparent-black-900"
           }
         }
       },
@@ -3510,8 +3195,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "098f2f56-e52f-47b1-943a-d1d7218de484",
-            "name": "transparent-black-1000",
-            "constant-token-duplicate": true
+            "name": "transparent-black-1000"
           }
         }
       }
@@ -3523,8 +3207,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "98a7279b-e21c-41ae-9bae-8b9b2b243e35",
-            "name": "transparent-white-25",
-            "constant-token-duplicate": true
+            "name": "transparent-white-25"
           }
         }
       },
@@ -3534,8 +3217,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "db1dbf26-fa48-42e1-b724-7953b0a6a543",
-            "name": "transparent-white-50",
-            "constant-token-duplicate": true
+            "name": "transparent-white-50"
           }
         }
       },
@@ -3545,8 +3227,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "28d11d38-570d-4d99-b581-855781b972c5",
-            "name": "transparent-white-75",
-            "constant-token-duplicate": true
+            "name": "transparent-white-75"
           }
         }
       },
@@ -3556,8 +3237,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a1b64a62-7c78-415e-a9be-c86acbf361ca",
-            "name": "transparent-white-100",
-            "constant-token-duplicate": true
+            "name": "transparent-white-100"
           }
         }
       },
@@ -3567,8 +3247,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "936db837-bc5a-40b0-a0e8-8e39b9fc62cb",
-            "name": "transparent-white-200",
-            "constant-token-duplicate": true
+            "name": "transparent-white-200"
           }
         }
       },
@@ -3578,8 +3257,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5ffa0283-ce9c-4f96-9227-f559ec54ee0c",
-            "name": "transparent-white-300",
-            "constant-token-duplicate": true
+            "name": "transparent-white-300"
           }
         }
       },
@@ -3589,8 +3267,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "12e610d4-e3dc-4e86-9c09-09d86915b6f1",
-            "name": "transparent-white-400",
-            "constant-token-duplicate": true
+            "name": "transparent-white-400"
           }
         }
       },
@@ -3600,8 +3277,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "89c1380f-3e8e-4895-b025-027cee7ecd5b",
-            "name": "transparent-white-500",
-            "constant-token-duplicate": true
+            "name": "transparent-white-500"
           }
         }
       },
@@ -3611,8 +3287,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b24431ee-5c72-4a73-8733-746c6f5d77c0",
-            "name": "transparent-white-600",
-            "constant-token-duplicate": true
+            "name": "transparent-white-600"
           }
         }
       },
@@ -3622,8 +3297,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3ecc14ec-a21e-47ba-8225-915509a532af",
-            "name": "transparent-white-700",
-            "constant-token-duplicate": true
+            "name": "transparent-white-700"
           }
         }
       },
@@ -3633,8 +3307,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b85836bf-af47-412a-900a-4ec5ad0733b2",
-            "name": "transparent-white-800",
-            "constant-token-duplicate": true
+            "name": "transparent-white-800"
           }
         }
       },
@@ -3644,8 +3317,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c5c823c6-1911-4e0e-ba2f-5105f467e108",
-            "name": "transparent-white-900",
-            "constant-token-duplicate": true
+            "name": "transparent-white-900"
           }
         }
       },
@@ -3655,8 +3327,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1409a50a-9a9d-463d-957f-fa2e4f98a0cd",
-            "name": "transparent-white-1000",
-            "constant-token-duplicate": true
+            "name": "transparent-white-1000"
           }
         }
       }

--- a/src/tokens-studio/spectrum2-colors/spectrum2/palette/light.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/palette/light.json
@@ -6,8 +6,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "28dea8b0-4e9a-46f9-babb-c8910e6ae783",
-          "name": "black",
-          "constant-token-duplicate": true
+          "name": "black"
         }
       }
     },
@@ -17,8 +16,7 @@
       "$extensions": {
         "spectrum-tokens": {
           "uuid": "9b799da8-2130-417e-b7ee-5e1154a89837",
-          "name": "white",
-          "constant-token-duplicate": true
+          "name": "white"
         }
       }
     },
@@ -29,8 +27,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a8c6363c-5297-41e3-ad76-1b6d0d3a3cc9",
-            "name": "gray-25",
-            "constant-token-duplicate": false
+            "name": "gray-25"
           }
         }
       },
@@ -40,8 +37,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f6e408a6-81ae-4658-8375-a532f324eba0",
-            "name": "gray-50",
-            "constant-token-duplicate": false
+            "name": "gray-50"
           }
         }
       },
@@ -51,8 +47,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "01cd6c7e-f2eb-4b5d-9e2a-30940e1ab37b",
-            "name": "gray-75",
-            "constant-token-duplicate": false
+            "name": "gray-75"
           }
         }
       },
@@ -62,8 +57,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "64e2dbc2-05fa-43d7-80ae-d4d11c55348f",
-            "name": "gray-100",
-            "constant-token-duplicate": false
+            "name": "gray-100"
           }
         }
       },
@@ -73,8 +67,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8de4888d-8da5-45a0-8d5d-64a734993ae4",
-            "name": "gray-200",
-            "constant-token-duplicate": false
+            "name": "gray-200"
           }
         }
       },
@@ -84,8 +77,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "aad52960-a7ec-4f69-85f9-3e1a87975120",
-            "name": "gray-300",
-            "constant-token-duplicate": false
+            "name": "gray-300"
           }
         }
       },
@@ -95,8 +87,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9a4b4fc4-25e4-4ca8-b0d1-949c5851b47e",
-            "name": "gray-400",
-            "constant-token-duplicate": false
+            "name": "gray-400"
           }
         }
       },
@@ -106,8 +97,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7fa86c73-f058-4922-be8d-19902515cf44",
-            "name": "gray-500",
-            "constant-token-duplicate": false
+            "name": "gray-500"
           }
         }
       },
@@ -117,8 +107,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e6a41088-a188-483c-b197-63ed3c70463d",
-            "name": "gray-600",
-            "constant-token-duplicate": false
+            "name": "gray-600"
           }
         }
       },
@@ -128,8 +117,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "97111e8e-5823-47f2-af64-c3244b8d3492",
-            "name": "gray-700",
-            "constant-token-duplicate": false
+            "name": "gray-700"
           }
         }
       },
@@ -139,8 +127,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2caf1f36-80b9-4659-90be-8d89672bb19f",
-            "name": "gray-800",
-            "constant-token-duplicate": false
+            "name": "gray-800"
           }
         }
       },
@@ -150,8 +137,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "59093f0d-98b7-4659-bea6-3248ad20e96c",
-            "name": "gray-900",
-            "constant-token-duplicate": false
+            "name": "gray-900"
           }
         }
       },
@@ -161,8 +147,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "457fbeb8-56cd-4f3c-9950-f5e01f83f07c",
-            "name": "gray-1000",
-            "constant-token-duplicate": false
+            "name": "gray-1000"
           }
         }
       }
@@ -174,8 +159,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "bb610367-a43d-4ba9-b667-84b4d8da69b2",
-            "name": "blue-100",
-            "constant-token-duplicate": false
+            "name": "blue-100"
           }
         }
       },
@@ -185,8 +169,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "989a37a5-66f2-4a84-a118-8d36caee6695",
-            "name": "blue-200",
-            "constant-token-duplicate": false
+            "name": "blue-200"
           }
         }
       },
@@ -196,8 +179,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "58dc7d3a-3a6d-4ee4-ad38-5e01a07335bd",
-            "name": "blue-300",
-            "constant-token-duplicate": false
+            "name": "blue-300"
           }
         }
       },
@@ -207,8 +189,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9c39c15f-04ee-4cb3-acf3-04c390f14780",
-            "name": "blue-400",
-            "constant-token-duplicate": false
+            "name": "blue-400"
           }
         }
       },
@@ -218,8 +199,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ccc5c654-280e-4f46-964e-9d589f571bc6",
-            "name": "blue-500",
-            "constant-token-duplicate": false
+            "name": "blue-500"
           }
         }
       },
@@ -229,8 +209,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b781aad3-054c-4e81-a368-a8165e6035fd",
-            "name": "blue-600",
-            "constant-token-duplicate": false
+            "name": "blue-600"
           }
         }
       },
@@ -240,8 +219,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1a25f1fe-6d20-49f9-b8f9-d304efc83626",
-            "name": "blue-700",
-            "constant-token-duplicate": false
+            "name": "blue-700"
           }
         }
       },
@@ -251,8 +229,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5ac73d3a-a6cc-4403-a8d5-46bc262d62e9",
-            "name": "blue-800",
-            "constant-token-duplicate": false
+            "name": "blue-800"
           }
         }
       },
@@ -262,8 +239,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3451c170-3e78-449b-86f2-8b7dbea24c1c",
-            "name": "blue-900",
-            "constant-token-duplicate": false
+            "name": "blue-900"
           }
         }
       },
@@ -273,8 +249,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "da15fc4a-a3ce-4cbe-a2d1-bf5a2e77e5c4",
-            "name": "blue-1000",
-            "constant-token-duplicate": false
+            "name": "blue-1000"
           }
         }
       },
@@ -284,8 +259,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7044000c-09c4-4c12-8b37-94f8601217e2",
-            "name": "blue-1100",
-            "constant-token-duplicate": false
+            "name": "blue-1100"
           }
         }
       },
@@ -295,8 +269,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "aae7bf70-35c6-49f9-a6da-ba40ee217c3d",
-            "name": "blue-1200",
-            "constant-token-duplicate": false
+            "name": "blue-1200"
           }
         }
       },
@@ -306,8 +279,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c6fce6c2-ca99-4a3d-b2af-d96a35ec70dc",
-            "name": "blue-1300",
-            "constant-token-duplicate": false
+            "name": "blue-1300"
           }
         }
       },
@@ -317,8 +289,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "af563d02-b975-4ba5-82d3-02bcf30f762c",
-            "name": "blue-1400",
-            "constant-token-duplicate": false
+            "name": "blue-1400"
           }
         }
       },
@@ -328,8 +299,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a24a53d4-d3c3-4d84-b6eb-048326659524",
-            "name": "blue-1500",
-            "constant-token-duplicate": false
+            "name": "blue-1500"
           }
         }
       },
@@ -339,8 +309,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "29610c54-a311-470d-ad77-c28c000730e3",
-            "name": "blue-1600",
-            "constant-token-duplicate": false
+            "name": "blue-1600"
           }
         }
       }
@@ -352,8 +321,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4428dba5-df85-4125-ba54-1c022b986847",
-            "name": "green-100",
-            "constant-token-duplicate": false
+            "name": "green-100"
           }
         }
       },
@@ -363,8 +331,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9d32cd19-8375-4da3-9324-0e8334c2e714",
-            "name": "green-200",
-            "constant-token-duplicate": false
+            "name": "green-200"
           }
         }
       },
@@ -374,8 +341,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "88bac762-84e1-4652-8152-384f3b1faf59",
-            "name": "green-300",
-            "constant-token-duplicate": false
+            "name": "green-300"
           }
         }
       },
@@ -385,8 +351,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5cb02868-9f86-4e20-85e0-e4f5df24853c",
-            "name": "green-400",
-            "constant-token-duplicate": false
+            "name": "green-400"
           }
         }
       },
@@ -396,8 +361,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8b315766-4fa0-4acc-a679-89da4162a15c",
-            "name": "green-500",
-            "constant-token-duplicate": false
+            "name": "green-500"
           }
         }
       },
@@ -407,8 +371,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4c6c7b90-29ac-4186-a991-c298f19aa83d",
-            "name": "green-600",
-            "constant-token-duplicate": false
+            "name": "green-600"
           }
         }
       },
@@ -418,8 +381,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "19a07ad0-9e01-4adc-861d-f7634de1f1ab",
-            "name": "green-700",
-            "constant-token-duplicate": false
+            "name": "green-700"
           }
         }
       },
@@ -429,8 +391,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1be225f8-3612-422c-923f-b35f1ec4fc00",
-            "name": "green-800",
-            "constant-token-duplicate": false
+            "name": "green-800"
           }
         }
       },
@@ -440,8 +401,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "cd39a520-2020-41d0-96d1-3b0fdb453fef",
-            "name": "green-900",
-            "constant-token-duplicate": false
+            "name": "green-900"
           }
         }
       },
@@ -451,8 +411,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b0846caa-d394-4614-aaa2-af179de285f4",
-            "name": "green-1000",
-            "constant-token-duplicate": false
+            "name": "green-1000"
           }
         }
       },
@@ -462,8 +421,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8d0742b8-c334-41e0-a8e1-50fc8ea3b3ef",
-            "name": "green-1100",
-            "constant-token-duplicate": false
+            "name": "green-1100"
           }
         }
       },
@@ -473,8 +431,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4ea6f2d0-bc92-44fa-90e9-9618806a19c2",
-            "name": "green-1200",
-            "constant-token-duplicate": false
+            "name": "green-1200"
           }
         }
       },
@@ -484,8 +441,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "569d58d2-c7e4-4a0c-b92a-841e45fcbc09",
-            "name": "green-1300",
-            "constant-token-duplicate": false
+            "name": "green-1300"
           }
         }
       },
@@ -495,8 +451,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c0711ebf-a91a-4041-8e1a-259ed6c3c54c",
-            "name": "green-1400",
-            "constant-token-duplicate": false
+            "name": "green-1400"
           }
         }
       },
@@ -506,8 +461,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f853b643-e7bf-4af6-81f4-bc6de9007f3c",
-            "name": "green-1500",
-            "constant-token-duplicate": false
+            "name": "green-1500"
           }
         }
       },
@@ -517,8 +471,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2b4c3a1a-8ea4-4149-862d-801b559e4f65",
-            "name": "green-1600",
-            "constant-token-duplicate": false
+            "name": "green-1600"
           }
         }
       }
@@ -530,8 +483,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8bfd5eff-55b4-4b98-9b2e-2871e4ec6ff6",
-            "name": "orange-100",
-            "constant-token-duplicate": false
+            "name": "orange-100"
           }
         }
       },
@@ -541,8 +493,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "64371717-ac11-4ec3-a0aa-9042cf43fa8f",
-            "name": "orange-200",
-            "constant-token-duplicate": false
+            "name": "orange-200"
           }
         }
       },
@@ -552,8 +503,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f34f9b32-ef46-4473-bfd6-10b858e53f55",
-            "name": "orange-300",
-            "constant-token-duplicate": false
+            "name": "orange-300"
           }
         }
       },
@@ -563,8 +513,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "15bea688-4c32-44c0-9ee3-242bdb50954c",
-            "name": "orange-400",
-            "constant-token-duplicate": false
+            "name": "orange-400"
           }
         }
       },
@@ -574,8 +523,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "33bd4908-1259-4e75-8e96-bd410bebcfd6",
-            "name": "orange-500",
-            "constant-token-duplicate": false
+            "name": "orange-500"
           }
         }
       },
@@ -585,8 +533,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "eeede364-d711-40e5-9d2a-0255b10d36f2",
-            "name": "orange-600",
-            "constant-token-duplicate": false
+            "name": "orange-600"
           }
         }
       },
@@ -596,8 +543,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a4527b6f-e2d4-4a0f-b013-007dc5a2d3ac",
-            "name": "orange-700",
-            "constant-token-duplicate": false
+            "name": "orange-700"
           }
         }
       },
@@ -607,8 +553,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "437e4f5b-e68c-4491-b26c-a9fa1503561b",
-            "name": "orange-800",
-            "constant-token-duplicate": false
+            "name": "orange-800"
           }
         }
       },
@@ -618,8 +563,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e9df9a43-f509-44f3-89f6-c277f7445651",
-            "name": "orange-900",
-            "constant-token-duplicate": false
+            "name": "orange-900"
           }
         }
       },
@@ -629,8 +573,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7dc902b9-6512-429e-9cb4-c2f97ca08e99",
-            "name": "orange-1000",
-            "constant-token-duplicate": false
+            "name": "orange-1000"
           }
         }
       },
@@ -640,8 +583,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b6c1e499-f043-4b5a-81cf-4224a0f83fce",
-            "name": "orange-1100",
-            "constant-token-duplicate": false
+            "name": "orange-1100"
           }
         }
       },
@@ -651,8 +593,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "14da1231-c89f-45a1-845e-f3bd902f704b",
-            "name": "orange-1200",
-            "constant-token-duplicate": false
+            "name": "orange-1200"
           }
         }
       },
@@ -662,8 +603,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f650301b-6586-4193-9937-9f12d6c3f99f",
-            "name": "orange-1300",
-            "constant-token-duplicate": false
+            "name": "orange-1300"
           }
         }
       },
@@ -673,8 +613,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "99a43835-df3a-4447-b91d-9d943659b07f",
-            "name": "orange-1400",
-            "constant-token-duplicate": false
+            "name": "orange-1400"
           }
         }
       },
@@ -684,8 +623,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8aa75bbd-fd78-463d-a321-8672e5a537d6",
-            "name": "orange-1500",
-            "constant-token-duplicate": false
+            "name": "orange-1500"
           }
         }
       },
@@ -695,8 +633,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e99566f3-7b29-4c75-a4bd-ce17c0d84c3f",
-            "name": "orange-1600",
-            "constant-token-duplicate": false
+            "name": "orange-1600"
           }
         }
       }
@@ -708,8 +645,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c9e0870a-8cf0-438e-9395-8141c316ad57",
-            "name": "red-100",
-            "constant-token-duplicate": false
+            "name": "red-100"
           }
         }
       },
@@ -719,8 +655,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a1f7b6a3-4195-44dc-a772-9a04d3cf859c",
-            "name": "red-200",
-            "constant-token-duplicate": false
+            "name": "red-200"
           }
         }
       },
@@ -730,8 +665,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3a393af6-c7f2-45bb-a4bc-9b55518c71ac",
-            "name": "red-300",
-            "constant-token-duplicate": false
+            "name": "red-300"
           }
         }
       },
@@ -741,8 +675,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "49e7cf3a-1f2a-4487-a0a9-3869a30593f1",
-            "name": "red-400",
-            "constant-token-duplicate": false
+            "name": "red-400"
           }
         }
       },
@@ -752,8 +685,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "70b11bf5-60c8-48a6-a1d5-2a74bc22e283",
-            "name": "red-500",
-            "constant-token-duplicate": false
+            "name": "red-500"
           }
         }
       },
@@ -763,8 +695,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "00d13447-f1f9-4cda-89b4-6a839260e91a",
-            "name": "red-600",
-            "constant-token-duplicate": false
+            "name": "red-600"
           }
         }
       },
@@ -774,8 +705,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a84b6ffe-5235-4517-9beb-320ed79cf6b0",
-            "name": "red-700",
-            "constant-token-duplicate": false
+            "name": "red-700"
           }
         }
       },
@@ -785,8 +715,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6c3daf67-9cdc-4c02-9912-ff0b902c22ed",
-            "name": "red-800",
-            "constant-token-duplicate": false
+            "name": "red-800"
           }
         }
       },
@@ -796,8 +725,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d5d3bc64-629c-44b0-8ff5-81f260521f5b",
-            "name": "red-900",
-            "constant-token-duplicate": false
+            "name": "red-900"
           }
         }
       },
@@ -807,8 +735,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4a585714-4331-44b1-b81f-25a8ff1cc8ea",
-            "name": "red-1000",
-            "constant-token-duplicate": false
+            "name": "red-1000"
           }
         }
       },
@@ -818,8 +745,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a02ee7fb-b9de-45f1-bee7-8ffe2145cbec",
-            "name": "red-1100",
-            "constant-token-duplicate": false
+            "name": "red-1100"
           }
         }
       },
@@ -829,8 +755,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ea79c634-9d94-4012-bae0-903479c34dc5",
-            "name": "red-1200",
-            "constant-token-duplicate": false
+            "name": "red-1200"
           }
         }
       },
@@ -840,8 +765,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "63934482-260f-4c73-a176-cad11427c537",
-            "name": "red-1300",
-            "constant-token-duplicate": false
+            "name": "red-1300"
           }
         }
       },
@@ -851,8 +775,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1c208bc2-2eca-4727-a195-f80fe0e7ea11",
-            "name": "red-1400",
-            "constant-token-duplicate": false
+            "name": "red-1400"
           }
         }
       },
@@ -862,8 +785,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "45ef3c1f-fb24-4a0e-98c3-69c6027eb709",
-            "name": "red-1500",
-            "constant-token-duplicate": false
+            "name": "red-1500"
           }
         }
       },
@@ -873,8 +795,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3d8a70af-6e0b-449f-98e3-515498bf00ca",
-            "name": "red-1600",
-            "constant-token-duplicate": false
+            "name": "red-1600"
           }
         }
       }
@@ -886,8 +807,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b4a22d71-d90a-4f6e-8f6d-e4967849376f",
-            "name": "celery-100",
-            "constant-token-duplicate": false
+            "name": "celery-100"
           }
         }
       },
@@ -897,8 +817,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "30941af9-354a-4d61-9462-aca4bcd50093",
-            "name": "celery-200",
-            "constant-token-duplicate": false
+            "name": "celery-200"
           }
         }
       },
@@ -908,8 +827,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3562f589-ba34-465e-9549-2600e2527ab8",
-            "name": "celery-300",
-            "constant-token-duplicate": false
+            "name": "celery-300"
           }
         }
       },
@@ -919,8 +837,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d86c4477-a2f4-449a-8883-daaf33608fde",
-            "name": "celery-400",
-            "constant-token-duplicate": false
+            "name": "celery-400"
           }
         }
       },
@@ -930,8 +847,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9c5fc2d5-30cc-4389-b219-2db69f8a86f9",
-            "name": "celery-500",
-            "constant-token-duplicate": false
+            "name": "celery-500"
           }
         }
       },
@@ -941,8 +857,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c2cfbc22-b556-4cb5-b5ee-670254d5ecbc",
-            "name": "celery-600",
-            "constant-token-duplicate": false
+            "name": "celery-600"
           }
         }
       },
@@ -952,8 +867,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "59b03f98-f898-4888-ad71-07a434e2fc7e",
-            "name": "celery-700",
-            "constant-token-duplicate": false
+            "name": "celery-700"
           }
         }
       },
@@ -963,8 +877,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "41747345-10ab-476a-9d3d-e657f9383e8e",
-            "name": "celery-800",
-            "constant-token-duplicate": false
+            "name": "celery-800"
           }
         }
       },
@@ -974,8 +887,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "deec9c21-caeb-4ec4-bca4-a7661a2c5f91",
-            "name": "celery-900",
-            "constant-token-duplicate": false
+            "name": "celery-900"
           }
         }
       },
@@ -985,8 +897,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3d509755-d653-4a3f-a5a3-fcbed0c2e21c",
-            "name": "celery-1000",
-            "constant-token-duplicate": false
+            "name": "celery-1000"
           }
         }
       },
@@ -996,8 +907,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ea7327bb-48a8-41dd-b139-c7bda3dedaee",
-            "name": "celery-1100",
-            "constant-token-duplicate": false
+            "name": "celery-1100"
           }
         }
       },
@@ -1007,8 +917,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fc4dedc3-0009-4a5a-8e93-f52ba4155e0a",
-            "name": "celery-1200",
-            "constant-token-duplicate": false
+            "name": "celery-1200"
           }
         }
       },
@@ -1018,8 +927,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7a3d9646-272f-4ca1-a4e6-0708eb2cd378",
-            "name": "celery-1300",
-            "constant-token-duplicate": false
+            "name": "celery-1300"
           }
         }
       },
@@ -1029,8 +937,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "02e66104-cbf7-4e27-89cf-f18b1ef04f2d",
-            "name": "celery-1400",
-            "constant-token-duplicate": false
+            "name": "celery-1400"
           }
         }
       },
@@ -1040,8 +947,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ca5c139e-1784-4139-89a3-281a83dbeb99",
-            "name": "celery-1500",
-            "constant-token-duplicate": false
+            "name": "celery-1500"
           }
         }
       },
@@ -1051,8 +957,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "56e0d793-ce33-4da3-8e67-d7df10b2cd89",
-            "name": "celery-1600",
-            "constant-token-duplicate": false
+            "name": "celery-1600"
           }
         }
       }
@@ -1064,8 +969,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b7cca467-abe9-4632-b01a-dda350c93480",
-            "name": "chartreuse-100",
-            "constant-token-duplicate": false
+            "name": "chartreuse-100"
           }
         }
       },
@@ -1075,8 +979,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c1146153-61bf-4a31-8254-54a1d25a93c5",
-            "name": "chartreuse-200",
-            "constant-token-duplicate": false
+            "name": "chartreuse-200"
           }
         }
       },
@@ -1086,8 +989,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f8812b11-742b-44d6-a21a-7fd3db39fe71",
-            "name": "chartreuse-300",
-            "constant-token-duplicate": false
+            "name": "chartreuse-300"
           }
         }
       },
@@ -1097,8 +999,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "32e471ce-5b0d-40f1-a77a-67feff02775e",
-            "name": "chartreuse-400",
-            "constant-token-duplicate": false
+            "name": "chartreuse-400"
           }
         }
       },
@@ -1108,8 +1009,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fe3be762-b55e-43cb-9163-68ee7dafc53e",
-            "name": "chartreuse-500",
-            "constant-token-duplicate": false
+            "name": "chartreuse-500"
           }
         }
       },
@@ -1119,8 +1019,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d61e865b-6538-42a8-aba8-0842359b80c2",
-            "name": "chartreuse-600",
-            "constant-token-duplicate": false
+            "name": "chartreuse-600"
           }
         }
       },
@@ -1130,8 +1029,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3d0fd171-80f3-4f08-9ac0-eb46d0e755f9",
-            "name": "chartreuse-700",
-            "constant-token-duplicate": false
+            "name": "chartreuse-700"
           }
         }
       },
@@ -1141,8 +1039,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9a0701e4-81a0-420b-b751-c6a46670fbf3",
-            "name": "chartreuse-800",
-            "constant-token-duplicate": false
+            "name": "chartreuse-800"
           }
         }
       },
@@ -1152,8 +1049,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7d22a144-0f7c-435e-ad05-b2d7672dff08",
-            "name": "chartreuse-900",
-            "constant-token-duplicate": false
+            "name": "chartreuse-900"
           }
         }
       },
@@ -1163,8 +1059,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "00100510-9965-4086-ba82-0cb62ffebba1",
-            "name": "chartreuse-1000",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1000"
           }
         }
       },
@@ -1174,8 +1069,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e964b654-261d-44a5-ab0a-78c8137a7783",
-            "name": "chartreuse-1100",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1100"
           }
         }
       },
@@ -1185,8 +1079,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6bf184f6-f0e1-41af-94a4-47aa1a37b0aa",
-            "name": "chartreuse-1200",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1200"
           }
         }
       },
@@ -1196,8 +1089,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e320e57d-2794-4c1e-97ef-3a8b04be1328",
-            "name": "chartreuse-1300",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1300"
           }
         }
       },
@@ -1207,8 +1099,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "56b4f40c-d9f2-4360-99eb-7097aafedf94",
-            "name": "chartreuse-1400",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1400"
           }
         }
       },
@@ -1218,8 +1109,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "63f13dcb-6d61-4ff0-9999-33e16d30e5d6",
-            "name": "chartreuse-1500",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1500"
           }
         }
       },
@@ -1229,8 +1119,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "01b68e1d-06d7-44a3-91e6-08e17353008c",
-            "name": "chartreuse-1600",
-            "constant-token-duplicate": false
+            "name": "chartreuse-1600"
           }
         }
       }
@@ -1242,8 +1131,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "72bef490-0c3a-4627-9341-fc6627cf3f74",
-            "name": "cyan-100",
-            "constant-token-duplicate": false
+            "name": "cyan-100"
           }
         }
       },
@@ -1253,8 +1141,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c2aaf729-7f39-499a-8b67-e23801073b05",
-            "name": "cyan-200",
-            "constant-token-duplicate": false
+            "name": "cyan-200"
           }
         }
       },
@@ -1264,8 +1151,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b54275ad-3ea6-4e69-aea2-97f488308fcc",
-            "name": "cyan-300",
-            "constant-token-duplicate": false
+            "name": "cyan-300"
           }
         }
       },
@@ -1275,8 +1161,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a33de292-77a9-40b7-961e-41ebfe331ad0",
-            "name": "cyan-400",
-            "constant-token-duplicate": false
+            "name": "cyan-400"
           }
         }
       },
@@ -1286,8 +1171,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f3e8ff9f-e60b-4bce-9c39-280aef6fcb08",
-            "name": "cyan-500",
-            "constant-token-duplicate": false
+            "name": "cyan-500"
           }
         }
       },
@@ -1297,8 +1181,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d65f3e1d-ad9d-4fa7-ac06-37235124e999",
-            "name": "cyan-600",
-            "constant-token-duplicate": false
+            "name": "cyan-600"
           }
         }
       },
@@ -1308,8 +1191,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "08b4548a-618d-4ab5-ae46-2a60c7936f57",
-            "name": "cyan-700",
-            "constant-token-duplicate": false
+            "name": "cyan-700"
           }
         }
       },
@@ -1319,8 +1201,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6dbdd00d-3b03-4eab-a77c-3a1f16d5e6ef",
-            "name": "cyan-800",
-            "constant-token-duplicate": false
+            "name": "cyan-800"
           }
         }
       },
@@ -1330,8 +1211,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "71769f93-467d-497a-b214-45c8753f34f5",
-            "name": "cyan-900",
-            "constant-token-duplicate": false
+            "name": "cyan-900"
           }
         }
       },
@@ -1341,8 +1221,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "25c689a1-7876-44fa-8849-3a8db03a866c",
-            "name": "cyan-1000",
-            "constant-token-duplicate": false
+            "name": "cyan-1000"
           }
         }
       },
@@ -1352,8 +1231,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "57ca59a9-1677-4813-9c0d-28267233ba35",
-            "name": "cyan-1100",
-            "constant-token-duplicate": false
+            "name": "cyan-1100"
           }
         }
       },
@@ -1363,8 +1241,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d6ba8ac5-09d4-44e2-8ade-216c626eb154",
-            "name": "cyan-1200",
-            "constant-token-duplicate": false
+            "name": "cyan-1200"
           }
         }
       },
@@ -1374,8 +1251,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1b179218-9e53-457d-977b-902509ef28aa",
-            "name": "cyan-1300",
-            "constant-token-duplicate": false
+            "name": "cyan-1300"
           }
         }
       },
@@ -1385,8 +1261,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3eac8807-136f-4687-8403-203fb49fbd74",
-            "name": "cyan-1400",
-            "constant-token-duplicate": false
+            "name": "cyan-1400"
           }
         }
       },
@@ -1396,8 +1271,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4d029c4c-4658-4207-b43c-d69b138b25a3",
-            "name": "cyan-1500",
-            "constant-token-duplicate": false
+            "name": "cyan-1500"
           }
         }
       },
@@ -1407,8 +1281,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e6cd6257-d8de-428e-8ebf-c1c812031e5e",
-            "name": "cyan-1600",
-            "constant-token-duplicate": false
+            "name": "cyan-1600"
           }
         }
       }
@@ -1420,8 +1293,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2a8743fc-d3b3-444a-b3f1-8ad816945941",
-            "name": "fuchsia-100",
-            "constant-token-duplicate": false
+            "name": "fuchsia-100"
           }
         }
       },
@@ -1431,8 +1303,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a304f27a-7a17-4c12-88d1-07171fa3ca75",
-            "name": "fuchsia-200",
-            "constant-token-duplicate": false
+            "name": "fuchsia-200"
           }
         }
       },
@@ -1442,8 +1313,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "723a23a1-0bb0-4c11-89cf-0eca2a421867",
-            "name": "fuchsia-300",
-            "constant-token-duplicate": false
+            "name": "fuchsia-300"
           }
         }
       },
@@ -1453,8 +1323,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ce8ce579-0dca-462c-a9d3-49e451931812",
-            "name": "fuchsia-400",
-            "constant-token-duplicate": false
+            "name": "fuchsia-400"
           }
         }
       },
@@ -1464,8 +1333,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "779bda09-25fd-4912-9aa8-8e3a5643d0cb",
-            "name": "fuchsia-500",
-            "constant-token-duplicate": false
+            "name": "fuchsia-500"
           }
         }
       },
@@ -1475,8 +1343,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "bd2db3f8-5eae-4fcb-a1f6-307d3b8e4139",
-            "name": "fuchsia-600",
-            "constant-token-duplicate": false
+            "name": "fuchsia-600"
           }
         }
       },
@@ -1486,8 +1353,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "42525649-03ba-44f7-bc8c-9a824b898920",
-            "name": "fuchsia-700",
-            "constant-token-duplicate": false
+            "name": "fuchsia-700"
           }
         }
       },
@@ -1497,8 +1363,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3b2867ea-80f8-44ca-9394-7bb17e8c5a22",
-            "name": "fuchsia-800",
-            "constant-token-duplicate": false
+            "name": "fuchsia-800"
           }
         }
       },
@@ -1508,8 +1373,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5fa3362b-01ee-4861-9a02-6af6da804f61",
-            "name": "fuchsia-900",
-            "constant-token-duplicate": false
+            "name": "fuchsia-900"
           }
         }
       },
@@ -1519,8 +1383,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fa79840c-fe56-4f21-b9c5-f1e24f89e031",
-            "name": "fuchsia-1000",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1000"
           }
         }
       },
@@ -1530,8 +1393,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "44aeb8b3-dd63-43a5-adb6-67cca83ca4c5",
-            "name": "fuchsia-1100",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1100"
           }
         }
       },
@@ -1541,8 +1403,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fc66406d-0e4c-4f82-9fa6-aec444f04070",
-            "name": "fuchsia-1200",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1200"
           }
         }
       },
@@ -1552,8 +1413,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "00cfb450-b2b1-47ea-aaf2-221827cca75d",
-            "name": "fuchsia-1300",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1300"
           }
         }
       },
@@ -1563,8 +1423,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e5fc57ed-6d37-4496-a89c-db93104cb333",
-            "name": "fuchsia-1400",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1400"
           }
         }
       },
@@ -1574,8 +1433,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "afdfcd22-19fd-4306-a069-c8f9cd0d4f2d",
-            "name": "fuchsia-1500",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1500"
           }
         }
       },
@@ -1585,8 +1443,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "38117e2a-efd1-4edd-8284-6fb0bc7482cc",
-            "name": "fuchsia-1600",
-            "constant-token-duplicate": false
+            "name": "fuchsia-1600"
           }
         }
       }
@@ -1598,8 +1455,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "04cf76e0-1e7c-479a-9411-0dcad2f6ab25",
-            "name": "indigo-100",
-            "constant-token-duplicate": false
+            "name": "indigo-100"
           }
         }
       },
@@ -1609,8 +1465,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ab568cfd-20e5-4e20-a3bf-32292297df8f",
-            "name": "indigo-200",
-            "constant-token-duplicate": false
+            "name": "indigo-200"
           }
         }
       },
@@ -1620,8 +1475,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a220a225-3bb9-446c-8ee3-732a96a150d2",
-            "name": "indigo-300",
-            "constant-token-duplicate": false
+            "name": "indigo-300"
           }
         }
       },
@@ -1631,8 +1485,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "891799a7-b51d-4769-abe3-62dd0da6e190",
-            "name": "indigo-400",
-            "constant-token-duplicate": false
+            "name": "indigo-400"
           }
         }
       },
@@ -1642,8 +1495,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2751b8ae-f347-4a57-938d-98a5ee86071c",
-            "name": "indigo-500",
-            "constant-token-duplicate": false
+            "name": "indigo-500"
           }
         }
       },
@@ -1653,8 +1505,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2d69bbe7-37c1-4302-9fee-39733bb13a86",
-            "name": "indigo-600",
-            "constant-token-duplicate": false
+            "name": "indigo-600"
           }
         }
       },
@@ -1664,8 +1515,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3c57f9f6-e837-450b-9443-a702caa049a4",
-            "name": "indigo-700",
-            "constant-token-duplicate": false
+            "name": "indigo-700"
           }
         }
       },
@@ -1675,8 +1525,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f5a317ea-25f2-4193-9305-f20c231e786e",
-            "name": "indigo-800",
-            "constant-token-duplicate": false
+            "name": "indigo-800"
           }
         }
       },
@@ -1686,8 +1535,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "87b65e85-d767-47bb-8af5-01b85282c663",
-            "name": "indigo-900",
-            "constant-token-duplicate": false
+            "name": "indigo-900"
           }
         }
       },
@@ -1697,8 +1545,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9d1a9aa9-a7b3-4254-9e55-a992784bb7b5",
-            "name": "indigo-1000",
-            "constant-token-duplicate": false
+            "name": "indigo-1000"
           }
         }
       },
@@ -1708,8 +1555,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2f59721c-2922-4ad3-b50a-37327d592050",
-            "name": "indigo-1100",
-            "constant-token-duplicate": false
+            "name": "indigo-1100"
           }
         }
       },
@@ -1719,8 +1565,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4aaedaea-2d42-4593-84e4-18a12ce5efc2",
-            "name": "indigo-1200",
-            "constant-token-duplicate": false
+            "name": "indigo-1200"
           }
         }
       },
@@ -1730,8 +1575,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f8300596-def6-4640-8d9a-c08fea25bfda",
-            "name": "indigo-1300",
-            "constant-token-duplicate": false
+            "name": "indigo-1300"
           }
         }
       },
@@ -1741,8 +1585,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4e8c10e6-0c7e-4f48-91a0-ff460915725d",
-            "name": "indigo-1400",
-            "constant-token-duplicate": false
+            "name": "indigo-1400"
           }
         }
       },
@@ -1752,8 +1595,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2653368d-d90b-4a5a-97f3-8380fe2e7551",
-            "name": "indigo-1500",
-            "constant-token-duplicate": false
+            "name": "indigo-1500"
           }
         }
       },
@@ -1763,8 +1605,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6a0ad8e2-b574-4148-b151-e0607c4d5317",
-            "name": "indigo-1600",
-            "constant-token-duplicate": false
+            "name": "indigo-1600"
           }
         }
       }
@@ -1776,8 +1617,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "06219a66-5150-42ab-a9fd-c743058728af",
-            "name": "magenta-100",
-            "constant-token-duplicate": false
+            "name": "magenta-100"
           }
         }
       },
@@ -1787,8 +1627,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0a9c01d3-0659-4884-a0e8-7032deeee766",
-            "name": "magenta-200",
-            "constant-token-duplicate": false
+            "name": "magenta-200"
           }
         }
       },
@@ -1798,8 +1637,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "bfe2436d-c026-4641-8cd7-a9824f6948dd",
-            "name": "magenta-300",
-            "constant-token-duplicate": false
+            "name": "magenta-300"
           }
         }
       },
@@ -1809,8 +1647,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4419b5e5-344d-4905-b39d-8935bedf7d6c",
-            "name": "magenta-400",
-            "constant-token-duplicate": false
+            "name": "magenta-400"
           }
         }
       },
@@ -1820,8 +1657,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d7c3e696-4ec4-497f-89c5-bad17cb4699a",
-            "name": "magenta-500",
-            "constant-token-duplicate": false
+            "name": "magenta-500"
           }
         }
       },
@@ -1831,8 +1667,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "329f4efa-6f0b-4bc1-95f7-1121bda7f421",
-            "name": "magenta-600",
-            "constant-token-duplicate": false
+            "name": "magenta-600"
           }
         }
       },
@@ -1842,8 +1677,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fcacf0f0-c919-4705-b4c2-6edbe2796fb0",
-            "name": "magenta-700",
-            "constant-token-duplicate": false
+            "name": "magenta-700"
           }
         }
       },
@@ -1853,8 +1687,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "21e774f7-89d8-438d-9fc4-aa93261022d1",
-            "name": "magenta-800",
-            "constant-token-duplicate": false
+            "name": "magenta-800"
           }
         }
       },
@@ -1864,8 +1697,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0166ed9b-52e7-447a-b45d-de29ba85eb0d",
-            "name": "magenta-900",
-            "constant-token-duplicate": false
+            "name": "magenta-900"
           }
         }
       },
@@ -1875,8 +1707,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "98125f18-a061-4aa7-a0c5-a746d635c4c5",
-            "name": "magenta-1000",
-            "constant-token-duplicate": false
+            "name": "magenta-1000"
           }
         }
       },
@@ -1886,8 +1717,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "29d203d7-7c2c-4f36-a5f3-d84fab6be9f1",
-            "name": "magenta-1100",
-            "constant-token-duplicate": false
+            "name": "magenta-1100"
           }
         }
       },
@@ -1897,8 +1727,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2a9f4ecf-5678-4345-973a-da1e066eaf10",
-            "name": "magenta-1200",
-            "constant-token-duplicate": false
+            "name": "magenta-1200"
           }
         }
       },
@@ -1908,8 +1737,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0be3f108-028b-4fdd-9a98-8bb24deec2d8",
-            "name": "magenta-1300",
-            "constant-token-duplicate": false
+            "name": "magenta-1300"
           }
         }
       },
@@ -1919,8 +1747,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "40d9a0f7-0085-4001-a22e-3c22d3887846",
-            "name": "magenta-1400",
-            "constant-token-duplicate": false
+            "name": "magenta-1400"
           }
         }
       },
@@ -1930,8 +1757,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "70dd220b-46cd-4975-ad8b-5ca31f7c33dc",
-            "name": "magenta-1500",
-            "constant-token-duplicate": false
+            "name": "magenta-1500"
           }
         }
       },
@@ -1941,8 +1767,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fd25d1ee-438b-49a3-93d8-1d59b2a06f72",
-            "name": "magenta-1600",
-            "constant-token-duplicate": false
+            "name": "magenta-1600"
           }
         }
       }
@@ -1954,8 +1779,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e80b112b-a26d-4392-a431-844b33d8bac8",
-            "name": "purple-100",
-            "constant-token-duplicate": false
+            "name": "purple-100"
           }
         }
       },
@@ -1965,8 +1789,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "65816c3d-544e-4bbd-bf0e-c0981e08a5cb",
-            "name": "purple-200",
-            "constant-token-duplicate": false
+            "name": "purple-200"
           }
         }
       },
@@ -1976,8 +1799,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "bea266d7-8f53-43b7-b7df-0daa5b7e6f89",
-            "name": "purple-300",
-            "constant-token-duplicate": false
+            "name": "purple-300"
           }
         }
       },
@@ -1987,8 +1809,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b68c2d3d-02e6-4130-9904-d2d32e67d115",
-            "name": "purple-400",
-            "constant-token-duplicate": false
+            "name": "purple-400"
           }
         }
       },
@@ -1998,8 +1819,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9625edd4-fcdd-406a-9a66-068dcfeb3bd9",
-            "name": "purple-500",
-            "constant-token-duplicate": false
+            "name": "purple-500"
           }
         }
       },
@@ -2009,8 +1829,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "bfd24d4f-9100-4937-a45d-7614ce0ece74",
-            "name": "purple-600",
-            "constant-token-duplicate": false
+            "name": "purple-600"
           }
         }
       },
@@ -2020,8 +1839,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2f218111-4cef-432b-8d69-06492e7c40c1",
-            "name": "purple-700",
-            "constant-token-duplicate": false
+            "name": "purple-700"
           }
         }
       },
@@ -2031,8 +1849,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a6205c53-9e63-475c-85f4-bdd5963e1eb2",
-            "name": "purple-800",
-            "constant-token-duplicate": false
+            "name": "purple-800"
           }
         }
       },
@@ -2042,8 +1859,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b72cb9ff-2b75-487c-914f-1c10bff76f75",
-            "name": "purple-900",
-            "constant-token-duplicate": false
+            "name": "purple-900"
           }
         }
       },
@@ -2053,8 +1869,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "163a3d87-cba9-48de-8384-c2820cf03984",
-            "name": "purple-1000",
-            "constant-token-duplicate": false
+            "name": "purple-1000"
           }
         }
       },
@@ -2064,8 +1879,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "991db22a-d0c2-4f1a-a45b-95aaf13d747d",
-            "name": "purple-1100",
-            "constant-token-duplicate": false
+            "name": "purple-1100"
           }
         }
       },
@@ -2075,8 +1889,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b71041e1-ca59-4d0c-87e4-2a8e8821b3ab",
-            "name": "purple-1200",
-            "constant-token-duplicate": false
+            "name": "purple-1200"
           }
         }
       },
@@ -2086,8 +1899,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7a524851-d57b-40f7-930a-f67739c0e138",
-            "name": "purple-1300",
-            "constant-token-duplicate": false
+            "name": "purple-1300"
           }
         }
       },
@@ -2097,8 +1909,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e1609d80-a6ba-46b6-bd52-83f32fd009ad",
-            "name": "purple-1400",
-            "constant-token-duplicate": false
+            "name": "purple-1400"
           }
         }
       },
@@ -2108,8 +1919,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f43e7a56-8663-41a9-b688-5b6471e3fcff",
-            "name": "purple-1500",
-            "constant-token-duplicate": false
+            "name": "purple-1500"
           }
         }
       },
@@ -2119,8 +1929,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8adc4493-0971-4b9c-bff7-c5ce8100fc43",
-            "name": "purple-1600",
-            "constant-token-duplicate": false
+            "name": "purple-1600"
           }
         }
       }
@@ -2132,8 +1941,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2330ab05-6153-47a1-ab56-18f3cb1c579f",
-            "name": "seafoam-100",
-            "constant-token-duplicate": false
+            "name": "seafoam-100"
           }
         }
       },
@@ -2143,8 +1951,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "870298fd-4e1f-4649-bfbc-5ad5b768c2e3",
-            "name": "seafoam-200",
-            "constant-token-duplicate": false
+            "name": "seafoam-200"
           }
         }
       },
@@ -2154,8 +1961,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1fe5483a-95bd-4597-802a-9e84c1486dbe",
-            "name": "seafoam-300",
-            "constant-token-duplicate": false
+            "name": "seafoam-300"
           }
         }
       },
@@ -2165,8 +1971,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e2b4d354-9a1d-4153-b988-4fc24c117252",
-            "name": "seafoam-400",
-            "constant-token-duplicate": false
+            "name": "seafoam-400"
           }
         }
       },
@@ -2176,8 +1981,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a1da1af7-df37-455d-8d27-2920b36f209f",
-            "name": "seafoam-500",
-            "constant-token-duplicate": false
+            "name": "seafoam-500"
           }
         }
       },
@@ -2187,8 +1991,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "cfd8a8b3-d567-4eb4-9b6f-5db352607dab",
-            "name": "seafoam-600",
-            "constant-token-duplicate": false
+            "name": "seafoam-600"
           }
         }
       },
@@ -2198,8 +2001,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a036b309-95ec-45e6-b035-f30f0f922422",
-            "name": "seafoam-700",
-            "constant-token-duplicate": false
+            "name": "seafoam-700"
           }
         }
       },
@@ -2209,8 +2011,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ac4f12a3-a3f0-4053-87f4-5fc42b08cf23",
-            "name": "seafoam-800",
-            "constant-token-duplicate": false
+            "name": "seafoam-800"
           }
         }
       },
@@ -2220,8 +2021,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "74cb44f8-8ab0-4a36-9920-0735756e0ddc",
-            "name": "seafoam-900",
-            "constant-token-duplicate": false
+            "name": "seafoam-900"
           }
         }
       },
@@ -2231,8 +2031,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "84e4e598-4fd7-445a-a6cf-2884c0aae4d0",
-            "name": "seafoam-1000",
-            "constant-token-duplicate": false
+            "name": "seafoam-1000"
           }
         }
       },
@@ -2242,8 +2041,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d1bb038a-f83b-4e97-b95f-b215c7bc2916",
-            "name": "seafoam-1100",
-            "constant-token-duplicate": false
+            "name": "seafoam-1100"
           }
         }
       },
@@ -2253,8 +2051,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0eab9416-b6f5-4d26-bde6-9b8a840f7681",
-            "name": "seafoam-1200",
-            "constant-token-duplicate": false
+            "name": "seafoam-1200"
           }
         }
       },
@@ -2264,8 +2061,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a88e0c6e-dfd5-4a43-8d43-97fa10101165",
-            "name": "seafoam-1300",
-            "constant-token-duplicate": false
+            "name": "seafoam-1300"
           }
         }
       },
@@ -2275,8 +2071,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "52c9177c-bc81-41b1-ba6d-9b075fbe8541",
-            "name": "seafoam-1400",
-            "constant-token-duplicate": false
+            "name": "seafoam-1400"
           }
         }
       },
@@ -2286,8 +2081,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4cbacecc-89c9-482d-b3f5-7d8f85f0a3f1",
-            "name": "seafoam-1500",
-            "constant-token-duplicate": false
+            "name": "seafoam-1500"
           }
         }
       },
@@ -2297,8 +2091,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ebbfe9f4-5c24-46b2-983a-98570ed5ec78",
-            "name": "seafoam-1600",
-            "constant-token-duplicate": false
+            "name": "seafoam-1600"
           }
         }
       }
@@ -2310,8 +2103,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "910d2e36-245f-4df6-a99c-92a5bb4d4cce",
-            "name": "yellow-100",
-            "constant-token-duplicate": false
+            "name": "yellow-100"
           }
         }
       },
@@ -2321,8 +2113,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0ebcaa53-4d19-4eed-99d1-4477f4358a58",
-            "name": "yellow-200",
-            "constant-token-duplicate": false
+            "name": "yellow-200"
           }
         }
       },
@@ -2332,8 +2123,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "97ea0771-52c6-48f0-8725-dc514b0738d4",
-            "name": "yellow-300",
-            "constant-token-duplicate": false
+            "name": "yellow-300"
           }
         }
       },
@@ -2343,8 +2133,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8ffb47cc-cc5c-4179-807e-4a1cb45c6496",
-            "name": "yellow-400",
-            "constant-token-duplicate": false
+            "name": "yellow-400"
           }
         }
       },
@@ -2354,8 +2143,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "68a43979-6dee-45b9-963d-3e827b2554f4",
-            "name": "yellow-500",
-            "constant-token-duplicate": false
+            "name": "yellow-500"
           }
         }
       },
@@ -2365,8 +2153,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8c86293e-334b-49ed-a7aa-eb4fe987002f",
-            "name": "yellow-600",
-            "constant-token-duplicate": false
+            "name": "yellow-600"
           }
         }
       },
@@ -2376,8 +2163,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "881b7389-0c65-46e6-a391-d1d5800c535c",
-            "name": "yellow-700",
-            "constant-token-duplicate": false
+            "name": "yellow-700"
           }
         }
       },
@@ -2387,8 +2173,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b9ee2410-9573-4acd-bff8-ce11bf0f72a0",
-            "name": "yellow-800",
-            "constant-token-duplicate": false
+            "name": "yellow-800"
           }
         }
       },
@@ -2398,8 +2183,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1b030fd3-f5bc-4e84-8efd-33db77bf64b8",
-            "name": "yellow-900",
-            "constant-token-duplicate": false
+            "name": "yellow-900"
           }
         }
       },
@@ -2409,8 +2193,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a9d84db4-e9db-45a8-9010-4e64822f0408",
-            "name": "yellow-1000",
-            "constant-token-duplicate": false
+            "name": "yellow-1000"
           }
         }
       },
@@ -2420,8 +2203,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b6001568-2f26-4722-85e2-e6a3a8ad0ec8",
-            "name": "yellow-1100",
-            "constant-token-duplicate": false
+            "name": "yellow-1100"
           }
         }
       },
@@ -2431,8 +2213,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7be15b50-51c6-4d0c-9ec8-89b4ac170a5a",
-            "name": "yellow-1200",
-            "constant-token-duplicate": false
+            "name": "yellow-1200"
           }
         }
       },
@@ -2442,8 +2223,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b5808c39-38db-4378-96db-1f6d44ce5172",
-            "name": "yellow-1300",
-            "constant-token-duplicate": false
+            "name": "yellow-1300"
           }
         }
       },
@@ -2453,8 +2233,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "65ad1c10-fb0d-4dd2-a9f5-66ab34dcc86b",
-            "name": "yellow-1400",
-            "constant-token-duplicate": false
+            "name": "yellow-1400"
           }
         }
       },
@@ -2464,8 +2243,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d8eebb60-7b0c-496e-ae04-1f1fc61f3013",
-            "name": "yellow-1500",
-            "constant-token-duplicate": false
+            "name": "yellow-1500"
           }
         }
       },
@@ -2475,8 +2253,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ada313e4-768c-4fd0-b93c-b6f6d2a50f68",
-            "name": "yellow-1600",
-            "constant-token-duplicate": false
+            "name": "yellow-1600"
           }
         }
       }
@@ -2488,8 +2265,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "89d9aa85-aef2-47fa-8939-e6774f5fa2de",
-            "name": "pink-100",
-            "constant-token-duplicate": false
+            "name": "pink-100"
           }
         }
       },
@@ -2499,8 +2275,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d80ed3c8-4db1-48e7-bd16-1d34580a3108",
-            "name": "pink-200",
-            "constant-token-duplicate": false
+            "name": "pink-200"
           }
         }
       },
@@ -2510,8 +2285,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3041a3b2-4275-41fb-94ff-607108d94df3",
-            "name": "pink-300",
-            "constant-token-duplicate": false
+            "name": "pink-300"
           }
         }
       },
@@ -2521,8 +2295,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c86af74f-6fe2-41a1-a934-2589f56fd041",
-            "name": "pink-400",
-            "constant-token-duplicate": false
+            "name": "pink-400"
           }
         }
       },
@@ -2532,8 +2305,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e526f977-736d-473b-b851-475fd08f5276",
-            "name": "pink-500",
-            "constant-token-duplicate": false
+            "name": "pink-500"
           }
         }
       },
@@ -2543,8 +2315,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d383f12e-48f4-446c-abb4-595a50fd29a2",
-            "name": "pink-600",
-            "constant-token-duplicate": false
+            "name": "pink-600"
           }
         }
       },
@@ -2554,8 +2325,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "91406d69-6d53-4231-be9e-e90d8ad0cc51",
-            "name": "pink-700",
-            "constant-token-duplicate": false
+            "name": "pink-700"
           }
         }
       },
@@ -2565,8 +2335,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "af67d2bf-e92e-42f2-93d6-2f0b45fba0ac",
-            "name": "pink-800",
-            "constant-token-duplicate": false
+            "name": "pink-800"
           }
         }
       },
@@ -2576,8 +2345,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a53ae96d-64bc-4baa-b51f-4490242047df",
-            "name": "pink-900",
-            "constant-token-duplicate": false
+            "name": "pink-900"
           }
         }
       },
@@ -2587,8 +2355,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8d8448ee-5b8d-4953-a2f8-ba34a3c7f796",
-            "name": "pink-1000",
-            "constant-token-duplicate": false
+            "name": "pink-1000"
           }
         }
       },
@@ -2598,8 +2365,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "889ea4ff-1362-474e-ab12-15eb08bec89b",
-            "name": "pink-1100",
-            "constant-token-duplicate": false
+            "name": "pink-1100"
           }
         }
       },
@@ -2609,8 +2375,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ac7fa4bb-da89-44ef-95d0-5d15fd8df976",
-            "name": "pink-1200",
-            "constant-token-duplicate": false
+            "name": "pink-1200"
           }
         }
       },
@@ -2620,8 +2385,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a10ffb76-fc1a-4f2f-ac43-dace44726820",
-            "name": "pink-1300",
-            "constant-token-duplicate": false
+            "name": "pink-1300"
           }
         }
       },
@@ -2631,8 +2395,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8c14e640-5df8-4753-8a47-295c1aee63c5",
-            "name": "pink-1400",
-            "constant-token-duplicate": false
+            "name": "pink-1400"
           }
         }
       },
@@ -2642,8 +2405,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "886065e2-949f-4f4c-9aa9-0a843c3d8cf2",
-            "name": "pink-1500",
-            "constant-token-duplicate": false
+            "name": "pink-1500"
           }
         }
       },
@@ -2653,8 +2415,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0612a373-58a7-4393-b789-7dcf8e388b2c",
-            "name": "pink-1600",
-            "constant-token-duplicate": false
+            "name": "pink-1600"
           }
         }
       }
@@ -2666,8 +2427,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8e69d558-2c95-496f-8244-56c1abecef5f",
-            "name": "turquoise-100",
-            "constant-token-duplicate": false
+            "name": "turquoise-100"
           }
         }
       },
@@ -2677,8 +2437,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "2dd6c94d-b55e-491e-91a9-bf9b4e3ceb54",
-            "name": "turquoise-200",
-            "constant-token-duplicate": false
+            "name": "turquoise-200"
           }
         }
       },
@@ -2688,8 +2447,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7eda1d2a-4c4a-495c-8b2f-c663be8c22f8",
-            "name": "turquoise-300",
-            "constant-token-duplicate": false
+            "name": "turquoise-300"
           }
         }
       },
@@ -2699,8 +2457,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7a80623f-07eb-426a-9a64-ced6e3d09df1",
-            "name": "turquoise-400",
-            "constant-token-duplicate": false
+            "name": "turquoise-400"
           }
         }
       },
@@ -2710,8 +2467,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1fae7edd-0b41-4ae6-a436-c1e5ecda3e3a",
-            "name": "turquoise-500",
-            "constant-token-duplicate": false
+            "name": "turquoise-500"
           }
         }
       },
@@ -2721,8 +2477,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "be19fd97-84da-40ed-82a2-1afa75b6f405",
-            "name": "turquoise-600",
-            "constant-token-duplicate": false
+            "name": "turquoise-600"
           }
         }
       },
@@ -2732,8 +2487,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0a313605-1db7-4801-afac-28aeb30aa005",
-            "name": "turquoise-700",
-            "constant-token-duplicate": false
+            "name": "turquoise-700"
           }
         }
       },
@@ -2743,8 +2497,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "cb62cb21-ce76-4f47-a88d-14682eb6e06d",
-            "name": "turquoise-800",
-            "constant-token-duplicate": false
+            "name": "turquoise-800"
           }
         }
       },
@@ -2754,8 +2507,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b1e2b910-c19d-4b83-9f49-f9e858ab58b9",
-            "name": "turquoise-900",
-            "constant-token-duplicate": false
+            "name": "turquoise-900"
           }
         }
       },
@@ -2765,8 +2517,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f46bb42a-00fe-44ae-8421-16fbdbe1a9e3",
-            "name": "turquoise-1000",
-            "constant-token-duplicate": false
+            "name": "turquoise-1000"
           }
         }
       },
@@ -2776,8 +2527,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7c957f48-f033-4814-a4e0-127e67169771",
-            "name": "turquoise-1100",
-            "constant-token-duplicate": false
+            "name": "turquoise-1100"
           }
         }
       },
@@ -2787,8 +2537,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d85163b6-fbaf-4c49-b61b-f0b7b9529ff7",
-            "name": "turquoise-1200",
-            "constant-token-duplicate": false
+            "name": "turquoise-1200"
           }
         }
       },
@@ -2798,8 +2547,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c9ab3575-f393-45db-a92b-07eccd4696bb",
-            "name": "turquoise-1300",
-            "constant-token-duplicate": false
+            "name": "turquoise-1300"
           }
         }
       },
@@ -2809,8 +2557,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6ee374d9-95c4-4e5d-8f4d-fa1912cf6514",
-            "name": "turquoise-1400",
-            "constant-token-duplicate": false
+            "name": "turquoise-1400"
           }
         }
       },
@@ -2820,8 +2567,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d3e919d4-3777-4dca-93f9-0e04ab00d0dd",
-            "name": "turquoise-1500",
-            "constant-token-duplicate": false
+            "name": "turquoise-1500"
           }
         }
       },
@@ -2831,8 +2577,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6af4ec29-d7c5-4562-be2c-a838aa919aed",
-            "name": "turquoise-1600",
-            "constant-token-duplicate": false
+            "name": "turquoise-1600"
           }
         }
       }
@@ -2844,8 +2589,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "aa01448b-bf3b-4da2-b483-127a3ed708f7",
-            "name": "brown-100",
-            "constant-token-duplicate": false
+            "name": "brown-100"
           }
         }
       },
@@ -2855,8 +2599,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1b19a7b6-469e-4f5a-b30b-f3f465021d25",
-            "name": "brown-200",
-            "constant-token-duplicate": false
+            "name": "brown-200"
           }
         }
       },
@@ -2866,8 +2609,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "9f0a77f8-aab8-4942-8119-332b09441939",
-            "name": "brown-300",
-            "constant-token-duplicate": false
+            "name": "brown-300"
           }
         }
       },
@@ -2877,8 +2619,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e33616c5-157c-42aa-a349-90d05f50beba",
-            "name": "brown-400",
-            "constant-token-duplicate": false
+            "name": "brown-400"
           }
         }
       },
@@ -2888,8 +2629,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5346904d-2c85-4dd5-815c-ea2708a4d380",
-            "name": "brown-500",
-            "constant-token-duplicate": false
+            "name": "brown-500"
           }
         }
       },
@@ -2899,8 +2639,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "970fd8ac-c68b-4789-84a6-1397b2514e2f",
-            "name": "brown-600",
-            "constant-token-duplicate": false
+            "name": "brown-600"
           }
         }
       },
@@ -2910,8 +2649,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "621aa30e-95de-4b69-814f-821dfe12b78d",
-            "name": "brown-700",
-            "constant-token-duplicate": false
+            "name": "brown-700"
           }
         }
       },
@@ -2921,8 +2659,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b15bdc92-c03f-4ad4-a385-110d635e66af",
-            "name": "brown-800",
-            "constant-token-duplicate": false
+            "name": "brown-800"
           }
         }
       },
@@ -2932,8 +2669,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b0445ddb-ec22-4dde-81a1-21ea14ed195a",
-            "name": "brown-900",
-            "constant-token-duplicate": false
+            "name": "brown-900"
           }
         }
       },
@@ -2943,8 +2679,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0dd635ef-0b0a-4914-8900-999ab7ce436e",
-            "name": "brown-1000",
-            "constant-token-duplicate": false
+            "name": "brown-1000"
           }
         }
       },
@@ -2954,8 +2689,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d14770ac-d032-4408-b5de-637de47bf151",
-            "name": "brown-1100",
-            "constant-token-duplicate": false
+            "name": "brown-1100"
           }
         }
       },
@@ -2965,8 +2699,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1a2cfeec-1d02-4225-a2a1-ecad878a0372",
-            "name": "brown-1200",
-            "constant-token-duplicate": false
+            "name": "brown-1200"
           }
         }
       },
@@ -2976,8 +2709,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "88621915-f832-4401-b42f-4026cbf6720c",
-            "name": "brown-1300",
-            "constant-token-duplicate": false
+            "name": "brown-1300"
           }
         }
       },
@@ -2987,8 +2719,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fa6e22f6-adb1-4123-b685-dd6050b0a248",
-            "name": "brown-1400",
-            "constant-token-duplicate": false
+            "name": "brown-1400"
           }
         }
       },
@@ -2998,8 +2729,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "ddac3cfe-8338-4df5-94c5-baf4e04e6c46",
-            "name": "brown-1500",
-            "constant-token-duplicate": false
+            "name": "brown-1500"
           }
         }
       },
@@ -3009,8 +2739,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e2753343-f81b-4677-899c-6dfbcc9378fe",
-            "name": "brown-1600",
-            "constant-token-duplicate": false
+            "name": "brown-1600"
           }
         }
       }
@@ -3022,8 +2751,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "27d84774-6d32-4499-8ba9-9d05c8fca55d",
-            "name": "cinnamon-100",
-            "constant-token-duplicate": false
+            "name": "cinnamon-100"
           }
         }
       },
@@ -3033,8 +2761,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a8d1aa1d-f9be-448e-8209-afc6097f38ed",
-            "name": "cinnamon-200",
-            "constant-token-duplicate": false
+            "name": "cinnamon-200"
           }
         }
       },
@@ -3044,8 +2771,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "56c7eeb3-990f-48e3-b024-56d36b0378f5",
-            "name": "cinnamon-300",
-            "constant-token-duplicate": false
+            "name": "cinnamon-300"
           }
         }
       },
@@ -3055,8 +2781,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d4760c87-d0e2-4c5c-84f3-81e0c4c8fbb3",
-            "name": "cinnamon-400",
-            "constant-token-duplicate": false
+            "name": "cinnamon-400"
           }
         }
       },
@@ -3066,8 +2791,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "39effb8c-2bba-4018-b6df-2465f2f7e0a0",
-            "name": "cinnamon-500",
-            "constant-token-duplicate": false
+            "name": "cinnamon-500"
           }
         }
       },
@@ -3077,8 +2801,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7d4de908-322f-4326-b623-a868b454b031",
-            "name": "cinnamon-600",
-            "constant-token-duplicate": false
+            "name": "cinnamon-600"
           }
         }
       },
@@ -3088,8 +2811,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "0601d1ba-9a38-4fc9-ac89-ef332e906f3d",
-            "name": "cinnamon-700",
-            "constant-token-duplicate": false
+            "name": "cinnamon-700"
           }
         }
       },
@@ -3099,8 +2821,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "560d578a-4128-40d5-979f-80d3057294a0",
-            "name": "cinnamon-800",
-            "constant-token-duplicate": false
+            "name": "cinnamon-800"
           }
         }
       },
@@ -3110,8 +2831,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "50199dcc-deae-42ba-99e7-cb98346789eb",
-            "name": "cinnamon-900",
-            "constant-token-duplicate": false
+            "name": "cinnamon-900"
           }
         }
       },
@@ -3121,8 +2841,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b6943b69-7cec-4707-a556-aa350d9d8b89",
-            "name": "cinnamon-1000",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1000"
           }
         }
       },
@@ -3132,8 +2851,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "62edca31-5c84-4353-9707-f3648c8e1936",
-            "name": "cinnamon-1100",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1100"
           }
         }
       },
@@ -3143,8 +2861,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e8b6ac17-268d-4ebc-99bc-480d15554356",
-            "name": "cinnamon-1200",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1200"
           }
         }
       },
@@ -3154,8 +2871,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4330fb2e-d402-43bc-b7a0-502c7f6d99ea",
-            "name": "cinnamon-1300",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1300"
           }
         }
       },
@@ -3165,8 +2881,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "6fe88344-7920-46a6-bbe4-be3cfa20298e",
-            "name": "cinnamon-1400",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1400"
           }
         }
       },
@@ -3176,8 +2891,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fe6e5407-3f9b-4dd0-9589-7029c19f35b5",
-            "name": "cinnamon-1500",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1500"
           }
         }
       },
@@ -3187,8 +2901,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e3727e22-c955-4116-b5a7-2877df6ef2fe",
-            "name": "cinnamon-1600",
-            "constant-token-duplicate": false
+            "name": "cinnamon-1600"
           }
         }
       }
@@ -3200,8 +2913,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "e190b39c-3e1f-4ad7-bc70-0b98c1770f61",
-            "name": "silver-100",
-            "constant-token-duplicate": false
+            "name": "silver-100"
           }
         }
       },
@@ -3211,8 +2923,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f0bae14e-1c9a-4a03-9dbf-dcd3213463c1",
-            "name": "silver-200",
-            "constant-token-duplicate": false
+            "name": "silver-200"
           }
         }
       },
@@ -3222,8 +2933,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "41989dfb-ef46-493d-8b50-d9422b221ee8",
-            "name": "silver-300",
-            "constant-token-duplicate": false
+            "name": "silver-300"
           }
         }
       },
@@ -3233,8 +2943,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "4bdcf062-a1b6-4615-ad8e-747082107f44",
-            "name": "silver-400",
-            "constant-token-duplicate": false
+            "name": "silver-400"
           }
         }
       },
@@ -3244,8 +2953,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1bd72e90-6ec1-4a55-beb2-04ad5afd03d5",
-            "name": "silver-500",
-            "constant-token-duplicate": false
+            "name": "silver-500"
           }
         }
       },
@@ -3255,8 +2963,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1354b7a3-d0b5-4f48-8631-6b4afd7efe4f",
-            "name": "silver-600",
-            "constant-token-duplicate": false
+            "name": "silver-600"
           }
         }
       },
@@ -3266,8 +2973,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "8c7b40e3-239d-4b57-a846-eb5d9f96615d",
-            "name": "silver-700",
-            "constant-token-duplicate": false
+            "name": "silver-700"
           }
         }
       },
@@ -3277,8 +2983,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "bbfb55a6-5bca-424d-8a27-e1e54fff7309",
-            "name": "silver-800",
-            "constant-token-duplicate": false
+            "name": "silver-800"
           }
         }
       },
@@ -3288,8 +2993,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "39cdbda8-3c8c-4977-a90e-3883647d93a6",
-            "name": "silver-900",
-            "constant-token-duplicate": false
+            "name": "silver-900"
           }
         }
       },
@@ -3299,8 +3003,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "943f1415-fc31-4724-8434-9e9cdb51d2b4",
-            "name": "silver-1000",
-            "constant-token-duplicate": false
+            "name": "silver-1000"
           }
         }
       },
@@ -3310,8 +3013,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "28748667-93d7-4752-8c75-419af48b4d1d",
-            "name": "silver-1100",
-            "constant-token-duplicate": false
+            "name": "silver-1100"
           }
         }
       },
@@ -3321,8 +3023,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "f1033f5b-aa7f-4351-9100-43ce546f6a8d",
-            "name": "silver-1200",
-            "constant-token-duplicate": false
+            "name": "silver-1200"
           }
         }
       },
@@ -3332,8 +3033,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "77bcd85e-90f8-47b8-a9a3-ec59cd7ffe14",
-            "name": "silver-1300",
-            "constant-token-duplicate": false
+            "name": "silver-1300"
           }
         }
       },
@@ -3343,8 +3043,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "369bdb1d-bd52-41b4-8512-159cb20c5d64",
-            "name": "silver-1400",
-            "constant-token-duplicate": false
+            "name": "silver-1400"
           }
         }
       },
@@ -3354,8 +3053,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b9b53281-a4f9-4073-8552-d3d4cec25271",
-            "name": "silver-1500",
-            "constant-token-duplicate": false
+            "name": "silver-1500"
           }
         }
       },
@@ -3365,8 +3063,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "fc85bffe-09d4-4fb6-bb7b-5f1053139b97",
-            "name": "silver-1600",
-            "constant-token-duplicate": false
+            "name": "silver-1600"
           }
         }
       }
@@ -3378,8 +3075,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d0867b86-6245-4c02-8617-ea7fd5c80288",
-            "name": "transparent-black-25",
-            "constant-token-duplicate": true
+            "name": "transparent-black-25"
           }
         }
       },
@@ -3389,8 +3085,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d6aa176c-30bd-423f-b05f-4360672bd87e",
-            "name": "transparent-black-50",
-            "constant-token-duplicate": true
+            "name": "transparent-black-50"
           }
         }
       },
@@ -3400,8 +3095,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "d33a66ea-ca60-416f-9e92-967dbbb1e983",
-            "name": "transparent-black-75",
-            "constant-token-duplicate": true
+            "name": "transparent-black-75"
           }
         }
       },
@@ -3411,8 +3105,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "7565eb32-d745-4fc3-8779-a717f8ba910a",
-            "name": "transparent-black-100",
-            "constant-token-duplicate": true
+            "name": "transparent-black-100"
           }
         }
       },
@@ -3422,8 +3115,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a84ecad8-8005-4ce4-add6-7f83f7e05ba0",
-            "name": "transparent-black-200",
-            "constant-token-duplicate": true
+            "name": "transparent-black-200"
           }
         }
       },
@@ -3433,8 +3125,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "16a871e1-d9df-42bb-8889-99059d70e82e",
-            "name": "transparent-black-300",
-            "constant-token-duplicate": true
+            "name": "transparent-black-300"
           }
         }
       },
@@ -3444,8 +3135,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b769453b-586c-4dd2-b3a1-ddf5964160bc",
-            "name": "transparent-black-400",
-            "constant-token-duplicate": true
+            "name": "transparent-black-400"
           }
         }
       },
@@ -3455,8 +3145,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "cebedd9f-9e4b-47cf-addb-45d8ff9c9179",
-            "name": "transparent-black-500",
-            "constant-token-duplicate": true
+            "name": "transparent-black-500"
           }
         }
       },
@@ -3466,8 +3155,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "199e19a5-bf7d-4933-8425-d7d5881e4cf5",
-            "name": "transparent-black-600",
-            "constant-token-duplicate": true
+            "name": "transparent-black-600"
           }
         }
       },
@@ -3477,8 +3165,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "56da822f-98ea-4ad1-b993-3f052de45f36",
-            "name": "transparent-black-700",
-            "constant-token-duplicate": true
+            "name": "transparent-black-700"
           }
         }
       },
@@ -3488,8 +3175,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3e89f180-b0f0-4de0-904b-c80f0210a361",
-            "name": "transparent-black-800",
-            "constant-token-duplicate": true
+            "name": "transparent-black-800"
           }
         }
       },
@@ -3499,8 +3185,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c0a331f9-53e3-4c72-b5e3-139d730a1752",
-            "name": "transparent-black-900",
-            "constant-token-duplicate": true
+            "name": "transparent-black-900"
           }
         }
       },
@@ -3510,8 +3195,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "098f2f56-e52f-47b1-943a-d1d7218de484",
-            "name": "transparent-black-1000",
-            "constant-token-duplicate": true
+            "name": "transparent-black-1000"
           }
         }
       }
@@ -3523,8 +3207,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "98a7279b-e21c-41ae-9bae-8b9b2b243e35",
-            "name": "transparent-white-25",
-            "constant-token-duplicate": true
+            "name": "transparent-white-25"
           }
         }
       },
@@ -3534,8 +3217,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "db1dbf26-fa48-42e1-b724-7953b0a6a543",
-            "name": "transparent-white-50",
-            "constant-token-duplicate": true
+            "name": "transparent-white-50"
           }
         }
       },
@@ -3545,8 +3227,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "28d11d38-570d-4d99-b581-855781b972c5",
-            "name": "transparent-white-75",
-            "constant-token-duplicate": true
+            "name": "transparent-white-75"
           }
         }
       },
@@ -3556,8 +3237,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "a1b64a62-7c78-415e-a9be-c86acbf361ca",
-            "name": "transparent-white-100",
-            "constant-token-duplicate": true
+            "name": "transparent-white-100"
           }
         }
       },
@@ -3567,8 +3247,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "936db837-bc5a-40b0-a0e8-8e39b9fc62cb",
-            "name": "transparent-white-200",
-            "constant-token-duplicate": true
+            "name": "transparent-white-200"
           }
         }
       },
@@ -3578,8 +3257,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "5ffa0283-ce9c-4f96-9227-f559ec54ee0c",
-            "name": "transparent-white-300",
-            "constant-token-duplicate": true
+            "name": "transparent-white-300"
           }
         }
       },
@@ -3589,8 +3267,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "12e610d4-e3dc-4e86-9c09-09d86915b6f1",
-            "name": "transparent-white-400",
-            "constant-token-duplicate": true
+            "name": "transparent-white-400"
           }
         }
       },
@@ -3600,8 +3277,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "89c1380f-3e8e-4895-b025-027cee7ecd5b",
-            "name": "transparent-white-500",
-            "constant-token-duplicate": true
+            "name": "transparent-white-500"
           }
         }
       },
@@ -3611,8 +3287,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b24431ee-5c72-4a73-8733-746c6f5d77c0",
-            "name": "transparent-white-600",
-            "constant-token-duplicate": true
+            "name": "transparent-white-600"
           }
         }
       },
@@ -3622,8 +3297,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "3ecc14ec-a21e-47ba-8225-915509a532af",
-            "name": "transparent-white-700",
-            "constant-token-duplicate": true
+            "name": "transparent-white-700"
           }
         }
       },
@@ -3633,8 +3307,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "b85836bf-af47-412a-900a-4ec5ad0733b2",
-            "name": "transparent-white-800",
-            "constant-token-duplicate": true
+            "name": "transparent-white-800"
           }
         }
       },
@@ -3644,8 +3317,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "c5c823c6-1911-4e0e-ba2f-5105f467e108",
-            "name": "transparent-white-900",
-            "constant-token-duplicate": true
+            "name": "transparent-white-900"
           }
         }
       },
@@ -3655,8 +3327,7 @@
         "$extensions": {
           "spectrum-tokens": {
             "uuid": "1409a50a-9a9d-463d-957f-fa2e4f98a0cd",
-            "name": "transparent-white-1000",
-            "constant-token-duplicate": true
+            "name": "transparent-white-1000"
           }
         }
       }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/icon/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/icon/desktop.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b39b3ce3-6a48-4025-96ef-659b0c9ae9e8",
-        "name": "arrow-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-75"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c22e7427-617d-4f99-bee7-e3fffba07fc2",
-        "name": "arrow-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-100"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "645d5384-e3a8-4d97-acf6-7cbce00e6537",
-        "name": "arrow-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-200"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d0df9084-c6bf-42e5-b830-82906036e397",
-        "name": "arrow-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-300"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4ced8527-31ad-4e48-9491-806ffc57442a",
-        "name": "arrow-icon-size-400",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-400"
       }
     }
   },
@@ -60,8 +55,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "31f09728-964b-4598-99a0-d17bf7256e40",
-        "name": "arrow-icon-size-500",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-500"
       }
     }
   },
@@ -71,8 +65,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5ffece39-b8fc-4a40-a051-0d6c8e253f8f",
-        "name": "arrow-icon-size-600",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-600"
       }
     }
   },
@@ -82,8 +75,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "49ea57ee-7b12-4a8b-a9bb-a11cf2c9d72c",
-        "name": "asterisk-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "asterisk-icon-size-75"
       }
     }
   },
@@ -93,8 +85,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d04b37cc-2c35-49af-9e92-9993264e405a",
-        "name": "asterisk-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "asterisk-icon-size-100"
       }
     }
   },
@@ -104,8 +95,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "49892fb4-a9df-4882-a656-7f9ffb9558bc",
-        "name": "asterisk-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "asterisk-icon-size-200"
       }
     }
   },
@@ -115,8 +105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "93506e7b-f388-4cf8-bd73-e7d96da935d5",
-        "name": "asterisk-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "asterisk-icon-size-300"
       }
     }
   },
@@ -126,8 +115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6335cb3a-6ceb-40e7-b241-ff9b36f1277c",
-        "name": "checkmark-icon-size-50",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-50"
       }
     }
   },
@@ -137,8 +125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0545a68c-f273-4348-84cd-9cd365bdb474",
-        "name": "checkmark-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-75"
       }
     }
   },
@@ -148,8 +135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9227a279-09f4-457a-b5b3-894f0d6a00df",
-        "name": "checkmark-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-100"
       }
     }
   },
@@ -159,8 +145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "342a360b-d58c-4d7a-9a9d-893600b90785",
-        "name": "checkmark-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-200"
       }
     }
   },
@@ -170,8 +155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b5eff9b7-6987-47a1-a673-c47b7e806370",
-        "name": "checkmark-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-300"
       }
     }
   },
@@ -181,8 +165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1a043355-03e6-4322-a462-7d628c23fd06",
-        "name": "checkmark-icon-size-400",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-400"
       }
     }
   },
@@ -192,8 +175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0bf97a2b-5fe6-46ca-8175-8457e8e37d36",
-        "name": "checkmark-icon-size-500",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-500"
       }
     }
   },
@@ -203,8 +185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4bacaeea-2d60-46d2-8c98-288b45a79aaf",
-        "name": "checkmark-icon-size-600",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-600"
       }
     }
   },
@@ -214,8 +195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "785a9152-a69b-4164-a8e2-cc201c1f8063",
-        "name": "chevron-icon-size-50",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-50"
       }
     }
   },
@@ -225,8 +205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "43ef1792-b182-419d-966c-a8a2d77dbe03",
-        "name": "chevron-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-75"
       }
     }
   },
@@ -236,8 +215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fdd4f0b4-3284-4734-b158-ecd5da36d586",
-        "name": "chevron-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-100"
       }
     }
   },
@@ -247,8 +225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2df0f6e0-5821-4f70-9aa9-1cc61f860b53",
-        "name": "chevron-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-200"
       }
     }
   },
@@ -258,8 +235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "087dcfa2-5bfd-47a4-a67c-dca50e086e7a",
-        "name": "chevron-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-300"
       }
     }
   },
@@ -269,8 +245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7fc3ab50-4856-442b-85f7-7f0e5ab3304a",
-        "name": "chevron-icon-size-400",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-400"
       }
     }
   },
@@ -280,8 +255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2891d3c7-1178-4901-9be9-75efada4a9e7",
-        "name": "chevron-icon-size-500",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-500"
       }
     }
   },
@@ -291,8 +265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c1de2d7d-ef83-4a3f-9407-2f512127244f",
-        "name": "chevron-icon-size-600",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-600"
       }
     }
   },
@@ -302,8 +275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "490fac13-d347-4c21-85fa-57814bff7537",
-        "name": "corner-triangle-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "corner-triangle-icon-size-75"
       }
     }
   },
@@ -313,8 +285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6fcfc18c-c5e0-4f50-beab-6c4a10bfdaa7",
-        "name": "corner-triangle-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "corner-triangle-icon-size-100"
       }
     }
   },
@@ -324,8 +295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9c2db47b-f017-432a-a44f-238bc461c4c1",
-        "name": "corner-triangle-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "corner-triangle-icon-size-200"
       }
     }
   },
@@ -335,8 +305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c9c18669-11bf-4ba3-b36f-26115981327c",
-        "name": "corner-triangle-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "corner-triangle-icon-size-300"
       }
     }
   },
@@ -346,8 +315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8e597833-1025-4de4-b34a-2f34201487c3",
-        "name": "cross-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-75"
       }
     }
   },
@@ -357,8 +325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c9fac273-0c5c-46cd-b774-ad566a540511",
-        "name": "cross-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-100"
       }
     }
   },
@@ -368,8 +335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5b416331-7910-4d64-9b5f-43fd1832d3a6",
-        "name": "cross-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-200"
       }
     }
   },
@@ -379,8 +345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f0a65c80-55e8-4ad3-b68c-8429c2fefcf5",
-        "name": "cross-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-300"
       }
     }
   },
@@ -390,8 +355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7e0939f-45ef-4250-8138-2bee9dcb2be4",
-        "name": "cross-icon-size-400",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-400"
       }
     }
   },
@@ -401,8 +365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1228762d-8c89-4e04-a097-5001d805877d",
-        "name": "cross-icon-size-500",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-500"
       }
     }
   },
@@ -412,8 +375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "825c1a0a-e6a3-41dc-81bb-0fb9b74c0ca2",
-        "name": "cross-icon-size-600",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-600"
       }
     }
   },
@@ -423,8 +385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "59e5a3f7-c1d0-4b76-bb7e-2bcddddb83da",
-        "name": "dash-icon-size-50",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-50"
       }
     }
   },
@@ -434,8 +395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bfd0ad6e-6656-46d6-aa9f-0940b2c2902a",
-        "name": "dash-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-75"
       }
     }
   },
@@ -445,8 +405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "67464126-edf0-49db-a07c-8641d4a24cae",
-        "name": "dash-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-100"
       }
     }
   },
@@ -456,8 +415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "220d2f95-067f-4169-bab7-1b4e202bd1a1",
-        "name": "dash-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-200"
       }
     }
   },
@@ -467,8 +425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "84f3da59-4c41-4e4e-925c-5fda4222361d",
-        "name": "dash-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-300"
       }
     }
   },
@@ -478,8 +435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "17540c3a-2f85-4771-a4f8-834c70872abb",
-        "name": "dash-icon-size-400",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-400"
       }
     }
   },
@@ -489,8 +445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "08358bbf-3f8d-48fe-bb48-5dadead4170f",
-        "name": "dash-icon-size-500",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-500"
       }
     }
   },
@@ -500,8 +455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "34316272-7bcd-4b44-af20-07c0e1cb8690",
-        "name": "dash-icon-size-600",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-600"
       }
     }
   },
@@ -511,8 +465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1423caf1-75ca-4ca8-aa6a-22dcf3655b0e",
-        "name": "workflow-icon-size-50",
-        "constant-token-duplicate": false
+        "name": "workflow-icon-size-50"
       }
     }
   },
@@ -522,8 +475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "85cdef34-0682-45eb-ac06-98c76883cdf7",
-        "name": "workflow-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "workflow-icon-size-75"
       }
     }
   },
@@ -533,8 +485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "40abc60f-ab65-41ef-b724-a0f0bdd94d14",
-        "name": "workflow-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "workflow-icon-size-100"
       }
     }
   },
@@ -544,8 +495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6392e605-932e-456d-be53-149b624a04e2",
-        "name": "workflow-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "workflow-icon-size-200"
       }
     }
   },
@@ -555,8 +505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "25908278-79d3-47f4-9b53-adbdd1c13e2a",
-        "name": "workflow-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "workflow-icon-size-300"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/icon/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/icon/mobile.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6ff35aff-8a9f-466c-bdd3-dda460ccaee5",
-        "name": "arrow-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-75"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e9b3eb08-2004-4ad3-bb13-a00a6cb536aa",
-        "name": "arrow-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-100"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c7df43e2-7354-4f53-b453-dc9bf9060e64",
-        "name": "arrow-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-200"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f6116604-efbe-4c6f-b047-29247d632174",
-        "name": "arrow-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-300"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "35f055a9-8a33-42b2-a316-7e2ef0a4b99d",
-        "name": "arrow-icon-size-400",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-400"
       }
     }
   },
@@ -60,8 +55,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dcf16e1a-49ea-4888-85b7-012462a60f40",
-        "name": "arrow-icon-size-500",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-500"
       }
     }
   },
@@ -71,8 +65,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2f5f49e5-9aba-4ea0-a8d9-0f0e4c086b89",
-        "name": "arrow-icon-size-600",
-        "constant-token-duplicate": false
+        "name": "arrow-icon-size-600"
       }
     }
   },
@@ -81,9 +74,8 @@
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "bcba4d11-e15a-4ebc-a152-224ef228036a",
-        "name": "asterisk-icon-size-75",
-        "constant-token-duplicate": false
+        "uuid": "49ea57ee-7b12-4a8b-a9bb-a11cf2c9d72c",
+        "name": "asterisk-icon-size-75"
       }
     }
   },
@@ -93,8 +85,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f6f11ca3-b78b-4207-868f-f834c19e8d3d",
-        "name": "asterisk-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "asterisk-icon-size-100"
       }
     }
   },
@@ -104,8 +95,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3f1b200b-d341-41e4-ae7b-c981ccb492f7",
-        "name": "asterisk-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "asterisk-icon-size-200"
       }
     }
   },
@@ -115,8 +105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a1cdad1f-6537-4c35-a87b-45d8e161ee46",
-        "name": "asterisk-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "asterisk-icon-size-300"
       }
     }
   },
@@ -126,8 +115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ee52f114-1ab6-430b-bd54-62a82bf3600e",
-        "name": "checkmark-icon-size-50",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-50"
       }
     }
   },
@@ -137,8 +125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "99224b4e-751a-49ec-8db4-41c8cc4c7bf5",
-        "name": "checkmark-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-75"
       }
     }
   },
@@ -148,8 +135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "23247915-3cc0-4fdf-b21a-85b97019a219",
-        "name": "checkmark-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-100"
       }
     }
   },
@@ -159,8 +145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d4e3f5ff-91d6-499e-b79e-b1d85c0c597b",
-        "name": "checkmark-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-200"
       }
     }
   },
@@ -170,8 +155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d9b251b2-aa8a-46dc-9a2a-0eb46afea241",
-        "name": "checkmark-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-300"
       }
     }
   },
@@ -181,8 +165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c044459e-12a3-4cdd-9f22-db1d14f34164",
-        "name": "checkmark-icon-size-400",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-400"
       }
     }
   },
@@ -192,8 +175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "29f107aa-b8a8-4a09-bf55-9c903c1005ed",
-        "name": "checkmark-icon-size-500",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-500"
       }
     }
   },
@@ -203,8 +185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b52f4e53-06c2-4746-8063-e2bd99361174",
-        "name": "checkmark-icon-size-600",
-        "constant-token-duplicate": false
+        "name": "checkmark-icon-size-600"
       }
     }
   },
@@ -214,8 +195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6d8ce7eb-a2a2-496c-9ce7-847f4da5fc0c",
-        "name": "chevron-icon-size-50",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-50"
       }
     }
   },
@@ -225,8 +205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "74dbb8c0-2e65-413d-8b52-7215993b5696",
-        "name": "chevron-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-75"
       }
     }
   },
@@ -236,8 +215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c4d6bea8-61b0-45a4-81e0-1e5dd7429463",
-        "name": "chevron-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-100"
       }
     }
   },
@@ -247,8 +225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "08bbd8dd-bb02-43b9-8e25-7709aee5ff52",
-        "name": "chevron-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-200"
       }
     }
   },
@@ -258,8 +235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e6fdcac2-9916-45e2-a479-e87d17ece1f9",
-        "name": "chevron-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-300"
       }
     }
   },
@@ -269,8 +245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ee913eaa-bdaf-44c0-a139-17c5d94b1d4a",
-        "name": "chevron-icon-size-400",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-400"
       }
     }
   },
@@ -280,8 +255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "95400787-7abb-4cad-830b-8a4042831860",
-        "name": "chevron-icon-size-500",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-500"
       }
     }
   },
@@ -291,8 +265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "350b77ab-6440-49c1-9b1c-a31c5c4f2f5f",
-        "name": "chevron-icon-size-600",
-        "constant-token-duplicate": false
+        "name": "chevron-icon-size-600"
       }
     }
   },
@@ -302,8 +275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "434b019c-efde-437a-967b-b841ec95e621",
-        "name": "corner-triangle-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "corner-triangle-icon-size-75"
       }
     }
   },
@@ -313,8 +285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1352ad8f-a8ec-459d-8ae3-71c27038a29d",
-        "name": "corner-triangle-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "corner-triangle-icon-size-100"
       }
     }
   },
@@ -324,8 +295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2be65bca-0f16-4754-bc8a-4a491ba87b90",
-        "name": "corner-triangle-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "corner-triangle-icon-size-200"
       }
     }
   },
@@ -335,8 +305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d396d74a-425d-4f06-837f-349f81ebf486",
-        "name": "corner-triangle-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "corner-triangle-icon-size-300"
       }
     }
   },
@@ -346,8 +315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "622d259d-b52b-409a-bf58-04705d8423f9",
-        "name": "cross-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-75"
       }
     }
   },
@@ -357,8 +325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "11f924ca-5542-4864-b153-77363a32d690",
-        "name": "cross-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-100"
       }
     }
   },
@@ -368,8 +335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "11f65b04-c50d-45bb-86bd-34520aa7db61",
-        "name": "cross-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-200"
       }
     }
   },
@@ -379,8 +345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "37867ac1-4101-4553-98e1-c8a94fdd2d66",
-        "name": "cross-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-300"
       }
     }
   },
@@ -390,8 +355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2fed48b7-dd3d-4c3c-9d5c-3046934f5cfd",
-        "name": "cross-icon-size-400",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-400"
       }
     }
   },
@@ -401,8 +365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a865d5f8-4798-4721-ab76-3b51067d6439",
-        "name": "cross-icon-size-500",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-500"
       }
     }
   },
@@ -412,8 +375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e12ac1ec-08f8-4d8b-8c4b-29b74cafe1a1",
-        "name": "cross-icon-size-600",
-        "constant-token-duplicate": false
+        "name": "cross-icon-size-600"
       }
     }
   },
@@ -423,8 +385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ea331ff6-aa92-4cb4-936a-554a2404152d",
-        "name": "dash-icon-size-50",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-50"
       }
     }
   },
@@ -434,8 +395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1b6d0e50-3ba2-43c9-8b8c-c220364f4434",
-        "name": "dash-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-75"
       }
     }
   },
@@ -445,8 +405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9dc14737-973d-4f6e-8336-2e119c1f1af7",
-        "name": "dash-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-100"
       }
     }
   },
@@ -456,8 +415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "98ebf128-02f1-4d4b-a686-af8713a0f24b",
-        "name": "dash-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-200"
       }
     }
   },
@@ -467,8 +425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ad59353e-3ed1-4e76-af87-020cebfa2664",
-        "name": "dash-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-300"
       }
     }
   },
@@ -478,8 +435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d2c45711-be18-4c85-8b23-f4d4f3d0b492",
-        "name": "dash-icon-size-400",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-400"
       }
     }
   },
@@ -489,8 +445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8d2ad303-095d-4f0c-b0c5-c1ec75b96819",
-        "name": "dash-icon-size-500",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-500"
       }
     }
   },
@@ -500,8 +455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2e81ce48-452d-401f-a44d-10ca427f031e",
-        "name": "dash-icon-size-600",
-        "constant-token-duplicate": false
+        "name": "dash-icon-size-600"
       }
     }
   },
@@ -511,8 +465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4c4cb541-7d42-4bb4-9c86-7197c4600896",
-        "name": "workflow-icon-size-50",
-        "constant-token-duplicate": false
+        "name": "workflow-icon-size-50"
       }
     }
   },
@@ -522,8 +475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b720c214-babe-426d-9629-9ec60d5e8622",
-        "name": "workflow-icon-size-75",
-        "constant-token-duplicate": false
+        "name": "workflow-icon-size-75"
       }
     }
   },
@@ -533,8 +485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9e882a20-b8e1-4e9b-89f9-26f21db3cd78",
-        "name": "workflow-icon-size-100",
-        "constant-token-duplicate": false
+        "name": "workflow-icon-size-100"
       }
     }
   },
@@ -544,8 +495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9948e083-8c75-48f7-8e58-32c75ec76116",
-        "name": "workflow-icon-size-200",
-        "constant-token-duplicate": false
+        "name": "workflow-icon-size-200"
       }
     }
   },
@@ -555,8 +505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "df0dc6c3-59fc-4ee0-87a9-c3d49a07cf9c",
-        "name": "workflow-icon-size-300",
-        "constant-token-duplicate": false
+        "name": "workflow-icon-size-300"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7a576841-a2a5-4443-9d31-03a12c7a2efd",
-        "name": "accordion-bottom-to-text-compact-extra-large",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-compact-extra-large"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "40f76138-1a69-45ed-8df5-db8bc9792383",
-        "name": "accordion-bottom-to-text-compact-large",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-compact-large"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c73f4637-7a33-4598-9498-8eb4a9e9e863",
-        "name": "accordion-bottom-to-text-compact-medium",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-compact-medium"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "524cb169-a9c1-4d3c-864e-dba03df6eac9",
-        "name": "accordion-bottom-to-text-compact-small",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-compact-small"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8c199212-a745-414c-8f6b-22d2445ade3c",
-        "name": "accordion-bottom-to-text-regular-extra-large",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-regular-extra-large"
       }
     }
   },
@@ -60,8 +55,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f484838e-1f0c-4125-9298-beb4ddc0fd53",
-        "name": "accordion-bottom-to-text-regular-large",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-regular-large"
       }
     }
   },
@@ -71,8 +65,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2d6fa243-5f7e-41a8-840b-27a6432f54bc",
-        "name": "accordion-bottom-to-text-regular-medium",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-regular-medium"
       }
     }
   },
@@ -82,8 +75,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d64620dc-dd4a-447a-8491-d9e144ec8828",
-        "name": "accordion-bottom-to-text-regular-small",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-regular-small"
       }
     }
   },
@@ -93,8 +85,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3ca8a65d-5561-4d8e-a4f2-0b653b42991b",
-        "name": "accordion-bottom-to-text-spacious-extra-large",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-spacious-extra-large"
       }
     }
   },
@@ -104,8 +95,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "96acbf76-082b-487c-8c47-f0fa173f54d2",
-        "name": "accordion-bottom-to-text-spacious-large",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-spacious-large"
       }
     }
   },
@@ -115,8 +105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8a3eadad-8b88-4885-b4ca-07360b45d3ba",
-        "name": "accordion-bottom-to-text-spacious-medium",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-spacious-medium"
       }
     }
   },
@@ -126,8 +115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bdc61836-fdcf-4ca0-a277-dd9cb314563a",
-        "name": "accordion-bottom-to-text-spacious-small",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-spacious-small"
       }
     }
   },
@@ -137,8 +125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "87008eae-491c-4f7d-a13b-83eae517c92f",
-        "name": "accordion-content-area-bottom-to-content",
-        "constant-token-duplicate": false
+        "name": "accordion-content-area-bottom-to-content"
       }
     }
   },
@@ -148,8 +135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "709082c2-71b9-423a-9c93-3b53a9e18da3",
-        "name": "accordion-content-area-top-to-content",
-        "constant-token-duplicate": false
+        "name": "accordion-content-area-top-to-content"
       }
     }
   },
@@ -159,8 +145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "27b481a4-0ea9-4e1c-a283-4a799d18d642",
-        "name": "accordion-disclosure-indicator-to-text",
-        "constant-token-duplicate": false
+        "name": "accordion-disclosure-indicator-to-text"
       }
     }
   },
@@ -170,8 +155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "614e6448-c0a4-4ad1-b125-f362e3001a86",
-        "name": "accordion-edge-to-disclosure-indicator",
-        "constant-token-duplicate": false
+        "name": "accordion-edge-to-disclosure-indicator"
       }
     }
   },
@@ -181,8 +165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a9641e89-2c2e-49c3-9662-f530ad23a688",
-        "name": "accordion-edge-to-text",
-        "constant-token-duplicate": false
+        "name": "accordion-edge-to-text"
       }
     }
   },
@@ -192,8 +175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "318c5cda-be1b-416b-b1b7-b962e5f45c0c",
-        "name": "accordion-focus-indicator-gap",
-        "constant-token-duplicate": false
+        "name": "accordion-focus-indicator-gap"
       }
     }
   },
@@ -203,8 +185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "47ae1059-6b16-4823-866d-11be0c0e0e8a",
-        "name": "accordion-minimum-width",
-        "constant-token-duplicate": false
+        "name": "accordion-minimum-width"
       }
     }
   },
@@ -214,8 +195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "229fa20e-6d13-40b0-b19f-5cf6386f81ac",
-        "name": "accordion-small-top-to-text-spacious",
-        "constant-token-duplicate": false
+        "name": "accordion-small-top-to-text-spacious"
       }
     }
   },
@@ -225,8 +205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6e08e002-56bf-421e-b9f8-9d37b1e80e6e",
-        "name": "accordion-top-to-text-compact-extra-large",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-compact-extra-large"
       }
     }
   },
@@ -236,8 +215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a73cc1b0-e31d-4d42-bb89-2e283fe9c59b",
-        "name": "accordion-top-to-text-compact-large",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-compact-large"
       }
     }
   },
@@ -247,8 +225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "484c9603-07f1-4ba6-b1bf-7cfaec5d1594",
-        "name": "accordion-top-to-text-compact-medium",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-compact-medium"
       }
     }
   },
@@ -258,8 +235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d6cc404c-af92-43be-88e3-407fdcb6e068",
-        "name": "accordion-top-to-text-compact-small",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-compact-small"
       }
     }
   },
@@ -269,8 +245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9289aae4-ddaa-4a43-8f00-973dea8350f2",
-        "name": "accordion-top-to-text-regular-extra-large",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-regular-extra-large"
       }
     }
   },
@@ -280,8 +255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2021d787-ddaa-470a-a25d-8a57f67b7359",
-        "name": "accordion-top-to-text-regular-large",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-regular-large"
       }
     }
   },
@@ -291,8 +265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "48db5aeb-6752-4267-89c7-48ed84692ec8",
-        "name": "accordion-top-to-text-regular-medium",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-regular-medium"
       }
     }
   },
@@ -302,8 +275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4f6e49d2-9ab8-4548-aae4-eed45a4003b9",
-        "name": "accordion-top-to-text-regular-small",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-regular-small"
       }
     }
   },
@@ -313,8 +285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5d8877e0-076c-4c9f-b2e9-cdde6942ea61",
-        "name": "accordion-top-to-text-spacious-extra-large",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-spacious-extra-large"
       }
     }
   },
@@ -324,8 +295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8e042372-2504-46f2-8486-4d6174293ea2",
-        "name": "accordion-top-to-text-spacious-large",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-spacious-large"
       }
     }
   },
@@ -335,8 +305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "19c91104-bdf4-4969-8d92-c9cd47d39d13",
-        "name": "accordion-top-to-text-spacious-medium",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-spacious-medium"
       }
     }
   },
@@ -346,8 +315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e67822de-d0cd-4b49-8e90-6c43523bb4dd",
-        "name": "action-bar-height",
-        "constant-token-duplicate": false
+        "name": "action-bar-height"
       }
     }
   },
@@ -357,8 +325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "73f82d09-7927-461c-b7d7-ab0bc6b3e3f9",
-        "name": "action-bar-top-to-item-counter",
-        "constant-token-duplicate": false
+        "name": "action-bar-top-to-item-counter"
       }
     }
   },
@@ -368,8 +335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1c72a1bf-cfcc-4553-91c6-d7bbcf02cc5a",
-        "name": "action-button-edge-to-hold-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "action-button-edge-to-hold-icon-extra-large"
       }
     }
   },
@@ -379,8 +345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b79597cc-5294-4555-ab78-f4200e480ac3",
-        "name": "action-button-edge-to-hold-icon-extra-small",
-        "constant-token-duplicate": false
+        "name": "action-button-edge-to-hold-icon-extra-small"
       }
     }
   },
@@ -390,8 +355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dc65074f-a923-4130-84e5-59fa5d5f4121",
-        "name": "action-button-edge-to-hold-icon-large",
-        "constant-token-duplicate": false
+        "name": "action-button-edge-to-hold-icon-large"
       }
     }
   },
@@ -401,8 +365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5022d77a-9332-4bb8-bd9f-d353eed2caa3",
-        "name": "action-button-edge-to-hold-icon-medium",
-        "constant-token-duplicate": false
+        "name": "action-button-edge-to-hold-icon-medium"
       }
     }
   },
@@ -412,8 +375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fa106863-0e09-44d4-9465-68cd3254ed2b",
-        "name": "action-button-edge-to-hold-icon-small",
-        "constant-token-duplicate": false
+        "name": "action-button-edge-to-hold-icon-small"
       }
     }
   },
@@ -423,8 +385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e19fdd96-44a4-407b-b2b1-01001684fc84",
-        "name": "alert-banner-bottom-to-text",
-        "constant-token-duplicate": false
+        "name": "alert-banner-bottom-to-text"
       }
     }
   },
@@ -434,8 +395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "450405f8-4f08-4151-85dd-730b669a7ed0",
-        "name": "alert-banner-minimum-height",
-        "constant-token-duplicate": false
+        "name": "alert-banner-minimum-height"
       }
     }
   },
@@ -445,8 +405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1d289972-d5ba-41e8-8935-e8c83afb15cf",
-        "name": "alert-banner-top-to-text",
-        "constant-token-duplicate": false
+        "name": "alert-banner-top-to-text"
       }
     }
   },
@@ -456,8 +415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fbe047c4-0346-4b81-bdf6-6565cede7a28",
-        "name": "alert-banner-top-to-workflow-icon",
-        "constant-token-duplicate": false
+        "name": "alert-banner-top-to-workflow-icon"
       }
     }
   },
@@ -467,8 +425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "713e9ae2-e226-45ab-bce9-869533253ee7",
-        "name": "alert-banner-width",
-        "constant-token-duplicate": false
+        "name": "alert-banner-width"
       }
     }
   },
@@ -478,8 +435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9dc42d1a-b87d-4a5d-a5a3-6afd4d5bd599",
-        "name": "alert-dialog-description-size",
-        "constant-token-duplicate": false
+        "name": "alert-dialog-description-size"
       }
     }
   },
@@ -489,8 +445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "45258afa-543b-4fbc-a621-677d8081c2f1",
-        "name": "alert-dialog-maximum-width",
-        "constant-token-duplicate": true
+        "name": "alert-dialog-maximum-width"
       }
     }
   },
@@ -500,8 +455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7d066c2d-ea59-483d-b8a3-6a9b9e35eedd",
-        "name": "alert-dialog-minimum-width",
-        "constant-token-duplicate": true
+        "name": "alert-dialog-minimum-width"
       }
     }
   },
@@ -511,8 +465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9b7ce1fc-ea8a-4d7b-a926-0accbd6b1197",
-        "name": "alert-dialog-title-size",
-        "constant-token-duplicate": false
+        "name": "alert-dialog-title-size"
       }
     }
   },
@@ -522,8 +475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "60fd0b38-3bad-4a0f-8a69-d4cf79b635ff",
-        "name": "avatar-size-50",
-        "constant-token-duplicate": false
+        "name": "avatar-size-50"
       }
     }
   },
@@ -533,8 +485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6aa2d529-0e10-4eaf-8786-f38e04e4d438",
-        "name": "avatar-size-75",
-        "constant-token-duplicate": false
+        "name": "avatar-size-75"
       }
     }
   },
@@ -544,8 +495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f3293ec2-befd-49e8-a280-b5a1827aa40c",
-        "name": "avatar-size-100",
-        "constant-token-duplicate": false
+        "name": "avatar-size-100"
       }
     }
   },
@@ -555,8 +505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a17f3911-00ad-4d52-a474-dc5d4e3341d1",
-        "name": "avatar-size-200",
-        "constant-token-duplicate": false
+        "name": "avatar-size-200"
       }
     }
   },
@@ -566,8 +515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "337f89c8-5b8a-4cd9-a32d-31f2d9804b2e",
-        "name": "avatar-size-300",
-        "constant-token-duplicate": false
+        "name": "avatar-size-300"
       }
     }
   },
@@ -577,8 +525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f7ee2f39-d2ea-44ce-a5e6-e9a2bb8af52e",
-        "name": "avatar-size-400",
-        "constant-token-duplicate": false
+        "name": "avatar-size-400"
       }
     }
   },
@@ -588,8 +535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9088ecf5-e278-48fe-a7cc-bdf77d15772f",
-        "name": "avatar-size-500",
-        "constant-token-duplicate": false
+        "name": "avatar-size-500"
       }
     }
   },
@@ -599,8 +545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "15634a63-05f3-4fb8-989a-cb3ad46b8946",
-        "name": "avatar-size-600",
-        "constant-token-duplicate": false
+        "name": "avatar-size-600"
       }
     }
   },
@@ -610,8 +555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "92260f9e-ad2a-4e46-ad65-d83d99f7e7b7",
-        "name": "avatar-size-700",
-        "constant-token-duplicate": false
+        "name": "avatar-size-700"
       }
     }
   },
@@ -621,8 +565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f0e6a20d-8c2d-4aa3-9060-b6ca66aa7943",
-        "name": "breadcrumbs-bottom-to-text",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-bottom-to-text"
       }
     }
   },
@@ -632,8 +575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "70a356be-c304-4bb4-a9df-97806931f089",
-        "name": "breadcrumbs-bottom-to-text-compact",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-bottom-to-text-compact"
       }
     }
   },
@@ -643,8 +585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5a78f5a4-ceee-4854-96d4-b61d76cc522b",
-        "name": "breadcrumbs-bottom-to-text-multiline",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-bottom-to-text-multiline"
       }
     }
   },
@@ -654,8 +595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "99ef1a0d-5fe1-4b62-9609-8929e7a3bf9c",
-        "name": "breadcrumbs-end-edge-to-text",
-        "constant-token-duplicate": true
+        "name": "breadcrumbs-end-edge-to-text"
       }
     }
   },
@@ -665,8 +605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2d39863c-6987-413c-90d8-07fcc506a0d4",
-        "name": "breadcrumbs-height",
-        "constant-token-duplicate": true
+        "name": "breadcrumbs-height"
       }
     }
   },
@@ -676,8 +615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8393f599-37e8-484a-a1c6-0934ce15a507",
-        "name": "breadcrumbs-height-compact",
-        "constant-token-duplicate": true
+        "name": "breadcrumbs-height-compact"
       }
     }
   },
@@ -687,8 +625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "237ff958-a86d-4632-aa7d-504a697509c3",
-        "name": "breadcrumbs-height-multiline",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-height-multiline"
       }
     }
   },
@@ -698,8 +635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "56dd2fd0-c7a3-4f2c-bda9-8e6ba6d99e6c",
-        "name": "breadcrumbs-separator-icon-to-bottom-text-multiline",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-separator-icon-to-bottom-text-multiline"
       }
     }
   },
@@ -709,8 +645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a0542dab-98fb-45d8-b4a0-79cfd2cc4f1c",
-        "name": "breadcrumbs-start-edge-to-text",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-start-edge-to-text"
       }
     }
   },
@@ -720,8 +655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b1fba444-c281-4be4-bded-4852b551cfee",
-        "name": "breadcrumbs-start-edge-to-truncated-menu",
-        "constant-token-duplicate": true
+        "name": "breadcrumbs-start-edge-to-truncated-menu"
       }
     }
   },
@@ -731,8 +665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3a89734d-4fcc-43cf-9b77-b2f6d3732391",
-        "name": "breadcrumbs-top-text-to-bottom-text",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-text-to-bottom-text"
       }
     }
   },
@@ -742,8 +675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "15e56281-5fc1-4b59-b815-fc333231e364",
-        "name": "breadcrumbs-top-to-separator-icon",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-separator-icon"
       }
     }
   },
@@ -753,8 +685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a63e8df1-124f-4f3e-9e1b-ba422b8d8257",
-        "name": "breadcrumbs-top-to-separator-icon-compact",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-separator-icon-compact"
       }
     }
   },
@@ -764,8 +695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6b310160-ab2e-40fd-9216-21ddcb36b575",
-        "name": "breadcrumbs-top-to-separator-icon-multiline",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-separator-icon-multiline"
       }
     }
   },
@@ -775,8 +705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d084038e-bc31-43be-99ee-13cf727eaf9d",
-        "name": "breadcrumbs-top-to-text",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-text"
       }
     }
   },
@@ -786,8 +715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b19547e2-bd8f-435d-b726-4f2ce6a83984",
-        "name": "breadcrumbs-top-to-text-compact",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-text-compact"
       }
     }
   },
@@ -797,8 +725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "138070fe-1f06-48b4-ac49-f8ff117c5f42",
-        "name": "breadcrumbs-top-to-text-multiline",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-text-multiline"
       }
     }
   },
@@ -808,8 +735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "751734bd-1c58-4222-bbd8-8b2349f2fbd2",
-        "name": "breadcrumbs-top-to-truncated-menu",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-truncated-menu"
       }
     }
   },
@@ -819,8 +745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e0aba287-799f-4621-97cb-563352002a20",
-        "name": "breadcrumbs-top-to-truncated-menu-compact",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-truncated-menu-compact"
       }
     }
   },
@@ -830,8 +755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2285d870-68ec-469f-a034-2fdeb31e33f0",
-        "name": "breadcrumbs-truncated-menu-to-bottom-text",
-        "constant-token-duplicate": true
+        "name": "breadcrumbs-truncated-menu-to-bottom-text"
       }
     }
   },
@@ -841,8 +765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1fe2a3df-3179-4c4a-8d1f-de41297b6d74",
-        "name": "breadcrumbs-truncated-menu-to-separator-icon",
-        "constant-token-duplicate": true
+        "name": "breadcrumbs-truncated-menu-to-separator-icon"
       }
     }
   },
@@ -852,8 +775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "68b6ac88-d229-460d-8d59-3f5c141db358",
-        "name": "button-minimum-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "button-minimum-width-multiplier"
       }
     }
   },
@@ -863,8 +785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "55db9f3d-621d-4d23-b3d0-c0f2b0f3f9b0",
-        "name": "card-minimum-width",
-        "constant-token-duplicate": true
+        "name": "card-minimum-width"
       }
     }
   },
@@ -874,8 +795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "58eb5be8-644f-448e-99b9-94d1fbb93240",
-        "name": "card-preview-minimum-height",
-        "constant-token-duplicate": true
+        "name": "card-preview-minimum-height"
       }
     }
   },
@@ -885,8 +805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "496fd060-70a9-48d0-948f-593b81847199",
-        "name": "card-selection-background-size",
-        "constant-token-duplicate": true
+        "name": "card-selection-background-size"
       }
     }
   },
@@ -896,8 +815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4ba47ba1-c9bd-447e-8948-009d5b424e0d",
-        "name": "checkbox-control-size-extra-large",
-        "constant-token-duplicate": false
+        "name": "checkbox-control-size-extra-large"
       }
     }
   },
@@ -907,8 +825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "839a52bc-b9ee-473f-acde-0799b4f55ded",
-        "name": "checkbox-control-size-large",
-        "constant-token-duplicate": false
+        "name": "checkbox-control-size-large"
       }
     }
   },
@@ -918,8 +835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "86288454-7192-4e4c-b55f-fc509fc58c01",
-        "name": "checkbox-control-size-medium",
-        "constant-token-duplicate": false
+        "name": "checkbox-control-size-medium"
       }
     }
   },
@@ -929,8 +845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "460e8170-de69-4f8e-8420-6c87a1f6f5cd",
-        "name": "checkbox-control-size-small",
-        "constant-token-duplicate": false
+        "name": "checkbox-control-size-small"
       }
     }
   },
@@ -940,8 +855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3c4217bb-91f2-4347-9f65-a0528992f600",
-        "name": "checkbox-top-to-control-extra-large",
-        "constant-token-duplicate": false
+        "name": "checkbox-top-to-control-extra-large"
       }
     }
   },
@@ -951,8 +865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "93edae08-5320-4e7e-a006-a9af1d3665ad",
-        "name": "checkbox-top-to-control-large",
-        "constant-token-duplicate": false
+        "name": "checkbox-top-to-control-large"
       }
     }
   },
@@ -962,8 +875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dcde5d2d-60f8-4d56-bfb1-bba44a087515",
-        "name": "checkbox-top-to-control-medium",
-        "constant-token-duplicate": false
+        "name": "checkbox-top-to-control-medium"
       }
     }
   },
@@ -973,8 +885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "20518175-5bc7-4659-8007-e74339c39433",
-        "name": "checkbox-top-to-control-small",
-        "constant-token-duplicate": false
+        "name": "checkbox-top-to-control-small"
       }
     }
   },
@@ -984,8 +895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "eba9f466-deda-48d5-a120-14419d5a670f",
-        "name": "coach-mark-body-size",
-        "constant-token-duplicate": false
+        "name": "coach-mark-body-size"
       }
     }
   },
@@ -995,8 +905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d5a3e2c7-f717-4436-91a3-3ab34aebd48e",
-        "name": "coach-mark-edge-to-content",
-        "constant-token-duplicate": false
+        "name": "coach-mark-edge-to-content"
       }
     }
   },
@@ -1006,8 +915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "07cdeb95-d368-4ed1-ba29-6b9ddeae1396",
-        "name": "coach-mark-maximum-width",
-        "constant-token-duplicate": false
+        "name": "coach-mark-maximum-width"
       }
     }
   },
@@ -1017,8 +925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f6381a33-ac4e-4ff9-86a3-183c857772ad",
-        "name": "coach-mark-media-height",
-        "constant-token-duplicate": false
+        "name": "coach-mark-media-height"
       }
     }
   },
@@ -1028,8 +935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e62c5a76-685c-4b48-98bb-746d6dd4b10e",
-        "name": "coach-mark-media-minimum-height",
-        "constant-token-duplicate": false
+        "name": "coach-mark-media-minimum-height"
       }
     }
   },
@@ -1039,8 +945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9f413341-5ed5-4cd0-8348-1c7141dcab8d",
-        "name": "coach-mark-minimum-width",
-        "constant-token-duplicate": false
+        "name": "coach-mark-minimum-width"
       }
     }
   },
@@ -1050,8 +955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "df8bc8ae-b6fa-4414-93b7-c89d8097fe11",
-        "name": "coach-mark-pagination-body-size",
-        "constant-token-duplicate": false
+        "name": "coach-mark-pagination-body-size"
       }
     }
   },
@@ -1061,8 +965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d2ff2d4f-058e-412b-9e16-1725d6d29e25",
-        "name": "coach-mark-pagination-text-to-bottom-edge",
-        "constant-token-duplicate": false
+        "name": "coach-mark-pagination-text-to-bottom-edge"
       }
     }
   },
@@ -1072,8 +975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "331604db-3f28-472e-810d-9010ed2c8e33",
-        "name": "coach-mark-title-size",
-        "constant-token-duplicate": false
+        "name": "coach-mark-title-size"
       }
     }
   },
@@ -1083,8 +985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "49d1e2be-3aa2-4515-ba54-7f6cf3ab007c",
-        "name": "coach-mark-width",
-        "constant-token-duplicate": false
+        "name": "coach-mark-width"
       }
     }
   },
@@ -1094,8 +995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ab656bf4-8814-42fa-9036-b1e67159e4e1",
-        "name": "color-area-border-rounding",
-        "constant-token-duplicate": true
+        "name": "color-area-border-rounding"
       }
     }
   },
@@ -1105,8 +1005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "78fff16d-d6fe-4a74-98bc-97c56e352250",
-        "name": "color-area-border-width",
-        "constant-token-duplicate": true
+        "name": "color-area-border-width"
       }
     }
   },
@@ -1116,8 +1015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "993f90f6-22a6-49ec-a8e6-7a8b904d42a7",
-        "name": "color-area-height",
-        "constant-token-duplicate": false
+        "name": "color-area-height"
       }
     }
   },
@@ -1127,8 +1025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "73c558f3-2a1c-4c1d-9b17-cfb49f510070",
-        "name": "color-area-minimum-height",
-        "constant-token-duplicate": false
+        "name": "color-area-minimum-height"
       }
     }
   },
@@ -1138,8 +1035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "19ff1ba5-a351-4427-bf2e-4e212dde3d3c",
-        "name": "color-area-minimum-width",
-        "constant-token-duplicate": false
+        "name": "color-area-minimum-width"
       }
     }
   },
@@ -1149,8 +1045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8fcf30ee-73e1-4f54-8975-5467dedade29",
-        "name": "color-area-width",
-        "constant-token-duplicate": false
+        "name": "color-area-width"
       }
     }
   },
@@ -1160,8 +1055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8ec9adae-0093-42f4-bd1b-6f3b2279996b",
-        "name": "color-handle-border-width",
-        "constant-token-duplicate": true
+        "name": "color-handle-border-width"
       }
     }
   },
@@ -1171,8 +1065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "29e4a8c8-33ba-44b3-952d-26f3fd6ae4f0",
-        "name": "color-handle-drop-shadow-blur",
-        "constant-token-duplicate": true
+        "name": "color-handle-drop-shadow-blur"
       }
     }
   },
@@ -1182,8 +1075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "49499527-3fdb-4a91-a832-0ae0631ba3bb",
-        "name": "color-handle-drop-shadow-x",
-        "constant-token-duplicate": true
+        "name": "color-handle-drop-shadow-x"
       }
     }
   },
@@ -1193,8 +1085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "05b11927-d0cd-46a6-ae30-6f268f143d4e",
-        "name": "color-handle-drop-shadow-y",
-        "constant-token-duplicate": true
+        "name": "color-handle-drop-shadow-y"
       }
     }
   },
@@ -1204,8 +1095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "945e0167-6893-49dd-ab21-886f93f70b92",
-        "name": "color-handle-inner-border-width",
-        "constant-token-duplicate": true
+        "name": "color-handle-inner-border-width"
       }
     }
   },
@@ -1215,8 +1105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fbf27473-7c97-4d94-968d-c3e68e0cd242",
-        "name": "color-handle-outer-border-width",
-        "constant-token-duplicate": true
+        "name": "color-handle-outer-border-width"
       }
     }
   },
@@ -1226,8 +1115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7c7fd224-a9d5-4d97-b3de-fd9e4e076444",
-        "name": "color-handle-size",
-        "constant-token-duplicate": false
+        "name": "color-handle-size"
       }
     }
   },
@@ -1237,8 +1125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "de9cc5ca-81cf-4bde-bd21-be2402e460c5",
-        "name": "color-handle-size-key-focus",
-        "constant-token-duplicate": false
+        "name": "color-handle-size-key-focus"
       }
     }
   },
@@ -1248,8 +1135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "92beba60-f61d-426a-a864-203dca7244a0",
-        "name": "color-loupe-bottom-to-color-handle",
-        "constant-token-duplicate": true
+        "name": "color-loupe-bottom-to-color-handle"
       }
     }
   },
@@ -1259,8 +1145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "86caa027-9e9e-4a5f-aa38-058f0a96bc9d",
-        "name": "color-loupe-drop-shadow-blur",
-        "constant-token-duplicate": true
+        "name": "color-loupe-drop-shadow-blur"
       }
     }
   },
@@ -1270,8 +1155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c9af5d60-11b1-4fc3-972e-6a607120657b",
-        "name": "color-loupe-drop-shadow-y",
-        "constant-token-duplicate": true
+        "name": "color-loupe-drop-shadow-y"
       }
     }
   },
@@ -1281,8 +1165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0f7e8b9e-99e5-4f5a-ae80-99f65f4c4e51",
-        "name": "color-loupe-height",
-        "constant-token-duplicate": true
+        "name": "color-loupe-height"
       }
     }
   },
@@ -1292,8 +1175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b3900f89-0a7a-4c47-a6d9-ca8aa19b9bfb",
-        "name": "color-loupe-inner-border-width",
-        "constant-token-duplicate": true
+        "name": "color-loupe-inner-border-width"
       }
     }
   },
@@ -1303,8 +1185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "51cd5039-1319-451a-b13f-bb3a218238a5",
-        "name": "color-loupe-outer-border-width",
-        "constant-token-duplicate": true
+        "name": "color-loupe-outer-border-width"
       }
     }
   },
@@ -1314,8 +1195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "889e2495-b882-4aa3-8a5b-1a71d44edde4",
-        "name": "color-loupe-width",
-        "constant-token-duplicate": true
+        "name": "color-loupe-width"
       }
     }
   },
@@ -1325,8 +1205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "991541a2-df44-4f32-90a5-de698adf5db3",
-        "name": "color-slider-border-rounding",
-        "constant-token-duplicate": true
+        "name": "color-slider-border-rounding"
       }
     }
   },
@@ -1336,8 +1215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2b907cad-7534-411b-b3bf-ab89a3712ad8",
-        "name": "color-slider-border-width",
-        "constant-token-duplicate": true
+        "name": "color-slider-border-width"
       }
     }
   },
@@ -1347,8 +1225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "11442823-3e61-425a-a24b-a4a0747a06c4",
-        "name": "color-slider-length",
-        "constant-token-duplicate": false
+        "name": "color-slider-length"
       }
     }
   },
@@ -1358,8 +1235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "54aad7a1-df6a-414a-82b4-7976c912a8e5",
-        "name": "color-slider-minimum-length",
-        "constant-token-duplicate": false
+        "name": "color-slider-minimum-length"
       }
     }
   },
@@ -1369,8 +1245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4b6bca16-ea29-4d6c-81cf-9005b9a3b5e5",
-        "name": "color-wheel-color-area-margin",
-        "constant-token-duplicate": true
+        "name": "color-wheel-color-area-margin"
       }
     }
   },
@@ -1380,8 +1255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "647244c3-b071-45c1-94f7-3be32cfebabe",
-        "name": "color-wheel-minimum-width",
-        "constant-token-duplicate": false
+        "name": "color-wheel-minimum-width"
       }
     }
   },
@@ -1391,8 +1265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d4cdb77e-54b8-4bcf-97b1-992287af2690",
-        "name": "color-wheel-width",
-        "constant-token-duplicate": false
+        "name": "color-wheel-width"
       }
     }
   },
@@ -1402,8 +1275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "eabcc77a-f263-43ed-9944-9daa78a56b66",
-        "name": "combo-box-minimum-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "combo-box-minimum-width-multiplier"
       }
     }
   },
@@ -1413,8 +1285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4798728b-9a97-4ce1-b703-0182b1513e8b",
-        "name": "combo-box-quiet-minimum-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "combo-box-quiet-minimum-width-multiplier"
       }
     }
   },
@@ -1424,8 +1295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4a4ee415-1f25-4d36-928c-5ece0ce4abcc",
-        "name": "combo-box-visual-to-field-button-extra-large",
-        "constant-token-duplicate": false
+        "name": "combo-box-visual-to-field-button-extra-large"
       }
     }
   },
@@ -1435,8 +1305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "356c4912-69c7-4a95-956b-c1aa78cb02cb",
-        "name": "combo-box-visual-to-field-button-large",
-        "constant-token-duplicate": false
+        "name": "combo-box-visual-to-field-button-large"
       }
     }
   },
@@ -1446,8 +1315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c5a4baf2-effe-4d9a-92f3-b4ead5440d36",
-        "name": "combo-box-visual-to-field-button-medium",
-        "constant-token-duplicate": false
+        "name": "combo-box-visual-to-field-button-medium"
       }
     }
   },
@@ -1457,8 +1325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "292cbbe1-1ba4-4369-9768-2051c07e6406",
-        "name": "combo-box-visual-to-field-button-quiet",
-        "constant-token-duplicate": true
+        "name": "combo-box-visual-to-field-button-quiet"
       }
     }
   },
@@ -1468,8 +1335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5d054a3e-e4bb-4ca3-b84a-51b3d7fa2cb8",
-        "name": "combo-box-visual-to-field-button-small",
-        "constant-token-duplicate": false
+        "name": "combo-box-visual-to-field-button-small"
       }
     }
   },
@@ -1479,8 +1345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e458fa68-ab9c-4441-a7d5-a02f42df1cae",
-        "name": "contextual-help-body-size",
-        "constant-token-duplicate": false
+        "name": "contextual-help-body-size"
       }
     }
   },
@@ -1490,8 +1355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "83be73fe-50bc-4be8-969c-0361a816225b",
-        "name": "contextual-help-minimum-width",
-        "constant-token-duplicate": true
+        "name": "contextual-help-minimum-width"
       }
     }
   },
@@ -1501,8 +1365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5358fd6c-d9a0-4caa-a85e-af82ed82efaf",
-        "name": "contextual-help-title-size",
-        "constant-token-duplicate": false
+        "name": "contextual-help-title-size"
       }
     }
   },
@@ -1512,8 +1375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "913cce2a-c928-4803-9bd6-3fb1e0fcbee5",
-        "name": "divider-thickness-large",
-        "constant-token-duplicate": true
+        "name": "divider-thickness-large"
       }
     }
   },
@@ -1523,8 +1385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3cf3e962-92f3-4334-8b92-9a1da9396c25",
-        "name": "divider-thickness-medium",
-        "constant-token-duplicate": true
+        "name": "divider-thickness-medium"
       }
     }
   },
@@ -1534,8 +1395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9dcc27ef-7044-4051-97f3-2fd64a5d0a36",
-        "name": "divider-thickness-small",
-        "constant-token-duplicate": true
+        "name": "divider-thickness-small"
       }
     }
   },
@@ -1545,8 +1405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bb3fee51-24cc-4643-9f22-fa1592ab2457",
-        "name": "drop-zone-body-size",
-        "constant-token-duplicate": true
+        "name": "drop-zone-body-size"
       }
     }
   },
@@ -1556,8 +1415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "47c15433-53d3-425b-8b87-ea234701f781",
-        "name": "drop-zone-border-dash-gap",
-        "constant-token-duplicate": true
+        "name": "drop-zone-border-dash-gap"
       }
     }
   },
@@ -1567,8 +1425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a596af57-256f-4445-b91f-36e47bfb2d95",
-        "name": "drop-zone-border-dash-length",
-        "constant-token-duplicate": true
+        "name": "drop-zone-border-dash-length"
       }
     }
   },
@@ -1578,8 +1435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "013387e8-8925-4bb4-a8ee-94420141fde9",
-        "name": "drop-zone-cjk-title-size",
-        "constant-token-duplicate": true
+        "name": "drop-zone-cjk-title-size"
       }
     }
   },
@@ -1589,8 +1445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b8d0db71-9a25-46fc-b77a-037fcf86be8e",
-        "name": "drop-zone-content-maximum-width",
-        "constant-token-duplicate": true
+        "name": "drop-zone-content-maximum-width"
       }
     }
   },
@@ -1600,8 +1455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "edc68bfe-7ad3-4a12-81fa-ded8fb6fc2e3",
-        "name": "drop-zone-title-size",
-        "constant-token-duplicate": true
+        "name": "drop-zone-title-size"
       }
     }
   },
@@ -1611,8 +1465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2097b13e-94b3-4a06-a0af-c7d8420d1273",
-        "name": "drop-zone-width",
-        "constant-token-duplicate": true
+        "name": "drop-zone-width"
       }
     }
   },
@@ -1622,8 +1475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4140e899-8a28-4627-a91a-e6526da1bdf5",
-        "name": "field-label-text-to-asterisk-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-label-text-to-asterisk-extra-large"
       }
     }
   },
@@ -1633,8 +1485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "997c475e-6ae5-469f-9c8e-9fedafa2b556",
-        "name": "field-label-text-to-asterisk-large",
-        "constant-token-duplicate": false
+        "name": "field-label-text-to-asterisk-large"
       }
     }
   },
@@ -1644,8 +1495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7be280dc-43dc-48c3-bf0c-b53f95e76516",
-        "name": "field-label-text-to-asterisk-medium",
-        "constant-token-duplicate": false
+        "name": "field-label-text-to-asterisk-medium"
       }
     }
   },
@@ -1655,8 +1505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4796831f-4d3e-472c-bad8-699d4eb443ea",
-        "name": "field-label-text-to-asterisk-small",
-        "constant-token-duplicate": false
+        "name": "field-label-text-to-asterisk-small"
       }
     }
   },
@@ -1666,8 +1515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4738ec46-a43c-48f9-aeca-87863275dc4d",
-        "name": "field-label-to-component",
-        "constant-token-duplicate": true
+        "name": "field-label-to-component"
       }
     }
   },
@@ -1677,8 +1525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d6c750dc-3117-4c1a-96bf-b94d530e912d",
-        "name": "field-label-to-component-quiet-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-label-to-component-quiet-extra-large"
       }
     }
   },
@@ -1688,8 +1535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "be80f1b1-4c08-479f-a39e-28b6a64714f2",
-        "name": "field-label-to-component-quiet-large",
-        "constant-token-duplicate": false
+        "name": "field-label-to-component-quiet-large"
       }
     }
   },
@@ -1699,8 +1545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dc00948e-3c0f-4c6b-8e3e-a7fbf396e059",
-        "name": "field-label-to-component-quiet-medium",
-        "constant-token-duplicate": false
+        "name": "field-label-to-component-quiet-medium"
       }
     }
   },
@@ -1710,8 +1555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1218beeb-1d74-4e1a-b495-38d5f07afb55",
-        "name": "field-label-to-component-quiet-small",
-        "constant-token-duplicate": false
+        "name": "field-label-to-component-quiet-small"
       }
     }
   },
@@ -1721,8 +1565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5c14d528-fe17-4b0b-a123-edbdb93fd173",
-        "name": "field-label-top-margin-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-label-top-margin-extra-large"
       }
     }
   },
@@ -1732,8 +1575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f7dd90d8-91e6-4090-a5a9-6b30087860a4",
-        "name": "field-label-top-margin-large",
-        "constant-token-duplicate": false
+        "name": "field-label-top-margin-large"
       }
     }
   },
@@ -1743,8 +1585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b5243f56-7985-4686-b41f-9b9b9a18b047",
-        "name": "field-label-top-margin-medium",
-        "constant-token-duplicate": false
+        "name": "field-label-top-margin-medium"
       }
     }
   },
@@ -1754,8 +1595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ab718f97-15c3-4b8b-aee7-b50b09ec0a33",
-        "name": "field-label-top-margin-small",
-        "constant-token-duplicate": false
+        "name": "field-label-top-margin-small"
       }
     }
   },
@@ -1765,8 +1605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e53ea4a5-bde5-4695-9ab8-50c2ce704019",
-        "name": "field-label-top-to-asterisk-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-label-top-to-asterisk-extra-large"
       }
     }
   },
@@ -1776,8 +1615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "60caa810-5335-4c9f-95a7-0e60d49f43fc",
-        "name": "field-label-top-to-asterisk-large",
-        "constant-token-duplicate": false
+        "name": "field-label-top-to-asterisk-large"
       }
     }
   },
@@ -1787,8 +1625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "eb2b857d-9482-42fb-82f9-bbe7899a22b9",
-        "name": "field-label-top-to-asterisk-medium",
-        "constant-token-duplicate": false
+        "name": "field-label-top-to-asterisk-medium"
       }
     }
   },
@@ -1798,8 +1635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7122627b-1906-424d-9cbf-261546ff3774",
-        "name": "field-label-top-to-asterisk-small",
-        "constant-token-duplicate": false
+        "name": "field-label-top-to-asterisk-small"
       }
     }
   },
@@ -1809,8 +1645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "82e8cf04-7eda-4f36-8d2c-fda63241c3de",
-        "name": "floating-action-button-drop-shadow-blur",
-        "constant-token-duplicate": true
+        "name": "floating-action-button-drop-shadow-blur"
       }
     }
   },
@@ -1820,8 +1655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a4ddc1a6-1367-4153-bb7c-c217d16d10f4",
-        "name": "floating-action-button-drop-shadow-y",
-        "constant-token-duplicate": true
+        "name": "floating-action-button-drop-shadow-y"
       }
     }
   },
@@ -1831,8 +1665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f99eb317-ebe5-43e7-8066-982fe7a9a8aa",
-        "name": "help-text-to-component",
-        "constant-token-duplicate": true
+        "name": "help-text-to-component"
       }
     }
   },
@@ -1842,8 +1675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bec914a9-5905-40ac-bd61-a727016c1228",
-        "name": "help-text-top-to-workflow-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "help-text-top-to-workflow-icon-extra-large"
       }
     }
   },
@@ -1853,8 +1685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "54cae12b-5f21-47b4-a964-6033bd025975",
-        "name": "help-text-top-to-workflow-icon-large",
-        "constant-token-duplicate": false
+        "name": "help-text-top-to-workflow-icon-large"
       }
     }
   },
@@ -1864,8 +1695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d159b313-4def-493a-adcf-398e2d1fce9f",
-        "name": "help-text-top-to-workflow-icon-medium",
-        "constant-token-duplicate": false
+        "name": "help-text-top-to-workflow-icon-medium"
       }
     }
   },
@@ -1875,8 +1705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "91cb19ef-63fc-4d98-a61e-a5f55951f656",
-        "name": "help-text-top-to-workflow-icon-small",
-        "constant-token-duplicate": false
+        "name": "help-text-top-to-workflow-icon-small"
       }
     }
   },
@@ -1886,8 +1715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4140710f-ae31-4ae3-b8b6-2d3eb6a1ae78",
-        "name": "illustrated-message-body-size",
-        "constant-token-duplicate": false
+        "name": "illustrated-message-body-size"
       }
     }
   },
@@ -1897,8 +1725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e77279df-bc62-441a-8a30-5faa41d0df10",
-        "name": "illustrated-message-cjk-title-size",
-        "constant-token-duplicate": false
+        "name": "illustrated-message-cjk-title-size"
       }
     }
   },
@@ -1908,8 +1735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0e464925-5524-4fcc-a2f1-54ef42a2990a",
-        "name": "illustrated-message-maximum-width",
-        "constant-token-duplicate": true
+        "name": "illustrated-message-maximum-width"
       }
     }
   },
@@ -1919,8 +1745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "365ec548-431b-4e1e-9f9d-7b04d337f001",
-        "name": "illustrated-message-title-size",
-        "constant-token-duplicate": false
+        "name": "illustrated-message-title-size"
       }
     }
   },
@@ -1930,8 +1755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d563157b-f0d7-407d-aaaf-ae1790c75503",
-        "name": "in-field-button-edge-to-disclosure-icon-stacked-extra-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-edge-to-disclosure-icon-stacked-extra-large"
       }
     }
   },
@@ -1941,8 +1765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6a6e5478-b549-4a39-a7f5-5d3c417464ce",
-        "name": "in-field-button-edge-to-disclosure-icon-stacked-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-edge-to-disclosure-icon-stacked-large"
       }
     }
   },
@@ -1952,8 +1775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ccb60cfc-86fe-4959-b4a8-1a45835132c8",
-        "name": "in-field-button-edge-to-disclosure-icon-stacked-medium",
-        "constant-token-duplicate": true
+        "name": "in-field-button-edge-to-disclosure-icon-stacked-medium"
       }
     }
   },
@@ -1963,8 +1785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8b6a0ab1-4dba-4da2-9c67-3befca0f110e",
-        "name": "in-field-button-edge-to-disclosure-icon-stacked-small",
-        "constant-token-duplicate": true
+        "name": "in-field-button-edge-to-disclosure-icon-stacked-small"
       }
     }
   },
@@ -1974,8 +1795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5bffe992-2982-49e8-aa3a-e4e93c884f43",
-        "name": "in-field-button-edge-to-fill",
-        "constant-token-duplicate": true
+        "name": "in-field-button-edge-to-fill"
       }
     }
   },
@@ -1985,8 +1805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f8ed9a70-58f1-4f1a-9e87-24bca6d7b4e1",
-        "name": "in-field-button-fill-stacked-inner-border-rounding",
-        "constant-token-duplicate": true
+        "name": "in-field-button-fill-stacked-inner-border-rounding"
       }
     }
   },
@@ -1996,8 +1815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c47499c1-b89f-49a7-bbb5-17e83e4b306e",
-        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-extra-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-extra-large"
       }
     }
   },
@@ -2007,8 +1825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "710ebe58-f0d8-4d6b-8974-0be1f2f48dc4",
-        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-large"
       }
     }
   },
@@ -2018,8 +1835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3dd5babb-5026-4f28-89ae-bfe687673f31",
-        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-medium",
-        "constant-token-duplicate": true
+        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-medium"
       }
     }
   },
@@ -2029,8 +1845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6c1330a4-1c89-45a7-b2b1-8cbcaf20b9ab",
-        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-small",
-        "constant-token-duplicate": true
+        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-small"
       }
     }
   },
@@ -2040,8 +1855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "391e1e67-1677-4f60-a09a-3b49bacd01f5",
-        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-extra-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-extra-large"
       }
     }
   },
@@ -2051,8 +1865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "acc9c48a-f461-48ff-9f69-0224c4feabc6",
-        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-large"
       }
     }
   },
@@ -2062,8 +1875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a87d68bb-4249-43cd-947d-bd061baba0ef",
-        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-medium",
-        "constant-token-duplicate": true
+        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-medium"
       }
     }
   },
@@ -2073,8 +1885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9890df35-2d45-4767-9cbe-ee745d09d990",
-        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-small",
-        "constant-token-duplicate": true
+        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-small"
       }
     }
   },
@@ -2084,8 +1895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "56b54ece-0ff3-4957-9c1c-9e7fb992653c",
-        "name": "in-field-button-stacked-inner-edge-to-fill",
-        "constant-token-duplicate": true
+        "name": "in-field-button-stacked-inner-edge-to-fill"
       }
     }
   },
@@ -2095,8 +1905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5f844b3f-e0d7-40f0-a754-a14bee6a0fb4",
-        "name": "in-field-button-width-stacked-extra-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-width-stacked-extra-large"
       }
     }
   },
@@ -2106,8 +1915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4e103763-4310-4aff-980f-652ad023084f",
-        "name": "in-field-button-width-stacked-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-width-stacked-large"
       }
     }
   },
@@ -2117,8 +1925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bb8c7ce0-1766-47f9-b30e-36b3b57dc2ea",
-        "name": "in-field-button-width-stacked-medium",
-        "constant-token-duplicate": true
+        "name": "in-field-button-width-stacked-medium"
       }
     }
   },
@@ -2128,8 +1935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "24125066-c8d1-4c4a-85b3-493d112d3ca0",
-        "name": "in-field-button-width-stacked-small",
-        "constant-token-duplicate": true
+        "name": "in-field-button-width-stacked-small"
       }
     }
   },
@@ -2139,8 +1945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8007ebd8-fd67-4dc2-8444-9e6a50c88675",
-        "name": "in-line-alert-minimum-width",
-        "constant-token-duplicate": true
+        "name": "in-line-alert-minimum-width"
       }
     }
   },
@@ -2150,8 +1955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2480bdaf-ac18-4f67-9a0b-f92200fb31d7",
-        "name": "menu-item-edge-to-content-not-selected-extra-large",
-        "constant-token-duplicate": false
+        "name": "menu-item-edge-to-content-not-selected-extra-large"
       }
     }
   },
@@ -2161,8 +1965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bc6a7e9d-b84c-4bf3-9a63-a08047deb41c",
-        "name": "menu-item-edge-to-content-not-selected-large",
-        "constant-token-duplicate": false
+        "name": "menu-item-edge-to-content-not-selected-large"
       }
     }
   },
@@ -2172,8 +1975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ac4c8abe-abca-4c6f-82e7-ed7fae0c761d",
-        "name": "menu-item-edge-to-content-not-selected-medium",
-        "constant-token-duplicate": false
+        "name": "menu-item-edge-to-content-not-selected-medium"
       }
     }
   },
@@ -2183,8 +1985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "033fb47f-30d8-4ff2-9825-a3318ca2118b",
-        "name": "menu-item-edge-to-content-not-selected-small",
-        "constant-token-duplicate": false
+        "name": "menu-item-edge-to-content-not-selected-small"
       }
     }
   },
@@ -2194,8 +1995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "628cf42f-eb40-49b0-b110-3340421d4502",
-        "name": "menu-item-label-to-description",
-        "constant-token-duplicate": true
+        "name": "menu-item-label-to-description"
       }
     }
   },
@@ -2205,8 +2005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dac5c077-b948-434b-91bd-0759c2414007",
-        "name": "menu-item-section-divider-height",
-        "constant-token-duplicate": true
+        "name": "menu-item-section-divider-height"
       }
     }
   },
@@ -2216,8 +2015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "63919dd9-0dfa-4e6f-ab89-8a24fc91061b",
-        "name": "menu-item-top-to-disclosure-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-disclosure-icon-extra-large"
       }
     }
   },
@@ -2227,8 +2025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bceffb12-72a3-40eb-98a5-3d5fb4d3b627",
-        "name": "menu-item-top-to-disclosure-icon-large",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-disclosure-icon-large"
       }
     }
   },
@@ -2238,8 +2035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0ed8f599-b4c1-4ac5-b2b0-60db06a98a88",
-        "name": "menu-item-top-to-disclosure-icon-medium",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-disclosure-icon-medium"
       }
     }
   },
@@ -2249,8 +2045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8e4b2873-fb57-42d6-8b7b-91fd270c048e",
-        "name": "menu-item-top-to-disclosure-icon-small",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-disclosure-icon-small"
       }
     }
   },
@@ -2260,8 +2055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7be78bf9-a761-45a4-b764-b88e6209440b",
-        "name": "menu-item-top-to-selected-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-selected-icon-extra-large"
       }
     }
   },
@@ -2271,8 +2065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ccfed193-e366-4b13-806c-0cc18e2a87b4",
-        "name": "menu-item-top-to-selected-icon-large",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-selected-icon-large"
       }
     }
   },
@@ -2282,8 +2075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8fb8ad12-9bb9-417f-8d0d-7323455cfb7a",
-        "name": "menu-item-top-to-selected-icon-medium",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-selected-icon-medium"
       }
     }
   },
@@ -2293,8 +2085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fbe45d1b-f4b9-40d1-965f-38abe057dc69",
-        "name": "menu-item-top-to-selected-icon-small",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-selected-icon-small"
       }
     }
   },
@@ -2304,8 +2095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "63bfb4da-4aaf-49c6-9328-16c636cf0bf9",
-        "name": "meter-maximum-width",
-        "constant-token-duplicate": true
+        "name": "meter-maximum-width"
       }
     }
   },
@@ -2315,8 +2105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fd4f6ef0-bab2-4405-9eea-8a9b8a7dd295",
-        "name": "meter-minimum-width",
-        "constant-token-duplicate": true
+        "name": "meter-minimum-width"
       }
     }
   },
@@ -2326,8 +2115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "06751674-2222-433d-9dc6-40f14b2add6c",
-        "name": "meter-thickness-large",
-        "constant-token-duplicate": false
+        "name": "meter-thickness-large"
       }
     }
   },
@@ -2337,8 +2125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0013e354-3f26-41a5-8486-2577045872f6",
-        "name": "meter-thickness-small",
-        "constant-token-duplicate": false
+        "name": "meter-thickness-small"
       }
     }
   },
@@ -2348,8 +2135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ceeda4da-026b-496c-8abd-7081aceae262",
-        "name": "meter-width",
-        "constant-token-duplicate": false
+        "name": "meter-width"
       }
     }
   },
@@ -2359,8 +2145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9ddf2e73-ad74-46d7-a79d-fe961b06dbbd",
-        "name": "opacity-checkerboard-square-size",
-        "constant-token-duplicate": false
+        "name": "opacity-checkerboard-square-size"
       }
     }
   },
@@ -2370,8 +2155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "69c28762-f456-4641-b6ce-7cb295e3a27d",
-        "name": "picker-border-width",
-        "constant-token-duplicate": true
+        "name": "picker-border-width"
       }
     }
   },
@@ -2381,8 +2165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "03da68d8-cd87-4e29-9aaf-ab467594ec2b",
-        "name": "picker-end-edge-to-disclosure-icon-quiet",
-        "constant-token-duplicate": true
+        "name": "picker-end-edge-to-disclosure-icon-quiet"
       }
     }
   },
@@ -2392,8 +2175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "67b68a30-ae00-4da2-9730-99196a2eaf96",
-        "name": "picker-minimum-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "picker-minimum-width-multiplier"
       }
     }
   },
@@ -2403,8 +2185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "de09427a-eef3-4360-a912-0b0d5602d4a4",
-        "name": "picker-visual-to-disclosure-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "picker-visual-to-disclosure-icon-extra-large"
       }
     }
   },
@@ -2414,8 +2195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2f22005b-305b-4629-bc03-10d81e36ce78",
-        "name": "picker-visual-to-disclosure-icon-large",
-        "constant-token-duplicate": false
+        "name": "picker-visual-to-disclosure-icon-large"
       }
     }
   },
@@ -2425,8 +2205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f83b0313-ba78-4c98-be6e-702b58956589",
-        "name": "picker-visual-to-disclosure-icon-medium",
-        "constant-token-duplicate": false
+        "name": "picker-visual-to-disclosure-icon-medium"
       }
     }
   },
@@ -2436,8 +2215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4bcebd07-28a8-401d-9072-3b2ac22e8b63",
-        "name": "picker-visual-to-disclosure-icon-small",
-        "constant-token-duplicate": false
+        "name": "picker-visual-to-disclosure-icon-small"
       }
     }
   },
@@ -2447,8 +2225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5960406b-973d-4e1f-9bb4-2c7a22422c5b",
-        "name": "popover-tip-height",
-        "constant-token-duplicate": true
+        "name": "popover-tip-height"
       }
     }
   },
@@ -2458,8 +2235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c4bc3596-1fbc-4b08-85af-6bd8142e499a",
-        "name": "popover-tip-width",
-        "constant-token-duplicate": true
+        "name": "popover-tip-width"
       }
     }
   },
@@ -2469,8 +2245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f97488e8-b1c1-442e-b98c-0ae6cff0b774",
-        "name": "popover-top-to-content-area",
-        "constant-token-duplicate": false
+        "name": "popover-top-to-content-area"
       }
     }
   },
@@ -2480,8 +2255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7ba00389-a6ba-4d18-9d88-8704427ad784",
-        "name": "progress-bar-maximum-width",
-        "constant-token-duplicate": true
+        "name": "progress-bar-maximum-width"
       }
     }
   },
@@ -2491,8 +2265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8dfd4f94-93cc-47dd-92d2-87d1696f4ab7",
-        "name": "progress-bar-minimum-width",
-        "constant-token-duplicate": true
+        "name": "progress-bar-minimum-width"
       }
     }
   },
@@ -2502,8 +2275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "71229a29-a2cf-46bc-84d4-d324bffad26b",
-        "name": "progress-bar-thickness-extra-large",
-        "constant-token-duplicate": false
+        "name": "progress-bar-thickness-extra-large"
       }
     }
   },
@@ -2513,8 +2285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f8dfa5e7-efb8-409f-8ab3-6bf3adf2199b",
-        "name": "progress-bar-thickness-large",
-        "constant-token-duplicate": false
+        "name": "progress-bar-thickness-large"
       }
     }
   },
@@ -2524,8 +2295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0d9f1945-262b-48d0-b584-ff78ec28e012",
-        "name": "progress-bar-thickness-medium",
-        "constant-token-duplicate": false
+        "name": "progress-bar-thickness-medium"
       }
     }
   },
@@ -2535,8 +2305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f8881a13-70fb-4797-a3ec-08c3c8432b5a",
-        "name": "progress-bar-thickness-small",
-        "constant-token-duplicate": false
+        "name": "progress-bar-thickness-small"
       }
     }
   },
@@ -2546,8 +2315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a91ff845-aeb8-4a1b-9e4a-d34c77bb8253",
-        "name": "progress-circle-size-large",
-        "constant-token-duplicate": false
+        "name": "progress-circle-size-large"
       }
     }
   },
@@ -2557,8 +2325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2b9efe78-8384-4994-a4ab-82046f109d20",
-        "name": "progress-circle-size-medium",
-        "constant-token-duplicate": false
+        "name": "progress-circle-size-medium"
       }
     }
   },
@@ -2568,8 +2335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2b9f6096-84e7-4430-a3a9-a9daadcd1225",
-        "name": "progress-circle-size-small",
-        "constant-token-duplicate": false
+        "name": "progress-circle-size-small"
       }
     }
   },
@@ -2579,8 +2345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6331ae2c-ddf9-4de4-8df4-82b5581cf2ea",
-        "name": "progress-circle-thickness-large",
-        "constant-token-duplicate": false
+        "name": "progress-circle-thickness-large"
       }
     }
   },
@@ -2590,8 +2355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a3adff4d-e69e-4aa0-95ec-2019328b7d08",
-        "name": "progress-circle-thickness-medium",
-        "constant-token-duplicate": false
+        "name": "progress-circle-thickness-medium"
       }
     }
   },
@@ -2601,8 +2365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "becddd13-6ef9-4abc-9468-25885b2b4b84",
-        "name": "progress-circle-thickness-small",
-        "constant-token-duplicate": false
+        "name": "progress-circle-thickness-small"
       }
     }
   },
@@ -2612,8 +2375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f8f1d29b-4093-40ed-b73c-7a27e27a63a4",
-        "name": "radio-button-control-size-extra-large",
-        "constant-token-duplicate": false
+        "name": "radio-button-control-size-extra-large"
       }
     }
   },
@@ -2623,8 +2385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cadf4b9e-b4d4-4ff5-808b-557864cf7dc8",
-        "name": "radio-button-control-size-large",
-        "constant-token-duplicate": false
+        "name": "radio-button-control-size-large"
       }
     }
   },
@@ -2634,8 +2395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9de5b045-532c-48ef-872e-bd3c22f89a41",
-        "name": "radio-button-control-size-medium",
-        "constant-token-duplicate": false
+        "name": "radio-button-control-size-medium"
       }
     }
   },
@@ -2645,8 +2405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "407304fc-7c74-4427-9032-b44ab03c07ce",
-        "name": "radio-button-control-size-small",
-        "constant-token-duplicate": false
+        "name": "radio-button-control-size-small"
       }
     }
   },
@@ -2656,8 +2415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a7fc6bdb-5b9c-42d4-8f78-d34021ac0708",
-        "name": "radio-button-selection-indicator",
-        "constant-token-duplicate": true
+        "name": "radio-button-selection-indicator"
       }
     }
   },
@@ -2667,8 +2425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f4620f0a-43ba-4650-8640-9425ed1a1260",
-        "name": "radio-button-top-to-control-extra-large",
-        "constant-token-duplicate": false
+        "name": "radio-button-top-to-control-extra-large"
       }
     }
   },
@@ -2678,8 +2435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "309c9559-1763-4345-8090-aaa12f570889",
-        "name": "radio-button-top-to-control-large",
-        "constant-token-duplicate": false
+        "name": "radio-button-top-to-control-large"
       }
     }
   },
@@ -2689,8 +2445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dcc0155a-6bd1-4148-acaf-e255a7f4d22a",
-        "name": "radio-button-top-to-control-medium",
-        "constant-token-duplicate": false
+        "name": "radio-button-top-to-control-medium"
       }
     }
   },
@@ -2700,8 +2455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b775d7e9-d182-4818-9ae0-b3765a0ecbf7",
-        "name": "radio-button-top-to-control-small",
-        "constant-token-duplicate": false
+        "name": "radio-button-top-to-control-small"
       }
     }
   },
@@ -2711,8 +2465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b132d948-bec9-4a29-b281-e77801ce5a7c",
-        "name": "rating-indicator-to-icon",
-        "constant-token-duplicate": false
+        "name": "rating-indicator-to-icon"
       }
     }
   },
@@ -2722,8 +2475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f0958cee-9688-43db-9542-1aef164f9dfe",
-        "name": "rating-indicator-width",
-        "constant-token-duplicate": false
+        "name": "rating-indicator-width"
       }
     }
   },
@@ -2733,8 +2485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c4b2177d-4468-4180-be27-69d26a51ba0b",
-        "name": "search-field-minimum-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "search-field-minimum-width-multiplier"
       }
     }
   },
@@ -2744,8 +2495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8751d85d-a325-4e4e-a7b2-0a3ca94b6b6e",
-        "name": "side-navigation-bottom-to-text",
-        "constant-token-duplicate": false
+        "name": "side-navigation-bottom-to-text"
       }
     }
   },
@@ -2755,8 +2505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "423b5520-bb29-4179-9145-67305ca75b75",
-        "name": "side-navigation-header-to-item",
-        "constant-token-duplicate": false
+        "name": "side-navigation-header-to-item"
       }
     }
   },
@@ -2766,8 +2515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c5de72a2-931a-429d-ba85-5aaf2e30fbc4",
-        "name": "side-navigation-item-to-header",
-        "constant-token-duplicate": false
+        "name": "side-navigation-item-to-header"
       }
     }
   },
@@ -2777,8 +2525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "47e687e4-c458-4e0b-bd02-7698cc14983b",
-        "name": "side-navigation-item-to-item",
-        "constant-token-duplicate": false
+        "name": "side-navigation-item-to-item"
       }
     }
   },
@@ -2788,8 +2535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "68210b40-f87e-4059-88c1-e66d1c8cbd38",
-        "name": "side-navigation-maximum-width",
-        "constant-token-duplicate": false
+        "name": "side-navigation-maximum-width"
       }
     }
   },
@@ -2799,8 +2545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "998bb752-7826-4437-ac18-14e08644e226",
-        "name": "side-navigation-minimum-width",
-        "constant-token-duplicate": false
+        "name": "side-navigation-minimum-width"
       }
     }
   },
@@ -2810,8 +2555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2e5df819-ac9e-4b09-bdf6-8b1fe751c8fb",
-        "name": "side-navigation-second-level-edge-to-text",
-        "constant-token-duplicate": false
+        "name": "side-navigation-second-level-edge-to-text"
       }
     }
   },
@@ -2821,8 +2565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "adfe198d-a39b-47a1-bfa4-77dd0d139803",
-        "name": "side-navigation-third-level-edge-to-text",
-        "constant-token-duplicate": false
+        "name": "side-navigation-third-level-edge-to-text"
       }
     }
   },
@@ -2832,8 +2575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d087f995-da55-4c96-89c4-69a9a83e2f05",
-        "name": "side-navigation-width",
-        "constant-token-duplicate": false
+        "name": "side-navigation-width"
       }
     }
   },
@@ -2843,8 +2585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d254c910-2939-48ce-8547-08cfb346a0db",
-        "name": "side-navigation-with-icon-second-level-edge-to-text",
-        "constant-token-duplicate": false
+        "name": "side-navigation-with-icon-second-level-edge-to-text"
       }
     }
   },
@@ -2854,8 +2595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f1d90f18-e114-477f-88ca-548c5ddbc287",
-        "name": "side-navigation-with-icon-third-level-edge-to-text",
-        "constant-token-duplicate": false
+        "name": "side-navigation-with-icon-third-level-edge-to-text"
       }
     }
   },
@@ -2865,8 +2605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "309b149c-306a-49ee-b14c-a0eb4826e3b1",
-        "name": "slider-control-to-field-label-extra-large",
-        "constant-token-duplicate": false
+        "name": "slider-control-to-field-label-extra-large"
       }
     }
   },
@@ -2876,8 +2615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a4be5828-2176-42e7-97de-1f80e7dc08bb",
-        "name": "slider-control-to-field-label-large",
-        "constant-token-duplicate": false
+        "name": "slider-control-to-field-label-large"
       }
     }
   },
@@ -2887,8 +2625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b257bf97-d632-4488-a954-57b16bcf18b9",
-        "name": "slider-control-to-field-label-medium",
-        "constant-token-duplicate": false
+        "name": "slider-control-to-field-label-medium"
       }
     }
   },
@@ -2898,8 +2635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cbf9c42b-c14e-440d-97ad-3c937c464446",
-        "name": "slider-control-to-field-label-small",
-        "constant-token-duplicate": false
+        "name": "slider-control-to-field-label-small"
       }
     }
   },
@@ -2909,8 +2645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "47d025e2-0b26-4ebc-9b46-3cd1e470b9bc",
-        "name": "slider-handle-border-width-down-extra-large",
-        "constant-token-duplicate": false
+        "name": "slider-handle-border-width-down-extra-large"
       }
     }
   },
@@ -2920,8 +2655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "525e7d74-2bc0-48ac-85ca-b07335819a31",
-        "name": "slider-handle-border-width-down-large",
-        "constant-token-duplicate": false
+        "name": "slider-handle-border-width-down-large"
       }
     }
   },
@@ -2931,8 +2665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "63c65cd6-a2c2-4430-a1e9-cf82ae0a3f25",
-        "name": "slider-handle-border-width-down-medium",
-        "constant-token-duplicate": false
+        "name": "slider-handle-border-width-down-medium"
       }
     }
   },
@@ -2942,8 +2675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c9b7d8d9-c5ba-4d97-a03b-a214104ede23",
-        "name": "slider-handle-border-width-down-small",
-        "constant-token-duplicate": false
+        "name": "slider-handle-border-width-down-small"
       }
     }
   },
@@ -2953,8 +2685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1a257268-32e9-4c5c-8477-32a724ff1d42",
-        "name": "slider-handle-gap",
-        "constant-token-duplicate": true
+        "name": "slider-handle-gap"
       }
     }
   },
@@ -2964,8 +2695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "10ccce0d-5a2c-414e-8055-0be76709c180",
-        "name": "slider-handle-size-extra-large",
-        "constant-token-duplicate": false
+        "name": "slider-handle-size-extra-large"
       }
     }
   },
@@ -2975,8 +2705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3df3c866-faf0-43db-8c18-f442e7f94822",
-        "name": "slider-handle-size-large",
-        "constant-token-duplicate": false
+        "name": "slider-handle-size-large"
       }
     }
   },
@@ -2986,8 +2715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a8a02181-c797-461d-a666-a63f7535a096",
-        "name": "slider-handle-size-medium",
-        "constant-token-duplicate": false
+        "name": "slider-handle-size-medium"
       }
     }
   },
@@ -2997,8 +2725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1384d419-bfad-44d7-847c-a0f2c195fb93",
-        "name": "slider-handle-size-small",
-        "constant-token-duplicate": false
+        "name": "slider-handle-size-small"
       }
     }
   },
@@ -3008,8 +2735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "50a71b8b-30fb-40c0-b81e-5ce0dcc8c96b",
-        "name": "slider-track-thickness",
-        "constant-token-duplicate": true
+        "name": "slider-track-thickness"
       }
     }
   },
@@ -3019,8 +2745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5e27b361-988c-42ac-8c66-f7d1ba00632d",
-        "name": "status-light-dot-size-extra-large",
-        "constant-token-duplicate": false
+        "name": "status-light-dot-size-extra-large"
       }
     }
   },
@@ -3030,8 +2755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "45832ec2-5f33-4861-a857-1ca2352213db",
-        "name": "status-light-dot-size-large",
-        "constant-token-duplicate": false
+        "name": "status-light-dot-size-large"
       }
     }
   },
@@ -3041,8 +2765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ada7bd8c-04c9-4d77-a6e8-072ff86984ae",
-        "name": "status-light-dot-size-medium",
-        "constant-token-duplicate": false
+        "name": "status-light-dot-size-medium"
       }
     }
   },
@@ -3052,8 +2775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "04485265-2983-4377-9ec5-f2456863a1df",
-        "name": "status-light-dot-size-small",
-        "constant-token-duplicate": false
+        "name": "status-light-dot-size-small"
       }
     }
   },
@@ -3063,8 +2785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "899c7b7c-7405-4e29-8d42-edf41ca2943f",
-        "name": "status-light-top-to-dot-extra-large",
-        "constant-token-duplicate": false
+        "name": "status-light-top-to-dot-extra-large"
       }
     }
   },
@@ -3074,8 +2795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ead22722-10f9-4cfe-a387-65f5d86ca520",
-        "name": "status-light-top-to-dot-large",
-        "constant-token-duplicate": false
+        "name": "status-light-top-to-dot-large"
       }
     }
   },
@@ -3085,8 +2805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e2aa334e-ebb7-4e5f-a735-4f6a43b2d6cf",
-        "name": "status-light-top-to-dot-medium",
-        "constant-token-duplicate": false
+        "name": "status-light-top-to-dot-medium"
       }
     }
   },
@@ -3096,8 +2815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ddece3b1-7f85-4c08-b783-5bde8e31f480",
-        "name": "status-light-top-to-dot-small",
-        "constant-token-duplicate": false
+        "name": "status-light-top-to-dot-small"
       }
     }
   },
@@ -3107,8 +2825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b3157e9d-82a0-429e-b987-8c240a669af7",
-        "name": "swatch-rectangle-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "swatch-rectangle-width-multiplier"
       }
     }
   },
@@ -3118,8 +2835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9fa676c9-ccfb-47db-9ae4-348884b9b120",
-        "name": "swatch-size-extra-small",
-        "constant-token-duplicate": false
+        "name": "swatch-size-extra-small"
       }
     }
   },
@@ -3129,8 +2845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "91e7d7f2-a34d-4d03-831c-75574d1b7bee",
-        "name": "swatch-size-large",
-        "constant-token-duplicate": false
+        "name": "swatch-size-large"
       }
     }
   },
@@ -3140,8 +2855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2e29b29f-b8b7-430a-8720-31422c6ad243",
-        "name": "swatch-size-medium",
-        "constant-token-duplicate": false
+        "name": "swatch-size-medium"
       }
     }
   },
@@ -3151,8 +2865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "33789b22-7d2c-4620-8f45-973e734ef5b6",
-        "name": "swatch-size-small",
-        "constant-token-duplicate": false
+        "name": "swatch-size-small"
       }
     }
   },
@@ -3162,8 +2875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "944c49d7-e189-4daa-aca1-b0b590d78875",
-        "name": "swatch-slash-thickness-extra-small",
-        "constant-token-duplicate": true
+        "name": "swatch-slash-thickness-extra-small"
       }
     }
   },
@@ -3173,8 +2885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6b1b2709-de8c-450d-9299-49200208599e",
-        "name": "swatch-slash-thickness-large",
-        "constant-token-duplicate": true
+        "name": "swatch-slash-thickness-large"
       }
     }
   },
@@ -3184,8 +2895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4e735599-f420-4b51-aa75-607046431c76",
-        "name": "swatch-slash-thickness-medium",
-        "constant-token-duplicate": true
+        "name": "swatch-slash-thickness-medium"
       }
     }
   },
@@ -3195,8 +2905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f626d145-7840-4958-86be-d2306b5b2233",
-        "name": "swatch-slash-thickness-small",
-        "constant-token-duplicate": true
+        "name": "swatch-slash-thickness-small"
       }
     }
   },
@@ -3206,8 +2915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2372d602-78ce-45a7-9dff-152152e55117",
-        "name": "switch-control-height-extra-large",
-        "constant-token-duplicate": false
+        "name": "switch-control-height-extra-large"
       }
     }
   },
@@ -3217,8 +2925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8301bfca-a086-4efd-a22f-1d348cbd6dcf",
-        "name": "switch-control-height-large",
-        "constant-token-duplicate": false
+        "name": "switch-control-height-large"
       }
     }
   },
@@ -3228,8 +2935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f97f0f1b-c0c2-410f-b116-86d30f4d52cf",
-        "name": "switch-control-height-medium",
-        "constant-token-duplicate": false
+        "name": "switch-control-height-medium"
       }
     }
   },
@@ -3239,8 +2945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3bf75a24-5e95-4c18-9da2-b7088377fe21",
-        "name": "switch-control-height-small",
-        "constant-token-duplicate": false
+        "name": "switch-control-height-small"
       }
     }
   },
@@ -3250,8 +2955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f3102afd-e5df-4912-9203-8226ce37fed5",
-        "name": "switch-control-width-extra-large",
-        "constant-token-duplicate": false
+        "name": "switch-control-width-extra-large"
       }
     }
   },
@@ -3261,8 +2965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cef839a5-2ba7-4e47-9a85-d94260a8ff10",
-        "name": "switch-control-width-large",
-        "constant-token-duplicate": false
+        "name": "switch-control-width-large"
       }
     }
   },
@@ -3272,8 +2975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d329eda6-f13d-4a44-b962-ff06c371ed93",
-        "name": "switch-control-width-medium",
-        "constant-token-duplicate": false
+        "name": "switch-control-width-medium"
       }
     }
   },
@@ -3283,8 +2985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f4d6fe1a-70bd-473a-9fa5-477865ea898e",
-        "name": "switch-control-width-small",
-        "constant-token-duplicate": false
+        "name": "switch-control-width-small"
       }
     }
   },
@@ -3294,8 +2995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fbc21571-970f-4bb2-8280-f6262446896b",
-        "name": "switch-top-to-control-extra-large",
-        "constant-token-duplicate": false
+        "name": "switch-top-to-control-extra-large"
       }
     }
   },
@@ -3305,8 +3005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f2c965e6-89fb-4b9d-843d-cfde31b7703d",
-        "name": "switch-top-to-control-large",
-        "constant-token-duplicate": false
+        "name": "switch-top-to-control-large"
       }
     }
   },
@@ -3316,8 +3015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0135b823-5097-43bb-9911-9f731146af3b",
-        "name": "switch-top-to-control-medium",
-        "constant-token-duplicate": false
+        "name": "switch-top-to-control-medium"
       }
     }
   },
@@ -3327,8 +3025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8a907825-236c-4548-91c4-2123e095726c",
-        "name": "switch-top-to-control-small",
-        "constant-token-duplicate": false
+        "name": "switch-top-to-control-small"
       }
     }
   },
@@ -3338,8 +3035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7e3a0369-fcc2-45d7-87ab-9053588713ef",
-        "name": "tab-item-bottom-to-text-compact-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-compact-extra-large"
       }
     }
   },
@@ -3349,8 +3045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8e701e0e-4d7c-4d38-ba6b-1fd2ef5978dc",
-        "name": "tab-item-bottom-to-text-compact-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-compact-large"
       }
     }
   },
@@ -3360,8 +3055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b44bbd5a-ef03-4e83-a9f5-88c896969d4d",
-        "name": "tab-item-bottom-to-text-compact-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-compact-medium"
       }
     }
   },
@@ -3371,8 +3065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d87a2ee3-6f7c-4f5e-8191-d35624fc10f1",
-        "name": "tab-item-bottom-to-text-compact-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-compact-small"
       }
     }
   },
@@ -3382,8 +3075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5840c3b8-3488-417b-8b33-f3fc667ffd7a",
-        "name": "tab-item-bottom-to-text-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-extra-large"
       }
     }
   },
@@ -3393,8 +3085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "61dd06ac-501e-4725-9d54-cc7a3d9f6586",
-        "name": "tab-item-bottom-to-text-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-large"
       }
     }
   },
@@ -3404,8 +3095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f507e1bd-f08e-42b1-aee6-ea38f9f8a387",
-        "name": "tab-item-bottom-to-text-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-medium"
       }
     }
   },
@@ -3415,8 +3105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2d0f71e2-66fc-4f28-bd4b-be41df0948ed",
-        "name": "tab-item-bottom-to-text-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-small"
       }
     }
   },
@@ -3426,8 +3115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "49130d66-edfb-48bd-8648-96c47f40a884",
-        "name": "tab-item-compact-height-extra-large",
-        "constant-token-duplicate": true
+        "name": "tab-item-compact-height-extra-large"
       }
     }
   },
@@ -3437,8 +3125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6d781a0e-e03d-4750-ae4f-67a29d731702",
-        "name": "tab-item-compact-height-large",
-        "constant-token-duplicate": true
+        "name": "tab-item-compact-height-large"
       }
     }
   },
@@ -3448,8 +3135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e8c7c826-548d-4037-b064-3cf699675d35",
-        "name": "tab-item-compact-height-medium",
-        "constant-token-duplicate": true
+        "name": "tab-item-compact-height-medium"
       }
     }
   },
@@ -3459,8 +3145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "25f7d9a5-9464-4447-97d9-97839b371f96",
-        "name": "tab-item-compact-height-small",
-        "constant-token-duplicate": true
+        "name": "tab-item-compact-height-small"
       }
     }
   },
@@ -3470,8 +3155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1f12f9aa-19bd-4f77-93db-d737c0538677",
-        "name": "tab-item-focus-indicator-gap-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-focus-indicator-gap-extra-large"
       }
     }
   },
@@ -3481,8 +3165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6fd78b93-1356-4eb0-9f70-bed00c3eb2aa",
-        "name": "tab-item-focus-indicator-gap-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-focus-indicator-gap-large"
       }
     }
   },
@@ -3492,8 +3175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cbbaa048-129d-439f-8aae-59153e28216b",
-        "name": "tab-item-focus-indicator-gap-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-focus-indicator-gap-medium"
       }
     }
   },
@@ -3503,8 +3185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d23bdd67-d7d0-42df-9575-61502d3692ab",
-        "name": "tab-item-focus-indicator-gap-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-focus-indicator-gap-small"
       }
     }
   },
@@ -3514,8 +3195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "42ed814c-5044-4c70-b82f-b49f8226241e",
-        "name": "tab-item-height-extra-large",
-        "constant-token-duplicate": true
+        "name": "tab-item-height-extra-large"
       }
     }
   },
@@ -3525,8 +3205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8abd0b0e-fd6d-4064-9d0e-1ab998fcb0ce",
-        "name": "tab-item-height-large",
-        "constant-token-duplicate": true
+        "name": "tab-item-height-large"
       }
     }
   },
@@ -3536,8 +3215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5d2288f4-f383-47fa-baca-0168cb46750a",
-        "name": "tab-item-height-medium",
-        "constant-token-duplicate": true
+        "name": "tab-item-height-medium"
       }
     }
   },
@@ -3547,8 +3225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7b31cf38-5bac-4f79-a4f1-172a4ea66e10",
-        "name": "tab-item-height-small",
-        "constant-token-duplicate": true
+        "name": "tab-item-height-small"
       }
     }
   },
@@ -3558,8 +3235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a480fffb-0a23-4893-87ce-730eb925a7cc",
-        "name": "tab-item-start-to-edge-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-start-to-edge-extra-large"
       }
     }
   },
@@ -3569,8 +3245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c3f8f94b-d456-4aeb-8340-bd5643efe8fc",
-        "name": "tab-item-start-to-edge-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-start-to-edge-large"
       }
     }
   },
@@ -3580,8 +3255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4d105a45-7403-47f2-ba50-419d822ff879",
-        "name": "tab-item-start-to-edge-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-start-to-edge-medium"
       }
     }
   },
@@ -3591,8 +3265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f869f703-a850-4c6c-b518-ec8a1b355046",
-        "name": "tab-item-start-to-edge-quiet",
-        "constant-token-duplicate": true
+        "name": "tab-item-start-to-edge-quiet"
       }
     }
   },
@@ -3602,8 +3275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "712e62ce-b869-4097-aee1-82e3b7505e14",
-        "name": "tab-item-start-to-edge-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-start-to-edge-small"
       }
     }
   },
@@ -3613,8 +3285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c92ec468-0fac-4e12-b1f8-f22d09cb6c1e",
-        "name": "tab-item-to-tab-item-horizontal-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-horizontal-extra-large"
       }
     }
   },
@@ -3624,8 +3295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1f9460a7-2ec0-4353-875c-ee5a6143d00b",
-        "name": "tab-item-to-tab-item-horizontal-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-horizontal-large"
       }
     }
   },
@@ -3635,8 +3305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "31bea7d1-c8c2-4901-9f18-7a5c936d243f",
-        "name": "tab-item-to-tab-item-horizontal-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-horizontal-medium"
       }
     }
   },
@@ -3646,8 +3315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "79695d07-21cb-4772-b3f7-b2eb56e7ad20",
-        "name": "tab-item-to-tab-item-horizontal-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-horizontal-small"
       }
     }
   },
@@ -3657,8 +3325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d74ea722-c146-4ad2-ab20-41c332ae1190",
-        "name": "tab-item-to-tab-item-vertical-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-vertical-extra-large"
       }
     }
   },
@@ -3668,8 +3335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9846992c-e27b-4760-8808-7c44cca2cc65",
-        "name": "tab-item-to-tab-item-vertical-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-vertical-large"
       }
     }
   },
@@ -3679,8 +3345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7cd196c1-18b1-4dae-abf7-7ef1b531e0af",
-        "name": "tab-item-to-tab-item-vertical-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-vertical-medium"
       }
     }
   },
@@ -3690,8 +3355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "da8211ee-8944-447f-a6df-6a16580e1893",
-        "name": "tab-item-to-tab-item-vertical-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-vertical-small"
       }
     }
   },
@@ -3701,8 +3365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2bdd22cd-93fe-4cf4-a025-e690ecafb50b",
-        "name": "tab-item-top-to-text-compact-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-compact-extra-large"
       }
     }
   },
@@ -3712,8 +3375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "93af7bac-830c-4460-abe2-0b2d8f786786",
-        "name": "tab-item-top-to-text-compact-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-compact-large"
       }
     }
   },
@@ -3723,8 +3385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2481e3a1-302b-46b8-98c2-e9461dd47d0c",
-        "name": "tab-item-top-to-text-compact-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-compact-medium"
       }
     }
   },
@@ -3734,8 +3395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bbcf3eda-4add-4d0d-b5ae-c2e7078e85ed",
-        "name": "tab-item-top-to-text-compact-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-compact-small"
       }
     }
   },
@@ -3745,8 +3405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f1b6b932-748d-4b26-9c03-2bd9d0a40ac6",
-        "name": "tab-item-top-to-text-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-extra-large"
       }
     }
   },
@@ -3756,8 +3415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8b9275f5-3e63-459c-97fc-bc03691aa772",
-        "name": "tab-item-top-to-text-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-large"
       }
     }
   },
@@ -3767,8 +3425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e75e4e96-6d1b-4a86-9059-5c1f6f6ab269",
-        "name": "tab-item-top-to-text-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-medium"
       }
     }
   },
@@ -3778,8 +3435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a9a6d785-f06d-4505-89ea-552d47ebe49d",
-        "name": "tab-item-top-to-text-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-small"
       }
     }
   },
@@ -3789,8 +3445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dd4769f3-5c7e-491f-9d01-c80af0b561fb",
-        "name": "tab-item-top-to-workflow-icon-compact-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-compact-extra-large"
       }
     }
   },
@@ -3800,8 +3455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fab951e5-1a78-4fb4-8c19-677f5f231189",
-        "name": "tab-item-top-to-workflow-icon-compact-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-compact-large"
       }
     }
   },
@@ -3811,8 +3465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7788c25c-0ce2-4170-8c5f-2fb1d98d953a",
-        "name": "tab-item-top-to-workflow-icon-compact-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-compact-medium"
       }
     }
   },
@@ -3822,8 +3475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "96c22cdc-aecb-4747-aea9-f140af5ee048",
-        "name": "tab-item-top-to-workflow-icon-compact-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-compact-small"
       }
     }
   },
@@ -3833,8 +3485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2c869793-c10b-40ef-9545-45a8a6b4cbb5",
-        "name": "tab-item-top-to-workflow-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-extra-large"
       }
     }
   },
@@ -3844,8 +3495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "65e1f735-5f46-4bb3-9c7b-d5f5abab91a1",
-        "name": "tab-item-top-to-workflow-icon-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-large"
       }
     }
   },
@@ -3855,8 +3505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "aec60dda-9e5a-40c8-8e45-5e1662eab6e3",
-        "name": "tab-item-top-to-workflow-icon-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-medium"
       }
     }
   },
@@ -3866,8 +3515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7bd7427d-06a8-4194-a9f4-300fd1a4f547",
-        "name": "tab-item-top-to-workflow-icon-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-small"
       }
     }
   },
@@ -3877,8 +3525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b6f2536c-deda-409f-8667-a5a99abdfa46",
-        "name": "table-border-divider-width",
-        "constant-token-duplicate": true
+        "name": "table-border-divider-width"
       }
     }
   },
@@ -3888,8 +3535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "400553db-907c-43a5-8545-92ba212e12b8",
-        "name": "table-checkbox-to-text",
-        "constant-token-duplicate": false
+        "name": "table-checkbox-to-text"
       }
     }
   },
@@ -3899,8 +3545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0f76ceee-1d19-4c69-9393-09b02e1eede5",
-        "name": "table-column-header-row-bottom-to-text-extra-large",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-bottom-to-text-extra-large"
       }
     }
   },
@@ -3910,8 +3555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fc30c9a8-b098-4edf-b3f4-c666c019b3f4",
-        "name": "table-column-header-row-bottom-to-text-large",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-bottom-to-text-large"
       }
     }
   },
@@ -3921,8 +3565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7357ba3f-c707-4475-b616-4752776c06d1",
-        "name": "table-column-header-row-bottom-to-text-medium",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-bottom-to-text-medium"
       }
     }
   },
@@ -3932,8 +3575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9388deb6-6a77-49bc-aeb5-9084352c2574",
-        "name": "table-column-header-row-bottom-to-text-small",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-bottom-to-text-small"
       }
     }
   },
@@ -3943,8 +3585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "05d4bb65-357a-4561-ab33-ea6de390a304",
-        "name": "table-column-header-row-top-to-text-extra-large",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-top-to-text-extra-large"
       }
     }
   },
@@ -3954,8 +3595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "40b7bc07-3252-492a-9ee1-37aceeca3674",
-        "name": "table-column-header-row-top-to-text-large",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-top-to-text-large"
       }
     }
   },
@@ -3965,8 +3605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0ec68b5a-4251-4727-a689-b10722ce1a43",
-        "name": "table-column-header-row-top-to-text-medium",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-top-to-text-medium"
       }
     }
   },
@@ -3976,8 +3615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "de67ada3-eeed-45a2-8d03-91a5b09156ec",
-        "name": "table-column-header-row-top-to-text-small",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-top-to-text-small"
       }
     }
   },
@@ -3987,8 +3625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5e46672f-eab0-4ec3-bd14-68ffa4404ec1",
-        "name": "table-edge-to-content",
-        "constant-token-duplicate": false
+        "name": "table-edge-to-content"
       }
     }
   },
@@ -3998,8 +3635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8adf3d5f-1024-4eb8-8515-f3b6fd7cc22c",
-        "name": "table-header-row-checkbox-to-top-extra-large",
-        "constant-token-duplicate": false
+        "name": "table-header-row-checkbox-to-top-extra-large"
       }
     }
   },
@@ -4009,8 +3645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5011ae3c-2e72-4891-926e-8de8847e0a47",
-        "name": "table-header-row-checkbox-to-top-large",
-        "constant-token-duplicate": false
+        "name": "table-header-row-checkbox-to-top-large"
       }
     }
   },
@@ -4020,8 +3655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "578765e6-b2ec-4bfe-ae28-f24cbee15898",
-        "name": "table-header-row-checkbox-to-top-medium",
-        "constant-token-duplicate": false
+        "name": "table-header-row-checkbox-to-top-medium"
       }
     }
   },
@@ -4031,8 +3665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "370e9149-aaf5-43cd-a783-90cfa8d37419",
-        "name": "table-header-row-checkbox-to-top-small",
-        "constant-token-duplicate": false
+        "name": "table-header-row-checkbox-to-top-small"
       }
     }
   },
@@ -4042,8 +3675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "effa3e3c-eb5b-4c0a-aca9-81331e6a08ac",
-        "name": "table-row-bottom-to-text-extra-large-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-bottom-to-text-extra-large-compact"
       }
     }
   },
@@ -4053,8 +3685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d13d2f2e-9425-403d-a95f-889d67f03425",
-        "name": "table-row-bottom-to-text-extra-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-extra-large-regular"
       }
     }
   },
@@ -4064,8 +3695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3271ab20-8a93-4b5b-a889-7a07d9f7e6ab",
-        "name": "table-row-bottom-to-text-extra-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-extra-large-spacious"
       }
     }
   },
@@ -4075,8 +3705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "15e21448-3174-4565-aed7-ab84aa30d7ac",
-        "name": "table-row-bottom-to-text-large-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-bottom-to-text-large-compact"
       }
     }
   },
@@ -4086,8 +3715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "775139b2-3fb4-4019-8a3e-2377211ed0ec",
-        "name": "table-row-bottom-to-text-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-large-regular"
       }
     }
   },
@@ -4097,8 +3725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3adc8c4f-32ce-4cd1-8bb1-518b9b267ed2",
-        "name": "table-row-bottom-to-text-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-large-spacious"
       }
     }
   },
@@ -4108,8 +3735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d9d8fee2-9e0f-4c2b-8059-f9badb3b6482",
-        "name": "table-row-bottom-to-text-medium-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-bottom-to-text-medium-compact"
       }
     }
   },
@@ -4119,8 +3745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c66ff3f2-3661-464c-b722-151f72d03f2a",
-        "name": "table-row-bottom-to-text-medium-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-medium-regular"
       }
     }
   },
@@ -4130,8 +3755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2cedf119-a2f6-484a-8bdd-83652a8d6d79",
-        "name": "table-row-bottom-to-text-medium-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-medium-spacious"
       }
     }
   },
@@ -4141,8 +3765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5eb79adf-f94c-4bf8-9ec9-279f49ce5331",
-        "name": "table-row-bottom-to-text-small-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-bottom-to-text-small-compact"
       }
     }
   },
@@ -4152,8 +3775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "90ae4c5b-a49d-40ad-8dd8-b25720c13f79",
-        "name": "table-row-bottom-to-text-small-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-small-regular"
       }
     }
   },
@@ -4163,8 +3785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ad51f205-c2e7-4af5-9301-937594c61027",
-        "name": "table-row-bottom-to-text-small-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-small-spacious"
       }
     }
   },
@@ -4174,8 +3795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a1aa1c65-a1e8-40d6-805f-309d5e43d129",
-        "name": "table-row-checkbox-to-top-extra-large-compact",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-extra-large-compact"
       }
     }
   },
@@ -4185,8 +3805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9b775e1f-9348-431d-9ba8-bffb19bcbf85",
-        "name": "table-row-checkbox-to-top-extra-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-extra-large-regular"
       }
     }
   },
@@ -4196,8 +3815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "568ba981-51b5-4443-a427-0f857ff02572",
-        "name": "table-row-checkbox-to-top-extra-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-extra-large-spacious"
       }
     }
   },
@@ -4207,8 +3825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "40acc8c4-81b4-4566-a7ce-7c3d0d8ab5c5",
-        "name": "table-row-checkbox-to-top-large-compact",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-large-compact"
       }
     }
   },
@@ -4218,8 +3835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "559b9fc0-389e-4e2f-985c-8741f218850a",
-        "name": "table-row-checkbox-to-top-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-large-regular"
       }
     }
   },
@@ -4229,8 +3845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d4b563c8-9234-4eed-a2a3-7e448a174286",
-        "name": "table-row-checkbox-to-top-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-large-spacious"
       }
     }
   },
@@ -4240,8 +3855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0b12ff10-52e2-4084-9f1b-ee7bc0b50576",
-        "name": "table-row-checkbox-to-top-medium-compact",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-medium-compact"
       }
     }
   },
@@ -4251,8 +3865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2c8f9b97-f4df-48c2-ab1a-82373d335b83",
-        "name": "table-row-checkbox-to-top-medium-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-medium-regular"
       }
     }
   },
@@ -4262,8 +3875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c8a04cab-bfad-4b82-94dc-6c2b4160c7cb",
-        "name": "table-row-checkbox-to-top-medium-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-medium-spacious"
       }
     }
   },
@@ -4273,8 +3885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f5c64a03-3750-4c92-afe2-43575bdb1df9",
-        "name": "table-row-checkbox-to-top-small-compact",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-small-compact"
       }
     }
   },
@@ -4284,8 +3895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4435c143-a75a-47c1-a629-3574b70247a3",
-        "name": "table-row-checkbox-to-top-small-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-small-regular"
       }
     }
   },
@@ -4295,8 +3905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4637c01d-66cd-451e-8950-9e72700c80d3",
-        "name": "table-row-checkbox-to-top-small-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-small-spacious"
       }
     }
   },
@@ -4306,8 +3915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dcc5dd06-bb3d-46d3-adf2-133e5be942b7",
-        "name": "table-row-height-extra-large-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-height-extra-large-compact"
       }
     }
   },
@@ -4317,8 +3925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "face2717-9c2c-4e18-9632-4e4a595b1fc7",
-        "name": "table-row-height-extra-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-height-extra-large-regular"
       }
     }
   },
@@ -4328,8 +3935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1504ecc5-0bd8-4bf2-ad3c-e073c824cd1a",
-        "name": "table-row-height-extra-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-height-extra-large-spacious"
       }
     }
   },
@@ -4339,8 +3945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d576b4aa-e3df-4aa9-8260-fecfe6517bde",
-        "name": "table-row-height-large-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-height-large-compact"
       }
     }
   },
@@ -4350,8 +3955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3b22a4c7-525c-4482-9e58-19cbe46d318b",
-        "name": "table-row-height-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-height-large-regular"
       }
     }
   },
@@ -4361,8 +3965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0cd072e1-1757-49b1-a985-09ab65feb672",
-        "name": "table-row-height-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-height-large-spacious"
       }
     }
   },
@@ -4372,8 +3975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b4b86a59-041d-451c-a0be-cc82e997a1d2",
-        "name": "table-row-height-medium-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-height-medium-compact"
       }
     }
   },
@@ -4383,8 +3985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1dc88a25-18bc-491a-ab02-2c1ec36f4c1e",
-        "name": "table-row-height-medium-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-height-medium-regular"
       }
     }
   },
@@ -4394,8 +3995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "697f4b63-14b9-4d58-9d16-b9dfd72ff391",
-        "name": "table-row-height-medium-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-height-medium-spacious"
       }
     }
   },
@@ -4405,8 +4005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a6dfc911-50fe-46dd-a7a3-cec3b115006a",
-        "name": "table-row-height-small-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-height-small-compact"
       }
     }
   },
@@ -4416,8 +4015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fd53964b-cf4a-4cdf-b088-418364b1c518",
-        "name": "table-row-height-small-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-height-small-regular"
       }
     }
   },
@@ -4427,8 +4025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cb6f8879-6d73-40ca-9ea4-7eb05b26385a",
-        "name": "table-row-height-small-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-height-small-spacious"
       }
     }
   },
@@ -4438,8 +4035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2e8eff8c-60fa-4e0f-ae40-7b9f9b3679d6",
-        "name": "table-row-top-to-text-extra-large-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-top-to-text-extra-large-compact"
       }
     }
   },
@@ -4449,8 +4045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "03555438-78f5-429a-a0dd-c6777dc36372",
-        "name": "table-row-top-to-text-extra-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-extra-large-regular"
       }
     }
   },
@@ -4460,8 +4055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7824ab63-198c-4ee3-99d7-9b151898eb40",
-        "name": "table-row-top-to-text-extra-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-extra-large-spacious"
       }
     }
   },
@@ -4471,8 +4065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "14437ed2-c60b-40ba-91e6-bed5353fc544",
-        "name": "table-row-top-to-text-large-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-top-to-text-large-compact"
       }
     }
   },
@@ -4482,8 +4075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2ed03fb3-fed4-41d4-8a14-f7446bb76486",
-        "name": "table-row-top-to-text-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-large-regular"
       }
     }
   },
@@ -4493,8 +4085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a3e22e10-1964-4d4a-8721-2eeddfed6f42",
-        "name": "table-row-top-to-text-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-large-spacious"
       }
     }
   },
@@ -4504,8 +4095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "02c5faff-dbb4-4633-ae57-413b3666dfca",
-        "name": "table-row-top-to-text-medium-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-top-to-text-medium-compact"
       }
     }
   },
@@ -4515,8 +4105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8e1448f8-5806-4629-8131-4e8422b26870",
-        "name": "table-row-top-to-text-medium-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-medium-regular"
       }
     }
   },
@@ -4526,8 +4115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9893c4bf-aa89-4b46-987f-09432943734a",
-        "name": "table-row-top-to-text-medium-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-medium-spacious"
       }
     }
   },
@@ -4537,8 +4125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7e7808a-16c6-481a-9257-9c1dc4e13b62",
-        "name": "table-row-top-to-text-small-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-top-to-text-small-compact"
       }
     }
   },
@@ -4548,8 +4135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5e5a6837-34c9-4f01-8769-b66c3f602d1f",
-        "name": "table-row-top-to-text-small-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-small-regular"
       }
     }
   },
@@ -4559,8 +4145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c0f9a500-3259-4888-ab43-c180c694a24e",
-        "name": "table-row-top-to-text-small-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-small-spacious"
       }
     }
   },
@@ -4570,8 +4155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "34b1c98f-7159-4ae0-b299-bf2fc53035c0",
-        "name": "table-section-header-row-height-extra-large",
-        "constant-token-duplicate": false
+        "name": "table-section-header-row-height-extra-large"
       }
     }
   },
@@ -4581,8 +4165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "553f5ffd-a163-4b33-b96a-5acc08cfb820",
-        "name": "table-section-header-row-height-large",
-        "constant-token-duplicate": false
+        "name": "table-section-header-row-height-large"
       }
     }
   },
@@ -4592,8 +4175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4c9e9bd8-9320-4648-bf2c-bb2db74a63fb",
-        "name": "table-section-header-row-height-medium",
-        "constant-token-duplicate": false
+        "name": "table-section-header-row-height-medium"
       }
     }
   },
@@ -4603,8 +4185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "89bd3638-bbbb-432d-84eb-e217f9bb0cbf",
-        "name": "table-section-header-row-height-small",
-        "constant-token-duplicate": false
+        "name": "table-section-header-row-height-small"
       }
     }
   },
@@ -4614,8 +4195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "499530d7-7c3c-4bed-a4a1-d4edc2195afe",
-        "name": "table-thumbnail-to-top-minimum-extra-large-compact",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-extra-large-compact"
       }
     }
   },
@@ -4625,8 +4205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "17c4c578-d3e1-44c0-bd21-ee4df5cb2027",
-        "name": "table-thumbnail-to-top-minimum-extra-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-extra-large-regular"
       }
     }
   },
@@ -4636,8 +4215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "127b9225-cbab-42c1-8c86-4f425c7c8e27",
-        "name": "table-thumbnail-to-top-minimum-extra-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-extra-large-spacious"
       }
     }
   },
@@ -4647,8 +4225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9b0e3ebe-59f6-4970-aa47-06b115f5efff",
-        "name": "table-thumbnail-to-top-minimum-large-compact",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-large-compact"
       }
     }
   },
@@ -4658,8 +4235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "de6e6ae5-eae6-4f7a-89be-176674176242",
-        "name": "table-thumbnail-to-top-minimum-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-large-regular"
       }
     }
   },
@@ -4669,8 +4245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f1cbc035-b4d0-4593-b563-a107ee2eebb0",
-        "name": "table-thumbnail-to-top-minimum-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-large-spacious"
       }
     }
   },
@@ -4680,8 +4255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "86a1c328-0845-47d8-a189-24a22c1ce053",
-        "name": "table-thumbnail-to-top-minimum-medium-compact",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-medium-compact"
       }
     }
   },
@@ -4691,8 +4265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "12a6fd11-d3a5-4d72-9942-89d828d1d256",
-        "name": "table-thumbnail-to-top-minimum-medium-regular",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-medium-regular"
       }
     }
   },
@@ -4702,8 +4275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1cd90c35-f688-4054-aec4-e1e3b200cfcf",
-        "name": "table-thumbnail-to-top-minimum-medium-spacious",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-medium-spacious"
       }
     }
   },
@@ -4713,8 +4285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d9cc50d4-6661-4a03-b850-ed0933f2dabb",
-        "name": "table-thumbnail-to-top-minimum-small-compact",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-small-compact"
       }
     }
   },
@@ -4724,8 +4295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "db98283d-1f25-4323-9f3a-0555b9670ba6",
-        "name": "table-thumbnail-to-top-minimum-small-regular",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-small-regular"
       }
     }
   },
@@ -4735,8 +4305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9b464ca8-f246-482d-b240-e12e097aaf8b",
-        "name": "table-thumbnail-to-top-minimum-small-spacious",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-small-spacious"
       }
     }
   },
@@ -4746,8 +4315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "57de6911-6f5f-4a0d-9606-e7584a10d7f4",
-        "name": "tag-top-to-avatar-large",
-        "constant-token-duplicate": false
+        "name": "tag-top-to-avatar-large"
       }
     }
   },
@@ -4757,8 +4325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "394343df-fb5d-44be-b6d1-9975ab8a4156",
-        "name": "tag-top-to-avatar-medium",
-        "constant-token-duplicate": false
+        "name": "tag-top-to-avatar-medium"
       }
     }
   },
@@ -4768,8 +4335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cf1239b1-495a-482c-8aeb-3b98c6b75583",
-        "name": "tag-top-to-avatar-small",
-        "constant-token-duplicate": false
+        "name": "tag-top-to-avatar-small"
       }
     }
   },
@@ -4779,8 +4345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e335436a-190c-4417-86f4-b7266c093377",
-        "name": "tag-top-to-cross-icon-large",
-        "constant-token-duplicate": false
+        "name": "tag-top-to-cross-icon-large"
       }
     }
   },
@@ -4790,8 +4355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1bfd3452-93c8-424a-99e4-55e5ecbee90b",
-        "name": "tag-top-to-cross-icon-medium",
-        "constant-token-duplicate": false
+        "name": "tag-top-to-cross-icon-medium"
       }
     }
   },
@@ -4801,8 +4365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c9e5e973-4942-414e-b128-5569f62453a2",
-        "name": "tag-top-to-cross-icon-small",
-        "constant-token-duplicate": false
+        "name": "tag-top-to-cross-icon-small"
       }
     }
   },
@@ -4812,8 +4375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "71bc5e67-900e-4e32-8109-a4c18da89348",
-        "name": "text-area-minimum-height",
-        "constant-token-duplicate": false
+        "name": "text-area-minimum-height"
       }
     }
   },
@@ -4823,8 +4385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "69694a85-5f31-43b4-8044-c0f08c83d618",
-        "name": "text-area-minimum-width",
-        "constant-token-duplicate": false
+        "name": "text-area-minimum-width"
       }
     }
   },
@@ -4834,8 +4395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "875bbeaf-b4b7-41b9-8e6f-d6a57ec03049",
-        "name": "text-field-minimum-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "text-field-minimum-width-multiplier"
       }
     }
   },
@@ -4845,8 +4405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0578d5e5-9c2d-46f2-9268-85bdf566b3a5",
-        "name": "thumbnail-size-50",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-50"
       }
     }
   },
@@ -4856,8 +4415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "20706cc7-9d07-4938-8328-debd3ab8d822",
-        "name": "thumbnail-size-75",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-75"
       }
     }
   },
@@ -4867,8 +4425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "46dd2eca-598a-45e3-8c7d-c6cf17e148bf",
-        "name": "thumbnail-size-100",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-100"
       }
     }
   },
@@ -4878,8 +4435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ec457831-d272-4809-a84a-f1e9dcaec495",
-        "name": "thumbnail-size-200",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-200"
       }
     }
   },
@@ -4889,8 +4445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "95c5905f-b209-4e84-881f-13ea85f12d87",
-        "name": "thumbnail-size-300",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-300"
       }
     }
   },
@@ -4900,8 +4455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7ee6d5ae-eb01-49e1-93ba-df3e7c25d876",
-        "name": "thumbnail-size-400",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-400"
       }
     }
   },
@@ -4911,8 +4465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "87234a25-8f6d-457c-9d3f-363930fec12c",
-        "name": "thumbnail-size-500",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-500"
       }
     }
   },
@@ -4922,8 +4475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d533a543-9622-4c43-92a6-82dd5eebcc64",
-        "name": "thumbnail-size-600",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-600"
       }
     }
   },
@@ -4933,8 +4485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d6aaa2c4-d213-44de-9bae-742d26df8765",
-        "name": "thumbnail-size-700",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-700"
       }
     }
   },
@@ -4944,8 +4495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8cee2b4d-48c8-45aa-803b-5d1cd9027fcf",
-        "name": "thumbnail-size-800",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-800"
       }
     }
   },
@@ -4955,8 +4505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5b9fb77d-8a2e-4e1c-ba86-475cd66b4202",
-        "name": "thumbnail-size-900",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-900"
       }
     }
   },
@@ -4966,8 +4515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "48959be8-02f9-45b9-8190-af60c93cbb6c",
-        "name": "thumbnail-size-1000",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-1000"
       }
     }
   },
@@ -4977,8 +4525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "821e8f74-d1de-4507-9ff7-ece44e535e8c",
-        "name": "toast-bottom-to-text",
-        "constant-token-duplicate": false
+        "name": "toast-bottom-to-text"
       }
     }
   },
@@ -4988,8 +4535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a6267318-c8b1-43d4-99b6-ca2a55e9dff4",
-        "name": "toast-height",
-        "constant-token-duplicate": false
+        "name": "toast-height"
       }
     }
   },
@@ -4999,8 +4545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9ac252c8-06dd-48a9-a3d3-ca8ccfb355dd",
-        "name": "toast-maximum-width",
-        "constant-token-duplicate": false
+        "name": "toast-maximum-width"
       }
     }
   },
@@ -5010,8 +4555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "be4f24cf-9334-4fc4-aa72-e0347beecda7",
-        "name": "toast-top-to-text",
-        "constant-token-duplicate": false
+        "name": "toast-top-to-text"
       }
     }
   },
@@ -5021,8 +4565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d10d2a55-2b4d-46b1-81e9-521d6c3578e1",
-        "name": "toast-top-to-workflow-icon",
-        "constant-token-duplicate": false
+        "name": "toast-top-to-workflow-icon"
       }
     }
   },
@@ -5032,8 +4575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e5ba234a-afdd-451e-84e7-51314446cdae",
-        "name": "tooltip-maximum-width",
-        "constant-token-duplicate": false
+        "name": "tooltip-maximum-width"
       }
     }
   },
@@ -5043,8 +4585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "481757aa-c6b5-4281-9a63-feeb1c88aec6",
-        "name": "tooltip-tip-height",
-        "constant-token-duplicate": false
+        "name": "tooltip-tip-height"
       }
     }
   },
@@ -5054,8 +4595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0732bd0e-c5c0-4e58-8fee-2015c1753237",
-        "name": "tooltip-tip-width",
-        "constant-token-duplicate": false
+        "name": "tooltip-tip-width"
       }
     }
   },
@@ -5065,8 +4605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a0093378-0b2c-474b-9fe5-76940fd1398b",
-        "name": "divider-horizontal-minimum-width",
-        "constant-token-duplicate": true
+        "name": "divider-horizontal-minimum-width"
       }
     }
   },
@@ -5076,8 +4615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "299db7d6-66f6-4fcb-890d-223406c85ae4",
-        "name": "divider-vertical-minimum-height",
-        "constant-token-duplicate": true
+        "name": "divider-vertical-minimum-height"
       }
     }
   },
@@ -5087,8 +4625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "74787427-ea2f-4b94-99c0-88454e8be6cf",
-        "name": "tray-top-to-content-area",
-        "constant-token-duplicate": false
+        "name": "tray-top-to-content-area"
       }
     }
   },
@@ -5098,8 +4635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "53fef925-59e3-4df5-9ac2-e2b4d34d9bca",
-        "name": "tooltip-tip-corner-radius",
-        "constant-token-duplicate": true
+        "name": "tooltip-tip-corner-radius"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "70e6d9e7-2a8e-4f0d-96d6-aac7cde829bd",
-        "name": "accordion-bottom-to-text-compact-extra-large",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-compact-extra-large"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b4f92e98-694f-46cc-91be-8e0e2d5a17a4",
-        "name": "accordion-bottom-to-text-compact-large",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-compact-large"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "97b9278a-11d0-4470-99c3-e2d47ca5a714",
-        "name": "accordion-bottom-to-text-compact-medium",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-compact-medium"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "af95123b-2ab5-49bb-a070-1ca48b498f58",
-        "name": "accordion-bottom-to-text-compact-small",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-compact-small"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ae5feb3e-bb5d-4187-b81f-3a42ebf47e78",
-        "name": "accordion-bottom-to-text-regular-extra-large",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-regular-extra-large"
       }
     }
   },
@@ -60,8 +55,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c449b115-2116-45bd-8d3d-03fb806dd460",
-        "name": "accordion-bottom-to-text-regular-large",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-regular-large"
       }
     }
   },
@@ -71,8 +65,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6a83235c-7d94-4cb7-9f6b-6dc82fcb2fb0",
-        "name": "accordion-bottom-to-text-regular-medium",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-regular-medium"
       }
     }
   },
@@ -82,8 +75,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "be3de2dc-7c53-4d8c-91b1-6aed5ea0895e",
-        "name": "accordion-bottom-to-text-regular-small",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-regular-small"
       }
     }
   },
@@ -93,8 +85,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ba11dc6e-fbd8-46bc-94fd-b4d02f654d2d",
-        "name": "accordion-bottom-to-text-spacious-extra-large",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-spacious-extra-large"
       }
     }
   },
@@ -104,8 +95,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2a6fa386-4eba-44d5-b129-c832264fafd9",
-        "name": "accordion-bottom-to-text-spacious-large",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-spacious-large"
       }
     }
   },
@@ -115,8 +105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "05d8a39d-a0d5-496c-810a-f1244c31b169",
-        "name": "accordion-bottom-to-text-spacious-medium",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-spacious-medium"
       }
     }
   },
@@ -126,8 +115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "56a65744-b195-4faf-ab5c-69a8424593f9",
-        "name": "accordion-bottom-to-text-spacious-small",
-        "constant-token-duplicate": false
+        "name": "accordion-bottom-to-text-spacious-small"
       }
     }
   },
@@ -137,8 +125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "48383ab9-1e66-47f9-988b-6f59b7349241",
-        "name": "accordion-content-area-bottom-to-content",
-        "constant-token-duplicate": false
+        "name": "accordion-content-area-bottom-to-content"
       }
     }
   },
@@ -148,8 +135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9c651dee-7d77-414d-930b-7c6b78cfed1b",
-        "name": "accordion-content-area-top-to-content",
-        "constant-token-duplicate": false
+        "name": "accordion-content-area-top-to-content"
       }
     }
   },
@@ -158,9 +144,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "d560c5a0-1fa3-4d94-a4e6-87b71780083b",
-        "name": "accordion-disclosure-indicator-to-text",
-        "constant-token-duplicate": false
+        "uuid": "27b481a4-0ea9-4e1c-a283-4a799d18d642",
+        "name": "accordion-disclosure-indicator-to-text"
       }
     }
   },
@@ -169,9 +154,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "d64e930a-5e7a-4438-801e-25bfe479f73d",
-        "name": "accordion-edge-to-disclosure-indicator",
-        "constant-token-duplicate": false
+        "uuid": "614e6448-c0a4-4ad1-b125-f362e3001a86",
+        "name": "accordion-edge-to-disclosure-indicator"
       }
     }
   },
@@ -180,9 +164,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "186b2461-88fe-41ba-8b1a-dbdb8a731e2f",
-        "name": "accordion-edge-to-text",
-        "constant-token-duplicate": false
+        "uuid": "a9641e89-2c2e-49c3-9662-f530ad23a688",
+        "name": "accordion-edge-to-text"
       }
     }
   },
@@ -191,9 +174,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "f8e8ebaa-a4e5-4874-ae6d-c6b421b2d216",
-        "name": "accordion-focus-indicator-gap",
-        "constant-token-duplicate": false
+        "uuid": "318c5cda-be1b-416b-b1b7-b962e5f45c0c",
+        "name": "accordion-focus-indicator-gap"
       }
     }
   },
@@ -203,8 +185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ae8169fe-1672-4e95-87a5-344ec4d7f163",
-        "name": "accordion-minimum-width",
-        "constant-token-duplicate": false
+        "name": "accordion-minimum-width"
       }
     }
   },
@@ -214,8 +195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bef73b91-db4f-4532-9f4d-f5a81ead625d",
-        "name": "accordion-small-top-to-text-spacious",
-        "constant-token-duplicate": false
+        "name": "accordion-small-top-to-text-spacious"
       }
     }
   },
@@ -225,8 +205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5ebd5aab-49b3-49d1-be25-8aff15217eda",
-        "name": "accordion-top-to-text-compact-extra-large",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-compact-extra-large"
       }
     }
   },
@@ -236,8 +215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c09ca9bf-1b8b-4ff3-93b7-e9296472dc76",
-        "name": "accordion-top-to-text-compact-large",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-compact-large"
       }
     }
   },
@@ -246,9 +224,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "47070193-194e-4211-b767-61ef8aed8723",
-        "name": "accordion-top-to-text-compact-medium",
-        "constant-token-duplicate": false
+        "uuid": "484c9603-07f1-4ba6-b1bf-7cfaec5d1594",
+        "name": "accordion-top-to-text-compact-medium"
       }
     }
   },
@@ -257,9 +234,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "0a5e5c70-d24e-48a2-9445-ccf87de892a9",
-        "name": "accordion-top-to-text-compact-small",
-        "constant-token-duplicate": false
+        "uuid": "d6cc404c-af92-43be-88e3-407fdcb6e068",
+        "name": "accordion-top-to-text-compact-small"
       }
     }
   },
@@ -269,8 +245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "51f14c59-3071-45e7-b919-683c30589da9",
-        "name": "accordion-top-to-text-regular-extra-large",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-regular-extra-large"
       }
     }
   },
@@ -280,8 +255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "96442c10-e84d-4b26-9b49-534597d3193e",
-        "name": "accordion-top-to-text-regular-large",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-regular-large"
       }
     }
   },
@@ -291,8 +265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1dab0630-304c-4087-b21c-83cd0e40b1d4",
-        "name": "accordion-top-to-text-regular-medium",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-regular-medium"
       }
     }
   },
@@ -302,8 +275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1aa82f7b-64d5-4a5c-921c-4b36d0c4bd2d",
-        "name": "accordion-top-to-text-regular-small",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-regular-small"
       }
     }
   },
@@ -313,8 +285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bd300d17-3599-4382-8a7d-1b78700d49e9",
-        "name": "accordion-top-to-text-spacious-extra-large",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-spacious-extra-large"
       }
     }
   },
@@ -324,8 +295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e90553f0-d71e-44c2-b70a-89110fab7c6a",
-        "name": "accordion-top-to-text-spacious-large",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-spacious-large"
       }
     }
   },
@@ -335,8 +305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "63602a66-5f96-4e6a-8bf0-2ac03321a577",
-        "name": "accordion-top-to-text-spacious-medium",
-        "constant-token-duplicate": false
+        "name": "accordion-top-to-text-spacious-medium"
       }
     }
   },
@@ -346,8 +315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4be2cf45-1ba5-4a6f-a004-8d26ecbb4c2f",
-        "name": "action-bar-height",
-        "constant-token-duplicate": false
+        "name": "action-bar-height"
       }
     }
   },
@@ -357,8 +325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b8466a83-3409-47c0-a329-b8e83b83abdb",
-        "name": "action-bar-top-to-item-counter",
-        "constant-token-duplicate": false
+        "name": "action-bar-top-to-item-counter"
       }
     }
   },
@@ -368,8 +335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b4b4710b-2073-4285-8342-31ae6712671b",
-        "name": "action-button-edge-to-hold-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "action-button-edge-to-hold-icon-extra-large"
       }
     }
   },
@@ -378,9 +344,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "d0c7ca7a-e92a-43e4-8b8d-4e4a7f8e9dcc",
-        "name": "action-button-edge-to-hold-icon-extra-small",
-        "constant-token-duplicate": false
+        "uuid": "b79597cc-5294-4555-ab78-f4200e480ac3",
+        "name": "action-button-edge-to-hold-icon-extra-small"
       }
     }
   },
@@ -390,8 +355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "86a36757-a2d1-4263-97dc-62cf4543b3f9",
-        "name": "action-button-edge-to-hold-icon-large",
-        "constant-token-duplicate": false
+        "name": "action-button-edge-to-hold-icon-large"
       }
     }
   },
@@ -401,8 +365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "255a24ab-f70d-4698-8d2e-569c37c6c798",
-        "name": "action-button-edge-to-hold-icon-medium",
-        "constant-token-duplicate": false
+        "name": "action-button-edge-to-hold-icon-medium"
       }
     }
   },
@@ -411,9 +374,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "d94c960b-4248-4422-9a0d-e77b41c6818a",
-        "name": "action-button-edge-to-hold-icon-small",
-        "constant-token-duplicate": false
+        "uuid": "fa106863-0e09-44d4-9465-68cd3254ed2b",
+        "name": "action-button-edge-to-hold-icon-small"
       }
     }
   },
@@ -423,8 +385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5f2b2bc1-ebb0-46dd-a563-58df6307996d",
-        "name": "alert-banner-bottom-to-text",
-        "constant-token-duplicate": false
+        "name": "alert-banner-bottom-to-text"
       }
     }
   },
@@ -434,8 +395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6d313800-3020-45f8-969d-63e81057ff97",
-        "name": "alert-banner-minimum-height",
-        "constant-token-duplicate": false
+        "name": "alert-banner-minimum-height"
       }
     }
   },
@@ -445,8 +405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8db02117-b543-4b3e-b0ff-203e9a821708",
-        "name": "alert-banner-top-to-text",
-        "constant-token-duplicate": false
+        "name": "alert-banner-top-to-text"
       }
     }
   },
@@ -456,8 +415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "402c755b-322c-4ea0-856c-ca209bdaa8ec",
-        "name": "alert-banner-top-to-workflow-icon",
-        "constant-token-duplicate": false
+        "name": "alert-banner-top-to-workflow-icon"
       }
     }
   },
@@ -467,8 +425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b02e6302-d443-4b94-bda9-f4cc90b3d4ca",
-        "name": "alert-banner-width",
-        "constant-token-duplicate": false
+        "name": "alert-banner-width"
       }
     }
   },
@@ -478,8 +435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "43c5762a-d3a6-49db-9e5e-4a524604fecc",
-        "name": "alert-dialog-description-size",
-        "constant-token-duplicate": false
+        "name": "alert-dialog-description-size"
       }
     }
   },
@@ -489,8 +445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "45258afa-543b-4fbc-a621-677d8081c2f1",
-        "name": "alert-dialog-maximum-width",
-        "constant-token-duplicate": true
+        "name": "alert-dialog-maximum-width"
       }
     }
   },
@@ -500,8 +455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7d066c2d-ea59-483d-b8a3-6a9b9e35eedd",
-        "name": "alert-dialog-minimum-width",
-        "constant-token-duplicate": true
+        "name": "alert-dialog-minimum-width"
       }
     }
   },
@@ -511,8 +465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3f362b57-09eb-4147-b366-5c1f04c9a29f",
-        "name": "alert-dialog-title-size",
-        "constant-token-duplicate": false
+        "name": "alert-dialog-title-size"
       }
     }
   },
@@ -522,8 +475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6f6fae3d-eafd-41d7-a863-b2f0b57240ab",
-        "name": "avatar-size-50",
-        "constant-token-duplicate": false
+        "name": "avatar-size-50"
       }
     }
   },
@@ -533,8 +485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f23636e9-93e2-444d-a95b-1311a7e074f3",
-        "name": "avatar-size-75",
-        "constant-token-duplicate": false
+        "name": "avatar-size-75"
       }
     }
   },
@@ -544,8 +495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a2833b95-ba74-4caf-89e6-8294465d2780",
-        "name": "avatar-size-100",
-        "constant-token-duplicate": false
+        "name": "avatar-size-100"
       }
     }
   },
@@ -555,8 +505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7bfa97a1-39a8-4a30-af13-31ce1393098a",
-        "name": "avatar-size-200",
-        "constant-token-duplicate": false
+        "name": "avatar-size-200"
       }
     }
   },
@@ -566,8 +515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b0bd14f7-9642-4e20-90c4-68f38a53e72c",
-        "name": "avatar-size-300",
-        "constant-token-duplicate": false
+        "name": "avatar-size-300"
       }
     }
   },
@@ -577,8 +525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "44237baf-1128-445d-8337-a943c6ac0019",
-        "name": "avatar-size-400",
-        "constant-token-duplicate": false
+        "name": "avatar-size-400"
       }
     }
   },
@@ -588,8 +535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "db33d97e-15e4-4248-a8cf-4b69d745a2e0",
-        "name": "avatar-size-500",
-        "constant-token-duplicate": false
+        "name": "avatar-size-500"
       }
     }
   },
@@ -599,8 +545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9ea7c014-2c8d-403f-ad7f-fa3c08a3a46d",
-        "name": "avatar-size-600",
-        "constant-token-duplicate": false
+        "name": "avatar-size-600"
       }
     }
   },
@@ -610,8 +555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0bec4f0f-efb2-44f9-a131-28f8fe248c40",
-        "name": "avatar-size-700",
-        "constant-token-duplicate": false
+        "name": "avatar-size-700"
       }
     }
   },
@@ -621,8 +565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "971f1589-f80b-4c1e-8814-b5c286c5f561",
-        "name": "breadcrumbs-bottom-to-text",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-bottom-to-text"
       }
     }
   },
@@ -632,8 +575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d783bd6f-fc7a-4be4-b53a-b8be86018b7b",
-        "name": "breadcrumbs-bottom-to-text-compact",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-bottom-to-text-compact"
       }
     }
   },
@@ -643,8 +585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a51a1142-e38e-4055-bd45-ad2bd0045880",
-        "name": "breadcrumbs-bottom-to-text-multiline",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-bottom-to-text-multiline"
       }
     }
   },
@@ -654,8 +595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "99ef1a0d-5fe1-4b62-9609-8929e7a3bf9c",
-        "name": "breadcrumbs-end-edge-to-text",
-        "constant-token-duplicate": true
+        "name": "breadcrumbs-end-edge-to-text"
       }
     }
   },
@@ -665,8 +605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2d39863c-6987-413c-90d8-07fcc506a0d4",
-        "name": "breadcrumbs-height",
-        "constant-token-duplicate": true
+        "name": "breadcrumbs-height"
       }
     }
   },
@@ -676,8 +615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8393f599-37e8-484a-a1c6-0934ce15a507",
-        "name": "breadcrumbs-height-compact",
-        "constant-token-duplicate": true
+        "name": "breadcrumbs-height-compact"
       }
     }
   },
@@ -687,8 +625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5e7426da-1a1e-4d37-8c96-4fdac06bfad5",
-        "name": "breadcrumbs-height-multiline",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-height-multiline"
       }
     }
   },
@@ -698,8 +635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "571239ce-690f-49ee-9e71-d14bbfe4b279",
-        "name": "breadcrumbs-separator-icon-to-bottom-text-multiline",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-separator-icon-to-bottom-text-multiline"
       }
     }
   },
@@ -709,8 +645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6d632147-5a1e-4a19-9fca-019b234d0455",
-        "name": "breadcrumbs-start-edge-to-text",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-start-edge-to-text"
       }
     }
   },
@@ -720,8 +655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b1fba444-c281-4be4-bded-4852b551cfee",
-        "name": "breadcrumbs-start-edge-to-truncated-menu",
-        "constant-token-duplicate": true
+        "name": "breadcrumbs-start-edge-to-truncated-menu"
       }
     }
   },
@@ -731,8 +665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b93aad22-aff0-46d5-b54e-17891f02124a",
-        "name": "breadcrumbs-top-text-to-bottom-text",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-text-to-bottom-text"
       }
     }
   },
@@ -742,8 +675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "882046d8-7111-4020-bf31-b8eb9d9013e0",
-        "name": "breadcrumbs-top-to-separator-icon",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-separator-icon"
       }
     }
   },
@@ -753,8 +685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f6c5b011-ec25-42ea-a708-d7dca1b5fb5a",
-        "name": "breadcrumbs-top-to-separator-icon-compact",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-separator-icon-compact"
       }
     }
   },
@@ -764,8 +695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "eb3b2566-6fc1-4a2c-a8cf-e40af3d34715",
-        "name": "breadcrumbs-top-to-separator-icon-multiline",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-separator-icon-multiline"
       }
     }
   },
@@ -775,8 +705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c4e58bb6-dcd7-4b64-b881-5b918c346989",
-        "name": "breadcrumbs-top-to-text",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-text"
       }
     }
   },
@@ -786,8 +715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "da5c0b1f-a8df-407c-888f-ac62d1fefa7c",
-        "name": "breadcrumbs-top-to-text-compact",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-text-compact"
       }
     }
   },
@@ -797,8 +725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ea82fc23-82e7-4116-a8bb-186a253675ad",
-        "name": "breadcrumbs-top-to-text-multiline",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-text-multiline"
       }
     }
   },
@@ -808,8 +735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "793da276-18a6-46d0-a0e5-a1676c4df583",
-        "name": "breadcrumbs-top-to-truncated-menu",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-truncated-menu"
       }
     }
   },
@@ -819,8 +745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d5e92b0a-6d37-4b77-a5d0-6c4f1b9a722c",
-        "name": "breadcrumbs-top-to-truncated-menu-compact",
-        "constant-token-duplicate": false
+        "name": "breadcrumbs-top-to-truncated-menu-compact"
       }
     }
   },
@@ -830,8 +755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2285d870-68ec-469f-a034-2fdeb31e33f0",
-        "name": "breadcrumbs-truncated-menu-to-bottom-text",
-        "constant-token-duplicate": true
+        "name": "breadcrumbs-truncated-menu-to-bottom-text"
       }
     }
   },
@@ -841,8 +765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1fe2a3df-3179-4c4a-8d1f-de41297b6d74",
-        "name": "breadcrumbs-truncated-menu-to-separator-icon",
-        "constant-token-duplicate": true
+        "name": "breadcrumbs-truncated-menu-to-separator-icon"
       }
     }
   },
@@ -852,8 +775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "68b6ac88-d229-460d-8d59-3f5c141db358",
-        "name": "button-minimum-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "button-minimum-width-multiplier"
       }
     }
   },
@@ -863,8 +785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "55db9f3d-621d-4d23-b3d0-c0f2b0f3f9b0",
-        "name": "card-minimum-width",
-        "constant-token-duplicate": true
+        "name": "card-minimum-width"
       }
     }
   },
@@ -874,8 +795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "58eb5be8-644f-448e-99b9-94d1fbb93240",
-        "name": "card-preview-minimum-height",
-        "constant-token-duplicate": true
+        "name": "card-preview-minimum-height"
       }
     }
   },
@@ -885,8 +805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "496fd060-70a9-48d0-948f-593b81847199",
-        "name": "card-selection-background-size",
-        "constant-token-duplicate": true
+        "name": "card-selection-background-size"
       }
     }
   },
@@ -896,8 +815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "13093f8b-e38e-449f-a982-7f960bb84dfa",
-        "name": "checkbox-control-size-extra-large",
-        "constant-token-duplicate": false
+        "name": "checkbox-control-size-extra-large"
       }
     }
   },
@@ -907,8 +825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b4367578-989e-438d-9a3e-7cb077f2f7c9",
-        "name": "checkbox-control-size-large",
-        "constant-token-duplicate": false
+        "name": "checkbox-control-size-large"
       }
     }
   },
@@ -918,8 +835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "00fee3f7-a743-45d6-a2b6-028d5d96964a",
-        "name": "checkbox-control-size-medium",
-        "constant-token-duplicate": false
+        "name": "checkbox-control-size-medium"
       }
     }
   },
@@ -929,8 +845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "af31c1a5-ffce-4a54-8862-3e711ca53d25",
-        "name": "checkbox-control-size-small",
-        "constant-token-duplicate": false
+        "name": "checkbox-control-size-small"
       }
     }
   },
@@ -940,8 +855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b3be5ac8-2415-4490-8b4a-c08661ec84d1",
-        "name": "checkbox-top-to-control-extra-large",
-        "constant-token-duplicate": false
+        "name": "checkbox-top-to-control-extra-large"
       }
     }
   },
@@ -951,8 +865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d040d2f4-9bb4-4d27-adac-40fef079d958",
-        "name": "checkbox-top-to-control-large",
-        "constant-token-duplicate": false
+        "name": "checkbox-top-to-control-large"
       }
     }
   },
@@ -962,8 +875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e3751526-2db9-421c-85f9-d60071aac49b",
-        "name": "checkbox-top-to-control-medium",
-        "constant-token-duplicate": false
+        "name": "checkbox-top-to-control-medium"
       }
     }
   },
@@ -973,8 +885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f254146e-f469-44b1-b0c9-1ac72e88f9e3",
-        "name": "checkbox-top-to-control-small",
-        "constant-token-duplicate": false
+        "name": "checkbox-top-to-control-small"
       }
     }
   },
@@ -984,8 +895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a0abef77-dafe-4158-9faa-a4b4b2871e54",
-        "name": "coach-mark-body-size",
-        "constant-token-duplicate": false
+        "name": "coach-mark-body-size"
       }
     }
   },
@@ -995,8 +905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "11fb0ab2-d6a0-4da8-9c83-c1f6b918406a",
-        "name": "coach-mark-edge-to-content",
-        "constant-token-duplicate": false
+        "name": "coach-mark-edge-to-content"
       }
     }
   },
@@ -1006,8 +915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7f8346b2-f8bf-441d-8412-2a2a28cf4b90",
-        "name": "coach-mark-maximum-width",
-        "constant-token-duplicate": false
+        "name": "coach-mark-maximum-width"
       }
     }
   },
@@ -1017,8 +925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "45b31e46-b878-40a2-a28a-91c480f45253",
-        "name": "coach-mark-media-height",
-        "constant-token-duplicate": false
+        "name": "coach-mark-media-height"
       }
     }
   },
@@ -1028,8 +935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "53703e12-f837-4573-bd44-e4727ed2aeaa",
-        "name": "coach-mark-media-minimum-height",
-        "constant-token-duplicate": false
+        "name": "coach-mark-media-minimum-height"
       }
     }
   },
@@ -1039,8 +945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9004d69e-5726-42f5-a4d0-de09db2de784",
-        "name": "coach-mark-minimum-width",
-        "constant-token-duplicate": false
+        "name": "coach-mark-minimum-width"
       }
     }
   },
@@ -1050,8 +955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "350d9235-ff9e-43d7-9298-56b36d58d6de",
-        "name": "coach-mark-pagination-body-size",
-        "constant-token-duplicate": false
+        "name": "coach-mark-pagination-body-size"
       }
     }
   },
@@ -1061,8 +965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cd48e6b7-a4d8-4a22-8d65-531d770a9898",
-        "name": "coach-mark-pagination-text-to-bottom-edge",
-        "constant-token-duplicate": false
+        "name": "coach-mark-pagination-text-to-bottom-edge"
       }
     }
   },
@@ -1072,8 +975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cd4848b6-d560-475a-9d80-f7b5acebce10",
-        "name": "coach-mark-title-size",
-        "constant-token-duplicate": false
+        "name": "coach-mark-title-size"
       }
     }
   },
@@ -1083,8 +985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b3f14387-44fd-43d3-a152-c8e691ef87df",
-        "name": "coach-mark-width",
-        "constant-token-duplicate": false
+        "name": "coach-mark-width"
       }
     }
   },
@@ -1094,8 +995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ab656bf4-8814-42fa-9036-b1e67159e4e1",
-        "name": "color-area-border-rounding",
-        "constant-token-duplicate": true
+        "name": "color-area-border-rounding"
       }
     }
   },
@@ -1105,8 +1005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "78fff16d-d6fe-4a74-98bc-97c56e352250",
-        "name": "color-area-border-width",
-        "constant-token-duplicate": true
+        "name": "color-area-border-width"
       }
     }
   },
@@ -1116,8 +1015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "552a014a-c590-48f8-98dc-26849b62c3ab",
-        "name": "color-area-height",
-        "constant-token-duplicate": false
+        "name": "color-area-height"
       }
     }
   },
@@ -1127,8 +1025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9b84d54e-2b10-4502-b072-ded2a8bf9cb3",
-        "name": "color-area-minimum-height",
-        "constant-token-duplicate": false
+        "name": "color-area-minimum-height"
       }
     }
   },
@@ -1138,8 +1035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "126cd0b8-55cc-489c-9582-fddde76b431c",
-        "name": "color-area-minimum-width",
-        "constant-token-duplicate": false
+        "name": "color-area-minimum-width"
       }
     }
   },
@@ -1149,8 +1045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e5daae6b-7040-4e80-a251-db4c8c79e113",
-        "name": "color-area-width",
-        "constant-token-duplicate": false
+        "name": "color-area-width"
       }
     }
   },
@@ -1160,8 +1055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8ec9adae-0093-42f4-bd1b-6f3b2279996b",
-        "name": "color-handle-border-width",
-        "constant-token-duplicate": true
+        "name": "color-handle-border-width"
       }
     }
   },
@@ -1171,8 +1065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "29e4a8c8-33ba-44b3-952d-26f3fd6ae4f0",
-        "name": "color-handle-drop-shadow-blur",
-        "constant-token-duplicate": true
+        "name": "color-handle-drop-shadow-blur"
       }
     }
   },
@@ -1182,8 +1075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "49499527-3fdb-4a91-a832-0ae0631ba3bb",
-        "name": "color-handle-drop-shadow-x",
-        "constant-token-duplicate": true
+        "name": "color-handle-drop-shadow-x"
       }
     }
   },
@@ -1193,8 +1085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "05b11927-d0cd-46a6-ae30-6f268f143d4e",
-        "name": "color-handle-drop-shadow-y",
-        "constant-token-duplicate": true
+        "name": "color-handle-drop-shadow-y"
       }
     }
   },
@@ -1204,8 +1095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "945e0167-6893-49dd-ab21-886f93f70b92",
-        "name": "color-handle-inner-border-width",
-        "constant-token-duplicate": true
+        "name": "color-handle-inner-border-width"
       }
     }
   },
@@ -1215,8 +1105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fbf27473-7c97-4d94-968d-c3e68e0cd242",
-        "name": "color-handle-outer-border-width",
-        "constant-token-duplicate": true
+        "name": "color-handle-outer-border-width"
       }
     }
   },
@@ -1226,8 +1115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b81cc6a6-390f-43dc-a6c8-dd335c177da3",
-        "name": "color-handle-size",
-        "constant-token-duplicate": false
+        "name": "color-handle-size"
       }
     }
   },
@@ -1237,8 +1125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "feddbfb7-7f1a-4eee-9cbf-b393aafb7385",
-        "name": "color-handle-size-key-focus",
-        "constant-token-duplicate": false
+        "name": "color-handle-size-key-focus"
       }
     }
   },
@@ -1248,8 +1135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "92beba60-f61d-426a-a864-203dca7244a0",
-        "name": "color-loupe-bottom-to-color-handle",
-        "constant-token-duplicate": true
+        "name": "color-loupe-bottom-to-color-handle"
       }
     }
   },
@@ -1259,8 +1145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "86caa027-9e9e-4a5f-aa38-058f0a96bc9d",
-        "name": "color-loupe-drop-shadow-blur",
-        "constant-token-duplicate": true
+        "name": "color-loupe-drop-shadow-blur"
       }
     }
   },
@@ -1270,8 +1155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c9af5d60-11b1-4fc3-972e-6a607120657b",
-        "name": "color-loupe-drop-shadow-y",
-        "constant-token-duplicate": true
+        "name": "color-loupe-drop-shadow-y"
       }
     }
   },
@@ -1281,8 +1165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0f7e8b9e-99e5-4f5a-ae80-99f65f4c4e51",
-        "name": "color-loupe-height",
-        "constant-token-duplicate": true
+        "name": "color-loupe-height"
       }
     }
   },
@@ -1292,8 +1175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b3900f89-0a7a-4c47-a6d9-ca8aa19b9bfb",
-        "name": "color-loupe-inner-border-width",
-        "constant-token-duplicate": true
+        "name": "color-loupe-inner-border-width"
       }
     }
   },
@@ -1303,8 +1185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "51cd5039-1319-451a-b13f-bb3a218238a5",
-        "name": "color-loupe-outer-border-width",
-        "constant-token-duplicate": true
+        "name": "color-loupe-outer-border-width"
       }
     }
   },
@@ -1314,8 +1195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "889e2495-b882-4aa3-8a5b-1a71d44edde4",
-        "name": "color-loupe-width",
-        "constant-token-duplicate": true
+        "name": "color-loupe-width"
       }
     }
   },
@@ -1325,8 +1205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "991541a2-df44-4f32-90a5-de698adf5db3",
-        "name": "color-slider-border-rounding",
-        "constant-token-duplicate": true
+        "name": "color-slider-border-rounding"
       }
     }
   },
@@ -1336,8 +1215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2b907cad-7534-411b-b3bf-ab89a3712ad8",
-        "name": "color-slider-border-width",
-        "constant-token-duplicate": true
+        "name": "color-slider-border-width"
       }
     }
   },
@@ -1347,8 +1225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c42de1ce-088a-4918-a7dc-36507c8acedf",
-        "name": "color-slider-length",
-        "constant-token-duplicate": false
+        "name": "color-slider-length"
       }
     }
   },
@@ -1358,8 +1235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "120308f7-4220-420e-b836-20176a8184b7",
-        "name": "color-slider-minimum-length",
-        "constant-token-duplicate": false
+        "name": "color-slider-minimum-length"
       }
     }
   },
@@ -1369,8 +1245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4b6bca16-ea29-4d6c-81cf-9005b9a3b5e5",
-        "name": "color-wheel-color-area-margin",
-        "constant-token-duplicate": true
+        "name": "color-wheel-color-area-margin"
       }
     }
   },
@@ -1380,8 +1255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6733cd28-a949-40f7-bd36-034af9c0261f",
-        "name": "color-wheel-minimum-width",
-        "constant-token-duplicate": false
+        "name": "color-wheel-minimum-width"
       }
     }
   },
@@ -1391,8 +1265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "81d866f0-e2a6-4f27-bb22-6675cce4e937",
-        "name": "color-wheel-width",
-        "constant-token-duplicate": false
+        "name": "color-wheel-width"
       }
     }
   },
@@ -1402,8 +1275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "eabcc77a-f263-43ed-9944-9daa78a56b66",
-        "name": "combo-box-minimum-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "combo-box-minimum-width-multiplier"
       }
     }
   },
@@ -1413,8 +1285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4798728b-9a97-4ce1-b703-0182b1513e8b",
-        "name": "combo-box-quiet-minimum-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "combo-box-quiet-minimum-width-multiplier"
       }
     }
   },
@@ -1424,8 +1295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "50ecd11d-6710-46e9-b1c6-923bb1d9f494",
-        "name": "combo-box-visual-to-field-button-extra-large",
-        "constant-token-duplicate": false
+        "name": "combo-box-visual-to-field-button-extra-large"
       }
     }
   },
@@ -1435,8 +1305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1a529788-8b87-4eef-aa07-a4ffb955761c",
-        "name": "combo-box-visual-to-field-button-large",
-        "constant-token-duplicate": false
+        "name": "combo-box-visual-to-field-button-large"
       }
     }
   },
@@ -1446,8 +1315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fefb7088-21e0-4cdf-a8a4-af2a6dcc2a1a",
-        "name": "combo-box-visual-to-field-button-medium",
-        "constant-token-duplicate": false
+        "name": "combo-box-visual-to-field-button-medium"
       }
     }
   },
@@ -1457,8 +1325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "292cbbe1-1ba4-4369-9768-2051c07e6406",
-        "name": "combo-box-visual-to-field-button-quiet",
-        "constant-token-duplicate": true
+        "name": "combo-box-visual-to-field-button-quiet"
       }
     }
   },
@@ -1468,8 +1335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4ccba158-da29-43a1-bbba-6531ecf98807",
-        "name": "combo-box-visual-to-field-button-small",
-        "constant-token-duplicate": false
+        "name": "combo-box-visual-to-field-button-small"
       }
     }
   },
@@ -1479,8 +1345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c180fa75-254e-4ee1-8b79-31a3d90254cc",
-        "name": "contextual-help-body-size",
-        "constant-token-duplicate": false
+        "name": "contextual-help-body-size"
       }
     }
   },
@@ -1490,8 +1355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "83be73fe-50bc-4be8-969c-0361a816225b",
-        "name": "contextual-help-minimum-width",
-        "constant-token-duplicate": true
+        "name": "contextual-help-minimum-width"
       }
     }
   },
@@ -1501,8 +1365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e91709ce-79e3-4a81-88fa-e124960d4389",
-        "name": "contextual-help-title-size",
-        "constant-token-duplicate": false
+        "name": "contextual-help-title-size"
       }
     }
   },
@@ -1512,8 +1375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "913cce2a-c928-4803-9bd6-3fb1e0fcbee5",
-        "name": "divider-thickness-large",
-        "constant-token-duplicate": true
+        "name": "divider-thickness-large"
       }
     }
   },
@@ -1523,8 +1385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3cf3e962-92f3-4334-8b92-9a1da9396c25",
-        "name": "divider-thickness-medium",
-        "constant-token-duplicate": true
+        "name": "divider-thickness-medium"
       }
     }
   },
@@ -1534,8 +1395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9dcc27ef-7044-4051-97f3-2fd64a5d0a36",
-        "name": "divider-thickness-small",
-        "constant-token-duplicate": true
+        "name": "divider-thickness-small"
       }
     }
   },
@@ -1545,8 +1405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bb3fee51-24cc-4643-9f22-fa1592ab2457",
-        "name": "drop-zone-body-size",
-        "constant-token-duplicate": true
+        "name": "drop-zone-body-size"
       }
     }
   },
@@ -1556,8 +1415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "47c15433-53d3-425b-8b87-ea234701f781",
-        "name": "drop-zone-border-dash-gap",
-        "constant-token-duplicate": true
+        "name": "drop-zone-border-dash-gap"
       }
     }
   },
@@ -1567,8 +1425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a596af57-256f-4445-b91f-36e47bfb2d95",
-        "name": "drop-zone-border-dash-length",
-        "constant-token-duplicate": true
+        "name": "drop-zone-border-dash-length"
       }
     }
   },
@@ -1578,8 +1435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "013387e8-8925-4bb4-a8ee-94420141fde9",
-        "name": "drop-zone-cjk-title-size",
-        "constant-token-duplicate": true
+        "name": "drop-zone-cjk-title-size"
       }
     }
   },
@@ -1589,8 +1445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b8d0db71-9a25-46fc-b77a-037fcf86be8e",
-        "name": "drop-zone-content-maximum-width",
-        "constant-token-duplicate": true
+        "name": "drop-zone-content-maximum-width"
       }
     }
   },
@@ -1600,8 +1455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "edc68bfe-7ad3-4a12-81fa-ded8fb6fc2e3",
-        "name": "drop-zone-title-size",
-        "constant-token-duplicate": true
+        "name": "drop-zone-title-size"
       }
     }
   },
@@ -1611,8 +1465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2097b13e-94b3-4a06-a0af-c7d8420d1273",
-        "name": "drop-zone-width",
-        "constant-token-duplicate": true
+        "name": "drop-zone-width"
       }
     }
   },
@@ -1622,8 +1475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "17ba788d-da38-455d-9322-16e4f05ea923",
-        "name": "field-label-text-to-asterisk-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-label-text-to-asterisk-extra-large"
       }
     }
   },
@@ -1633,8 +1485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "87149afe-899b-4fb6-bd7c-d2becf8117fc",
-        "name": "field-label-text-to-asterisk-large",
-        "constant-token-duplicate": false
+        "name": "field-label-text-to-asterisk-large"
       }
     }
   },
@@ -1644,8 +1495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2fbc4add-e6b4-4dfa-9a7d-0de628b2f63c",
-        "name": "field-label-text-to-asterisk-medium",
-        "constant-token-duplicate": false
+        "name": "field-label-text-to-asterisk-medium"
       }
     }
   },
@@ -1655,8 +1505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4271498d-747c-423d-87cc-761b8a181f7c",
-        "name": "field-label-text-to-asterisk-small",
-        "constant-token-duplicate": false
+        "name": "field-label-text-to-asterisk-small"
       }
     }
   },
@@ -1666,8 +1515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4738ec46-a43c-48f9-aeca-87863275dc4d",
-        "name": "field-label-to-component",
-        "constant-token-duplicate": true
+        "name": "field-label-to-component"
       }
     }
   },
@@ -1677,8 +1525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e1298748-d7cc-4bff-93bc-745b777fcf9e",
-        "name": "field-label-to-component-quiet-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-label-to-component-quiet-extra-large"
       }
     }
   },
@@ -1688,8 +1535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c29cfb87-34e7-4397-bfd8-23378ecbb011",
-        "name": "field-label-to-component-quiet-large",
-        "constant-token-duplicate": false
+        "name": "field-label-to-component-quiet-large"
       }
     }
   },
@@ -1699,8 +1545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "074489d2-66b0-4198-94fe-9818279bbf0f",
-        "name": "field-label-to-component-quiet-medium",
-        "constant-token-duplicate": false
+        "name": "field-label-to-component-quiet-medium"
       }
     }
   },
@@ -1710,8 +1555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2d3e67ce-de6d-4e41-bcf8-06b09c0bcce7",
-        "name": "field-label-to-component-quiet-small",
-        "constant-token-duplicate": false
+        "name": "field-label-to-component-quiet-small"
       }
     }
   },
@@ -1720,9 +1564,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "c4c5e251-d514-42cf-b9e3-56694910e95b",
-        "name": "field-label-top-margin-extra-large",
-        "constant-token-duplicate": false
+        "uuid": "5c14d528-fe17-4b0b-a123-edbdb93fd173",
+        "name": "field-label-top-margin-extra-large"
       }
     }
   },
@@ -1731,9 +1574,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "f83b208f-dfdb-49a8-aedd-08fe8c7a86a9",
-        "name": "field-label-top-margin-large",
-        "constant-token-duplicate": false
+        "uuid": "f7dd90d8-91e6-4090-a5a9-6b30087860a4",
+        "name": "field-label-top-margin-large"
       }
     }
   },
@@ -1742,9 +1584,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "9d00a023-3a33-4b98-819e-3229e03d103b",
-        "name": "field-label-top-margin-medium",
-        "constant-token-duplicate": false
+        "uuid": "b5243f56-7985-4686-b41f-9b9b9a18b047",
+        "name": "field-label-top-margin-medium"
       }
     }
   },
@@ -1753,9 +1594,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "3240fc8b-c1de-42bd-a004-9b27748f5574",
-        "name": "field-label-top-margin-small",
-        "constant-token-duplicate": false
+        "uuid": "ab718f97-15c3-4b8b-aee7-b50b09ec0a33",
+        "name": "field-label-top-margin-small"
       }
     }
   },
@@ -1765,8 +1605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5227bf07-140a-49c6-88f9-cc454d8a90c1",
-        "name": "field-label-top-to-asterisk-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-label-top-to-asterisk-extra-large"
       }
     }
   },
@@ -1776,8 +1615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e410a804-2655-4bbc-9b66-53a5facc92ac",
-        "name": "field-label-top-to-asterisk-large",
-        "constant-token-duplicate": false
+        "name": "field-label-top-to-asterisk-large"
       }
     }
   },
@@ -1787,8 +1625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6f65ad1a-4a65-4b83-af44-5bd893f3b40e",
-        "name": "field-label-top-to-asterisk-medium",
-        "constant-token-duplicate": false
+        "name": "field-label-top-to-asterisk-medium"
       }
     }
   },
@@ -1798,8 +1635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ec0c072f-50fb-4934-99fc-a2576062e7b4",
-        "name": "field-label-top-to-asterisk-small",
-        "constant-token-duplicate": false
+        "name": "field-label-top-to-asterisk-small"
       }
     }
   },
@@ -1809,8 +1645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "82e8cf04-7eda-4f36-8d2c-fda63241c3de",
-        "name": "floating-action-button-drop-shadow-blur",
-        "constant-token-duplicate": true
+        "name": "floating-action-button-drop-shadow-blur"
       }
     }
   },
@@ -1820,8 +1655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a4ddc1a6-1367-4153-bb7c-c217d16d10f4",
-        "name": "floating-action-button-drop-shadow-y",
-        "constant-token-duplicate": true
+        "name": "floating-action-button-drop-shadow-y"
       }
     }
   },
@@ -1831,8 +1665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f99eb317-ebe5-43e7-8066-982fe7a9a8aa",
-        "name": "help-text-to-component",
-        "constant-token-duplicate": true
+        "name": "help-text-to-component"
       }
     }
   },
@@ -1841,9 +1674,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "251c39cc-f949-4055-aecb-42fc99f9d504",
-        "name": "help-text-top-to-workflow-icon-extra-large",
-        "constant-token-duplicate": false
+        "uuid": "bec914a9-5905-40ac-bd61-a727016c1228",
+        "name": "help-text-top-to-workflow-icon-extra-large"
       }
     }
   },
@@ -1852,9 +1684,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "e2c40309-5b3d-485a-bafa-9015a5b751e7",
-        "name": "help-text-top-to-workflow-icon-large",
-        "constant-token-duplicate": false
+        "uuid": "54cae12b-5f21-47b4-a964-6033bd025975",
+        "name": "help-text-top-to-workflow-icon-large"
       }
     }
   },
@@ -1863,9 +1694,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "b690bd12-855e-444d-8b76-a7ae948e3f52",
-        "name": "help-text-top-to-workflow-icon-medium",
-        "constant-token-duplicate": false
+        "uuid": "d159b313-4def-493a-adcf-398e2d1fce9f",
+        "name": "help-text-top-to-workflow-icon-medium"
       }
     }
   },
@@ -1874,9 +1704,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "00334ebf-5706-4a97-b02c-9f41642c4795",
-        "name": "help-text-top-to-workflow-icon-small",
-        "constant-token-duplicate": false
+        "uuid": "91cb19ef-63fc-4d98-a61e-a5f55951f656",
+        "name": "help-text-top-to-workflow-icon-small"
       }
     }
   },
@@ -1886,8 +1715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f3ba73a4-16ba-44a4-abf2-9893e8f02344",
-        "name": "illustrated-message-body-size",
-        "constant-token-duplicate": false
+        "name": "illustrated-message-body-size"
       }
     }
   },
@@ -1897,8 +1725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "00c938e6-e62e-4bc3-8884-cf23b10e286c",
-        "name": "illustrated-message-cjk-title-size",
-        "constant-token-duplicate": false
+        "name": "illustrated-message-cjk-title-size"
       }
     }
   },
@@ -1908,8 +1735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0e464925-5524-4fcc-a2f1-54ef42a2990a",
-        "name": "illustrated-message-maximum-width",
-        "constant-token-duplicate": true
+        "name": "illustrated-message-maximum-width"
       }
     }
   },
@@ -1919,8 +1745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cfca5a29-7073-4627-8a61-27d37552dc03",
-        "name": "illustrated-message-title-size",
-        "constant-token-duplicate": false
+        "name": "illustrated-message-title-size"
       }
     }
   },
@@ -1930,8 +1755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d563157b-f0d7-407d-aaaf-ae1790c75503",
-        "name": "in-field-button-edge-to-disclosure-icon-stacked-extra-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-edge-to-disclosure-icon-stacked-extra-large"
       }
     }
   },
@@ -1941,8 +1765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6a6e5478-b549-4a39-a7f5-5d3c417464ce",
-        "name": "in-field-button-edge-to-disclosure-icon-stacked-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-edge-to-disclosure-icon-stacked-large"
       }
     }
   },
@@ -1952,8 +1775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ccb60cfc-86fe-4959-b4a8-1a45835132c8",
-        "name": "in-field-button-edge-to-disclosure-icon-stacked-medium",
-        "constant-token-duplicate": true
+        "name": "in-field-button-edge-to-disclosure-icon-stacked-medium"
       }
     }
   },
@@ -1963,8 +1785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8b6a0ab1-4dba-4da2-9c67-3befca0f110e",
-        "name": "in-field-button-edge-to-disclosure-icon-stacked-small",
-        "constant-token-duplicate": true
+        "name": "in-field-button-edge-to-disclosure-icon-stacked-small"
       }
     }
   },
@@ -1974,8 +1795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5bffe992-2982-49e8-aa3a-e4e93c884f43",
-        "name": "in-field-button-edge-to-fill",
-        "constant-token-duplicate": true
+        "name": "in-field-button-edge-to-fill"
       }
     }
   },
@@ -1985,8 +1805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f8ed9a70-58f1-4f1a-9e87-24bca6d7b4e1",
-        "name": "in-field-button-fill-stacked-inner-border-rounding",
-        "constant-token-duplicate": true
+        "name": "in-field-button-fill-stacked-inner-border-rounding"
       }
     }
   },
@@ -1996,8 +1815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c47499c1-b89f-49a7-bbb5-17e83e4b306e",
-        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-extra-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-extra-large"
       }
     }
   },
@@ -2007,8 +1825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "710ebe58-f0d8-4d6b-8974-0be1f2f48dc4",
-        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-large"
       }
     }
   },
@@ -2018,8 +1835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3dd5babb-5026-4f28-89ae-bfe687673f31",
-        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-medium",
-        "constant-token-duplicate": true
+        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-medium"
       }
     }
   },
@@ -2029,8 +1845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6c1330a4-1c89-45a7-b2b1-8cbcaf20b9ab",
-        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-small",
-        "constant-token-duplicate": true
+        "name": "in-field-button-inner-edge-to-disclosure-icon-stacked-small"
       }
     }
   },
@@ -2040,8 +1855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "391e1e67-1677-4f60-a09a-3b49bacd01f5",
-        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-extra-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-extra-large"
       }
     }
   },
@@ -2051,8 +1865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "acc9c48a-f461-48ff-9f69-0224c4feabc6",
-        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-large"
       }
     }
   },
@@ -2062,8 +1875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a87d68bb-4249-43cd-947d-bd061baba0ef",
-        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-medium",
-        "constant-token-duplicate": true
+        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-medium"
       }
     }
   },
@@ -2073,8 +1885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9890df35-2d45-4767-9cbe-ee745d09d990",
-        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-small",
-        "constant-token-duplicate": true
+        "name": "in-field-button-outer-edge-to-disclosure-icon-stacked-small"
       }
     }
   },
@@ -2084,8 +1895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "56b54ece-0ff3-4957-9c1c-9e7fb992653c",
-        "name": "in-field-button-stacked-inner-edge-to-fill",
-        "constant-token-duplicate": true
+        "name": "in-field-button-stacked-inner-edge-to-fill"
       }
     }
   },
@@ -2095,8 +1905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5f844b3f-e0d7-40f0-a754-a14bee6a0fb4",
-        "name": "in-field-button-width-stacked-extra-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-width-stacked-extra-large"
       }
     }
   },
@@ -2106,8 +1915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4e103763-4310-4aff-980f-652ad023084f",
-        "name": "in-field-button-width-stacked-large",
-        "constant-token-duplicate": true
+        "name": "in-field-button-width-stacked-large"
       }
     }
   },
@@ -2117,8 +1925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bb8c7ce0-1766-47f9-b30e-36b3b57dc2ea",
-        "name": "in-field-button-width-stacked-medium",
-        "constant-token-duplicate": true
+        "name": "in-field-button-width-stacked-medium"
       }
     }
   },
@@ -2128,8 +1935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "24125066-c8d1-4c4a-85b3-493d112d3ca0",
-        "name": "in-field-button-width-stacked-small",
-        "constant-token-duplicate": true
+        "name": "in-field-button-width-stacked-small"
       }
     }
   },
@@ -2139,8 +1945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8007ebd8-fd67-4dc2-8444-9e6a50c88675",
-        "name": "in-line-alert-minimum-width",
-        "constant-token-duplicate": true
+        "name": "in-line-alert-minimum-width"
       }
     }
   },
@@ -2150,8 +1955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3385c12f-199b-4e9d-b2e2-ef6e2658d180",
-        "name": "menu-item-edge-to-content-not-selected-extra-large",
-        "constant-token-duplicate": false
+        "name": "menu-item-edge-to-content-not-selected-extra-large"
       }
     }
   },
@@ -2161,8 +1965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "90385dcc-ea45-466f-ba4d-a1b13f6a079c",
-        "name": "menu-item-edge-to-content-not-selected-large",
-        "constant-token-duplicate": false
+        "name": "menu-item-edge-to-content-not-selected-large"
       }
     }
   },
@@ -2172,8 +1975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5faa4858-5590-40d4-bd12-b4c839908c4c",
-        "name": "menu-item-edge-to-content-not-selected-medium",
-        "constant-token-duplicate": false
+        "name": "menu-item-edge-to-content-not-selected-medium"
       }
     }
   },
@@ -2183,8 +1985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "de2ef572-54a2-46c2-ad1d-60468fbe6090",
-        "name": "menu-item-edge-to-content-not-selected-small",
-        "constant-token-duplicate": false
+        "name": "menu-item-edge-to-content-not-selected-small"
       }
     }
   },
@@ -2194,8 +1995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "628cf42f-eb40-49b0-b110-3340421d4502",
-        "name": "menu-item-label-to-description",
-        "constant-token-duplicate": true
+        "name": "menu-item-label-to-description"
       }
     }
   },
@@ -2205,8 +2005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dac5c077-b948-434b-91bd-0759c2414007",
-        "name": "menu-item-section-divider-height",
-        "constant-token-duplicate": true
+        "name": "menu-item-section-divider-height"
       }
     }
   },
@@ -2216,8 +2015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "77e97b70-ef7e-4228-8d91-0ff9d9d2b063",
-        "name": "menu-item-top-to-disclosure-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-disclosure-icon-extra-large"
       }
     }
   },
@@ -2227,8 +2025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bda3ee60-8f9a-41b2-a8a2-894aed3b3bed",
-        "name": "menu-item-top-to-disclosure-icon-large",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-disclosure-icon-large"
       }
     }
   },
@@ -2238,8 +2035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e0468683-b2d2-4839-9ad8-46963d7402fc",
-        "name": "menu-item-top-to-disclosure-icon-medium",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-disclosure-icon-medium"
       }
     }
   },
@@ -2249,8 +2045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "eb9cf950-cba2-4fb8-a115-8a4c0ddb00d0",
-        "name": "menu-item-top-to-disclosure-icon-small",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-disclosure-icon-small"
       }
     }
   },
@@ -2260,8 +2055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3ff6cb7a-20cb-4b25-a367-7e4497d0f237",
-        "name": "menu-item-top-to-selected-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-selected-icon-extra-large"
       }
     }
   },
@@ -2271,8 +2065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f84569c5-bb63-4eb1-8193-1130e88e7e5b",
-        "name": "menu-item-top-to-selected-icon-large",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-selected-icon-large"
       }
     }
   },
@@ -2282,8 +2075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "61e906e3-6daa-4841-b4f0-54939157a50b",
-        "name": "menu-item-top-to-selected-icon-medium",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-selected-icon-medium"
       }
     }
   },
@@ -2293,8 +2085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "943a0b43-6c91-40a3-a680-318a934bf6ef",
-        "name": "menu-item-top-to-selected-icon-small",
-        "constant-token-duplicate": false
+        "name": "menu-item-top-to-selected-icon-small"
       }
     }
   },
@@ -2304,8 +2095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "63bfb4da-4aaf-49c6-9328-16c636cf0bf9",
-        "name": "meter-maximum-width",
-        "constant-token-duplicate": true
+        "name": "meter-maximum-width"
       }
     }
   },
@@ -2315,8 +2105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fd4f6ef0-bab2-4405-9eea-8a9b8a7dd295",
-        "name": "meter-minimum-width",
-        "constant-token-duplicate": true
+        "name": "meter-minimum-width"
       }
     }
   },
@@ -2326,8 +2115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c9052808-918e-4368-b113-28f928104eda",
-        "name": "meter-thickness-large",
-        "constant-token-duplicate": false
+        "name": "meter-thickness-large"
       }
     }
   },
@@ -2337,8 +2125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "eb9c3cff-5a1a-4832-a623-6ab258b81d37",
-        "name": "meter-thickness-small",
-        "constant-token-duplicate": false
+        "name": "meter-thickness-small"
       }
     }
   },
@@ -2348,8 +2135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dc5f4966-4ddd-4e9a-a748-370d8eaae568",
-        "name": "meter-width",
-        "constant-token-duplicate": false
+        "name": "meter-width"
       }
     }
   },
@@ -2359,8 +2145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "879360e9-a7b0-47e0-bc4a-931a12877014",
-        "name": "opacity-checkerboard-square-size",
-        "constant-token-duplicate": false
+        "name": "opacity-checkerboard-square-size"
       }
     }
   },
@@ -2370,8 +2155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "69c28762-f456-4641-b6ce-7cb295e3a27d",
-        "name": "picker-border-width",
-        "constant-token-duplicate": true
+        "name": "picker-border-width"
       }
     }
   },
@@ -2381,8 +2165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "03da68d8-cd87-4e29-9aaf-ab467594ec2b",
-        "name": "picker-end-edge-to-disclosure-icon-quiet",
-        "constant-token-duplicate": true
+        "name": "picker-end-edge-to-disclosure-icon-quiet"
       }
     }
   },
@@ -2392,8 +2175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "67b68a30-ae00-4da2-9730-99196a2eaf96",
-        "name": "picker-minimum-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "picker-minimum-width-multiplier"
       }
     }
   },
@@ -2403,8 +2185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0ac097c8-020e-4a7b-b692-59dfdf07e3f8",
-        "name": "picker-visual-to-disclosure-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "picker-visual-to-disclosure-icon-extra-large"
       }
     }
   },
@@ -2414,8 +2195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "47f5a27f-4039-4668-bb21-aafb9dcb82fb",
-        "name": "picker-visual-to-disclosure-icon-large",
-        "constant-token-duplicate": false
+        "name": "picker-visual-to-disclosure-icon-large"
       }
     }
   },
@@ -2425,8 +2205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c620ab2b-256d-409a-a80c-7d7c2295efc8",
-        "name": "picker-visual-to-disclosure-icon-medium",
-        "constant-token-duplicate": false
+        "name": "picker-visual-to-disclosure-icon-medium"
       }
     }
   },
@@ -2436,8 +2215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "269725c9-3462-4132-8487-95dd61814448",
-        "name": "picker-visual-to-disclosure-icon-small",
-        "constant-token-duplicate": false
+        "name": "picker-visual-to-disclosure-icon-small"
       }
     }
   },
@@ -2447,8 +2225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5960406b-973d-4e1f-9bb4-2c7a22422c5b",
-        "name": "popover-tip-height",
-        "constant-token-duplicate": true
+        "name": "popover-tip-height"
       }
     }
   },
@@ -2458,8 +2235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c4bc3596-1fbc-4b08-85af-6bd8142e499a",
-        "name": "popover-tip-width",
-        "constant-token-duplicate": true
+        "name": "popover-tip-width"
       }
     }
   },
@@ -2469,8 +2245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6165bae4-7148-4cb2-a1b4-38a25f2d8cde",
-        "name": "popover-top-to-content-area",
-        "constant-token-duplicate": false
+        "name": "popover-top-to-content-area"
       }
     }
   },
@@ -2480,8 +2255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7ba00389-a6ba-4d18-9d88-8704427ad784",
-        "name": "progress-bar-maximum-width",
-        "constant-token-duplicate": true
+        "name": "progress-bar-maximum-width"
       }
     }
   },
@@ -2491,8 +2265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8dfd4f94-93cc-47dd-92d2-87d1696f4ab7",
-        "name": "progress-bar-minimum-width",
-        "constant-token-duplicate": true
+        "name": "progress-bar-minimum-width"
       }
     }
   },
@@ -2502,8 +2275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c15e51b3-4a5e-421e-aa4e-e0a82840f1a2",
-        "name": "progress-bar-thickness-extra-large",
-        "constant-token-duplicate": false
+        "name": "progress-bar-thickness-extra-large"
       }
     }
   },
@@ -2513,8 +2285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4b680695-7e42-493c-889b-c76a60ab1f4f",
-        "name": "progress-bar-thickness-large",
-        "constant-token-duplicate": false
+        "name": "progress-bar-thickness-large"
       }
     }
   },
@@ -2524,8 +2295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d53e3ac6-6091-4c3f-9e1b-b12b716a5f95",
-        "name": "progress-bar-thickness-medium",
-        "constant-token-duplicate": false
+        "name": "progress-bar-thickness-medium"
       }
     }
   },
@@ -2535,8 +2305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ab98c47f-f2e4-4f74-8008-55c65907b6eb",
-        "name": "progress-bar-thickness-small",
-        "constant-token-duplicate": false
+        "name": "progress-bar-thickness-small"
       }
     }
   },
@@ -2546,8 +2315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c7719369-7d3d-4446-ade2-08abb472a985",
-        "name": "progress-circle-size-large",
-        "constant-token-duplicate": false
+        "name": "progress-circle-size-large"
       }
     }
   },
@@ -2557,8 +2325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c380cf9b-cb59-465c-9b56-41654d3239f1",
-        "name": "progress-circle-size-medium",
-        "constant-token-duplicate": false
+        "name": "progress-circle-size-medium"
       }
     }
   },
@@ -2568,8 +2335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a7fafd60-dc38-425a-b6b6-952a06d30ab4",
-        "name": "progress-circle-size-small",
-        "constant-token-duplicate": false
+        "name": "progress-circle-size-small"
       }
     }
   },
@@ -2579,8 +2345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "076b031f-5980-4112-bf0b-2cec47f54c6b",
-        "name": "progress-circle-thickness-large",
-        "constant-token-duplicate": false
+        "name": "progress-circle-thickness-large"
       }
     }
   },
@@ -2590,8 +2355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "aa930d94-7874-44d7-80f1-dc431d40c4a4",
-        "name": "progress-circle-thickness-medium",
-        "constant-token-duplicate": false
+        "name": "progress-circle-thickness-medium"
       }
     }
   },
@@ -2601,8 +2365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a37ef752-662b-4152-b247-0ce9fcd624e4",
-        "name": "progress-circle-thickness-small",
-        "constant-token-duplicate": false
+        "name": "progress-circle-thickness-small"
       }
     }
   },
@@ -2612,8 +2375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cc041f48-aaa4-4c20-8990-599e0c56134e",
-        "name": "radio-button-control-size-extra-large",
-        "constant-token-duplicate": false
+        "name": "radio-button-control-size-extra-large"
       }
     }
   },
@@ -2623,8 +2385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "23d0a4aa-693d-4b79-b942-3898f9cf0b80",
-        "name": "radio-button-control-size-large",
-        "constant-token-duplicate": false
+        "name": "radio-button-control-size-large"
       }
     }
   },
@@ -2634,8 +2395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2eef4003-e666-48e7-b25b-8c50063ce400",
-        "name": "radio-button-control-size-medium",
-        "constant-token-duplicate": false
+        "name": "radio-button-control-size-medium"
       }
     }
   },
@@ -2645,8 +2405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "90a2b18a-61c7-40d8-926c-d6b18a641010",
-        "name": "radio-button-control-size-small",
-        "constant-token-duplicate": false
+        "name": "radio-button-control-size-small"
       }
     }
   },
@@ -2656,8 +2415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a7fc6bdb-5b9c-42d4-8f78-d34021ac0708",
-        "name": "radio-button-selection-indicator",
-        "constant-token-duplicate": true
+        "name": "radio-button-selection-indicator"
       }
     }
   },
@@ -2667,8 +2425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c478710f-1747-455b-998a-6fa837762905",
-        "name": "radio-button-top-to-control-extra-large",
-        "constant-token-duplicate": false
+        "name": "radio-button-top-to-control-extra-large"
       }
     }
   },
@@ -2678,8 +2435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "41d0dde7-de34-4e99-96d0-4f727ed71673",
-        "name": "radio-button-top-to-control-large",
-        "constant-token-duplicate": false
+        "name": "radio-button-top-to-control-large"
       }
     }
   },
@@ -2689,8 +2445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2f805530-cefe-420a-89e6-a6a81c0faea0",
-        "name": "radio-button-top-to-control-medium",
-        "constant-token-duplicate": false
+        "name": "radio-button-top-to-control-medium"
       }
     }
   },
@@ -2700,8 +2455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "02438c4c-161d-45eb-935d-b083ab830876",
-        "name": "radio-button-top-to-control-small",
-        "constant-token-duplicate": false
+        "name": "radio-button-top-to-control-small"
       }
     }
   },
@@ -2711,8 +2465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8e13ea1d-8000-485e-8700-5522cc71b95c",
-        "name": "rating-indicator-to-icon",
-        "constant-token-duplicate": false
+        "name": "rating-indicator-to-icon"
       }
     }
   },
@@ -2722,8 +2475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dce9ff1e-06d1-49a5-817f-5319f4ab15e2",
-        "name": "rating-indicator-width",
-        "constant-token-duplicate": false
+        "name": "rating-indicator-width"
       }
     }
   },
@@ -2733,8 +2485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c4b2177d-4468-4180-be27-69d26a51ba0b",
-        "name": "search-field-minimum-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "search-field-minimum-width-multiplier"
       }
     }
   },
@@ -2744,8 +2495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e3f49e5e-f9ec-485c-846e-7a8fda08caea",
-        "name": "side-navigation-bottom-to-text",
-        "constant-token-duplicate": false
+        "name": "side-navigation-bottom-to-text"
       }
     }
   },
@@ -2755,8 +2505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ad959938-ad69-4137-91e4-fcf2465b223a",
-        "name": "side-navigation-header-to-item",
-        "constant-token-duplicate": false
+        "name": "side-navigation-header-to-item"
       }
     }
   },
@@ -2766,8 +2515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0f3821f1-6f0e-4325-bfa7-e572768fd468",
-        "name": "side-navigation-item-to-header",
-        "constant-token-duplicate": false
+        "name": "side-navigation-item-to-header"
       }
     }
   },
@@ -2777,8 +2525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "be37c65c-88c5-48cd-9554-8240909db98d",
-        "name": "side-navigation-item-to-item",
-        "constant-token-duplicate": false
+        "name": "side-navigation-item-to-item"
       }
     }
   },
@@ -2788,8 +2535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bcb163a0-0156-4e2e-abfe-b2ac0158f348",
-        "name": "side-navigation-maximum-width",
-        "constant-token-duplicate": false
+        "name": "side-navigation-maximum-width"
       }
     }
   },
@@ -2799,8 +2545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ad835d79-64d9-4183-ace0-912c87fc2241",
-        "name": "side-navigation-minimum-width",
-        "constant-token-duplicate": false
+        "name": "side-navigation-minimum-width"
       }
     }
   },
@@ -2810,8 +2555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e77cde34-8f77-4fd1-a1f7-aa6738130902",
-        "name": "side-navigation-second-level-edge-to-text",
-        "constant-token-duplicate": false
+        "name": "side-navigation-second-level-edge-to-text"
       }
     }
   },
@@ -2821,8 +2565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "06140452-b779-4527-ae3a-5f0623a6b97c",
-        "name": "side-navigation-third-level-edge-to-text",
-        "constant-token-duplicate": false
+        "name": "side-navigation-third-level-edge-to-text"
       }
     }
   },
@@ -2832,8 +2575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3bc5710f-5fd7-4cce-a3c2-f1e45deee2b2",
-        "name": "side-navigation-width",
-        "constant-token-duplicate": false
+        "name": "side-navigation-width"
       }
     }
   },
@@ -2843,8 +2585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7d4cd9bd-bfaf-4ad7-9c3b-19f7913f0825",
-        "name": "side-navigation-with-icon-second-level-edge-to-text",
-        "constant-token-duplicate": false
+        "name": "side-navigation-with-icon-second-level-edge-to-text"
       }
     }
   },
@@ -2854,8 +2595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f82ab001-808a-4528-bf4a-be27645a28fc",
-        "name": "side-navigation-with-icon-third-level-edge-to-text",
-        "constant-token-duplicate": false
+        "name": "side-navigation-with-icon-third-level-edge-to-text"
       }
     }
   },
@@ -2865,8 +2605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9be47810-7a07-4885-a86d-647f5f36d7e5",
-        "name": "slider-control-to-field-label-extra-large",
-        "constant-token-duplicate": false
+        "name": "slider-control-to-field-label-extra-large"
       }
     }
   },
@@ -2876,8 +2615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f4fc7ec7-cc02-4ff4-bd9a-f05f9bd59c1d",
-        "name": "slider-control-to-field-label-large",
-        "constant-token-duplicate": false
+        "name": "slider-control-to-field-label-large"
       }
     }
   },
@@ -2887,8 +2625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "20a8d579-038e-4432-b271-8e44b83a9aa1",
-        "name": "slider-control-to-field-label-medium",
-        "constant-token-duplicate": false
+        "name": "slider-control-to-field-label-medium"
       }
     }
   },
@@ -2898,8 +2635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d20768dd-dbf4-48a9-8cc8-3370fa6ef810",
-        "name": "slider-control-to-field-label-small",
-        "constant-token-duplicate": false
+        "name": "slider-control-to-field-label-small"
       }
     }
   },
@@ -2909,8 +2645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "feac9f02-b52a-4694-a5d4-4b1930ab4f07",
-        "name": "slider-handle-border-width-down-extra-large",
-        "constant-token-duplicate": false
+        "name": "slider-handle-border-width-down-extra-large"
       }
     }
   },
@@ -2920,8 +2655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3bf8805b-b4f7-4d0d-af85-d227d6380539",
-        "name": "slider-handle-border-width-down-large",
-        "constant-token-duplicate": false
+        "name": "slider-handle-border-width-down-large"
       }
     }
   },
@@ -2931,8 +2665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "25959ff8-6c2f-4612-8d69-b95bfe485ce4",
-        "name": "slider-handle-border-width-down-medium",
-        "constant-token-duplicate": false
+        "name": "slider-handle-border-width-down-medium"
       }
     }
   },
@@ -2942,8 +2675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "683fb538-290c-423f-990b-d7134e485f51",
-        "name": "slider-handle-border-width-down-small",
-        "constant-token-duplicate": false
+        "name": "slider-handle-border-width-down-small"
       }
     }
   },
@@ -2953,8 +2685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1a257268-32e9-4c5c-8477-32a724ff1d42",
-        "name": "slider-handle-gap",
-        "constant-token-duplicate": true
+        "name": "slider-handle-gap"
       }
     }
   },
@@ -2964,8 +2695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "413dc697-1f14-47c8-a7f2-e52254513e6e",
-        "name": "slider-handle-size-extra-large",
-        "constant-token-duplicate": false
+        "name": "slider-handle-size-extra-large"
       }
     }
   },
@@ -2975,8 +2705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2a3fb9b0-d701-4e86-8180-9d81f68e91d5",
-        "name": "slider-handle-size-large",
-        "constant-token-duplicate": false
+        "name": "slider-handle-size-large"
       }
     }
   },
@@ -2986,8 +2715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "278fc618-f6c1-4d30-bf85-075654079003",
-        "name": "slider-handle-size-medium",
-        "constant-token-duplicate": false
+        "name": "slider-handle-size-medium"
       }
     }
   },
@@ -2997,8 +2725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7feb3d57-59fb-4095-966e-e8ca0e91442f",
-        "name": "slider-handle-size-small",
-        "constant-token-duplicate": false
+        "name": "slider-handle-size-small"
       }
     }
   },
@@ -3008,8 +2735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "50a71b8b-30fb-40c0-b81e-5ce0dcc8c96b",
-        "name": "slider-track-thickness",
-        "constant-token-duplicate": true
+        "name": "slider-track-thickness"
       }
     }
   },
@@ -3019,8 +2745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "38b8d9c8-d340-4123-88bc-f739cfde91e9",
-        "name": "status-light-dot-size-extra-large",
-        "constant-token-duplicate": false
+        "name": "status-light-dot-size-extra-large"
       }
     }
   },
@@ -3030,8 +2755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6554dae9-18b6-4c90-b2f4-8aeaab0724ad",
-        "name": "status-light-dot-size-large",
-        "constant-token-duplicate": false
+        "name": "status-light-dot-size-large"
       }
     }
   },
@@ -3041,8 +2765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a7fc9ca1-ad6d-47cb-8798-4a18ba4acc79",
-        "name": "status-light-dot-size-medium",
-        "constant-token-duplicate": false
+        "name": "status-light-dot-size-medium"
       }
     }
   },
@@ -3051,9 +2774,8 @@
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "cd7e6182-25e6-46cc-99f7-1750bc889183",
-        "name": "status-light-dot-size-small",
-        "constant-token-duplicate": false
+        "uuid": "04485265-2983-4377-9ec5-f2456863a1df",
+        "name": "status-light-dot-size-small"
       }
     }
   },
@@ -3063,8 +2785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b351cade-6d69-449e-908a-518793fef5b9",
-        "name": "status-light-top-to-dot-extra-large",
-        "constant-token-duplicate": false
+        "name": "status-light-top-to-dot-extra-large"
       }
     }
   },
@@ -3074,8 +2795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8d9d872f-7c55-4a94-a80d-c1f2c8834f5d",
-        "name": "status-light-top-to-dot-large",
-        "constant-token-duplicate": false
+        "name": "status-light-top-to-dot-large"
       }
     }
   },
@@ -3085,8 +2805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "321a462b-8811-4264-ac1f-4608df8f8c53",
-        "name": "status-light-top-to-dot-medium",
-        "constant-token-duplicate": false
+        "name": "status-light-top-to-dot-medium"
       }
     }
   },
@@ -3096,8 +2815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a4f43adc-1db1-4e2f-a5d1-3ec06c62c9ff",
-        "name": "status-light-top-to-dot-small",
-        "constant-token-duplicate": false
+        "name": "status-light-top-to-dot-small"
       }
     }
   },
@@ -3107,8 +2825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b3157e9d-82a0-429e-b987-8c240a669af7",
-        "name": "swatch-rectangle-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "swatch-rectangle-width-multiplier"
       }
     }
   },
@@ -3118,8 +2835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0d926e1a-080a-41ba-8bb9-ef6d0847cb77",
-        "name": "swatch-size-extra-small",
-        "constant-token-duplicate": false
+        "name": "swatch-size-extra-small"
       }
     }
   },
@@ -3129,8 +2845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "162c1233-3420-44a2-a270-97d0a7c23df1",
-        "name": "swatch-size-large",
-        "constant-token-duplicate": false
+        "name": "swatch-size-large"
       }
     }
   },
@@ -3140,8 +2855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "77be7e79-a589-4f32-9e42-ea45ed7763aa",
-        "name": "swatch-size-medium",
-        "constant-token-duplicate": false
+        "name": "swatch-size-medium"
       }
     }
   },
@@ -3151,8 +2865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c8d8e379-1e3f-4f5e-bce3-df3fc05ff16e",
-        "name": "swatch-size-small",
-        "constant-token-duplicate": false
+        "name": "swatch-size-small"
       }
     }
   },
@@ -3162,8 +2875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "944c49d7-e189-4daa-aca1-b0b590d78875",
-        "name": "swatch-slash-thickness-extra-small",
-        "constant-token-duplicate": true
+        "name": "swatch-slash-thickness-extra-small"
       }
     }
   },
@@ -3173,8 +2885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6b1b2709-de8c-450d-9299-49200208599e",
-        "name": "swatch-slash-thickness-large",
-        "constant-token-duplicate": true
+        "name": "swatch-slash-thickness-large"
       }
     }
   },
@@ -3184,8 +2895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4e735599-f420-4b51-aa75-607046431c76",
-        "name": "swatch-slash-thickness-medium",
-        "constant-token-duplicate": true
+        "name": "swatch-slash-thickness-medium"
       }
     }
   },
@@ -3195,8 +2905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f626d145-7840-4958-86be-d2306b5b2233",
-        "name": "swatch-slash-thickness-small",
-        "constant-token-duplicate": true
+        "name": "swatch-slash-thickness-small"
       }
     }
   },
@@ -3206,8 +2915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7ae7b32-b347-4e09-9978-3b0b92a4dbab",
-        "name": "switch-control-height-extra-large",
-        "constant-token-duplicate": false
+        "name": "switch-control-height-extra-large"
       }
     }
   },
@@ -3217,8 +2925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "91b828ce-8ff9-4d32-958e-a8a23ef9b345",
-        "name": "switch-control-height-large",
-        "constant-token-duplicate": false
+        "name": "switch-control-height-large"
       }
     }
   },
@@ -3228,8 +2935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0d5f13f2-4d5b-4c30-b3a3-fa4fcc33b928",
-        "name": "switch-control-height-medium",
-        "constant-token-duplicate": false
+        "name": "switch-control-height-medium"
       }
     }
   },
@@ -3239,8 +2945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a1dbcaf0-bbcf-444d-9d22-7f86db20303a",
-        "name": "switch-control-height-small",
-        "constant-token-duplicate": false
+        "name": "switch-control-height-small"
       }
     }
   },
@@ -3250,8 +2955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4e9d9b63-989a-4b63-b74d-22b5188f8df7",
-        "name": "switch-control-width-extra-large",
-        "constant-token-duplicate": false
+        "name": "switch-control-width-extra-large"
       }
     }
   },
@@ -3261,8 +2965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5c7bdcc9-63f8-4c4b-b26f-97b39f53dbea",
-        "name": "switch-control-width-large",
-        "constant-token-duplicate": false
+        "name": "switch-control-width-large"
       }
     }
   },
@@ -3272,8 +2975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ec2f3b6b-80db-4c43-bdd2-caee98796775",
-        "name": "switch-control-width-medium",
-        "constant-token-duplicate": false
+        "name": "switch-control-width-medium"
       }
     }
   },
@@ -3283,8 +2985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ca939c4d-9369-498c-81cb-61df1397f657",
-        "name": "switch-control-width-small",
-        "constant-token-duplicate": false
+        "name": "switch-control-width-small"
       }
     }
   },
@@ -3294,8 +2995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7e95ad9a-ca10-4f06-9c19-8dd2270cfdad",
-        "name": "switch-top-to-control-extra-large",
-        "constant-token-duplicate": false
+        "name": "switch-top-to-control-extra-large"
       }
     }
   },
@@ -3305,8 +3005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "035e786b-17f2-488e-a049-84b257a3312f",
-        "name": "switch-top-to-control-large",
-        "constant-token-duplicate": false
+        "name": "switch-top-to-control-large"
       }
     }
   },
@@ -3316,8 +3015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "68276028-41d8-49e1-b0d4-f70cd27ab149",
-        "name": "switch-top-to-control-medium",
-        "constant-token-duplicate": false
+        "name": "switch-top-to-control-medium"
       }
     }
   },
@@ -3327,8 +3025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f379c453-da21-41f6-92d1-9b6bdb95fd86",
-        "name": "switch-top-to-control-small",
-        "constant-token-duplicate": false
+        "name": "switch-top-to-control-small"
       }
     }
   },
@@ -3338,8 +3035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3641ac9c-5610-4996-a55d-c2a94b2ff9ea",
-        "name": "tab-item-bottom-to-text-compact-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-compact-extra-large"
       }
     }
   },
@@ -3349,8 +3045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "091144b7-c63b-4827-840d-741cec01432a",
-        "name": "tab-item-bottom-to-text-compact-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-compact-large"
       }
     }
   },
@@ -3360,8 +3055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e69dee42-92da-4ca9-9eb8-97a7860adaba",
-        "name": "tab-item-bottom-to-text-compact-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-compact-medium"
       }
     }
   },
@@ -3371,8 +3065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f453e51e-3d58-430e-8f17-8b95718dbf34",
-        "name": "tab-item-bottom-to-text-compact-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-compact-small"
       }
     }
   },
@@ -3382,8 +3075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c63380d4-cc26-4299-b227-af2faedfdc74",
-        "name": "tab-item-bottom-to-text-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-extra-large"
       }
     }
   },
@@ -3393,8 +3085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "31d1b6b6-721f-4474-ba86-795367399e49",
-        "name": "tab-item-bottom-to-text-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-large"
       }
     }
   },
@@ -3404,8 +3095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "691db84a-5336-4e45-bf73-ee617057e718",
-        "name": "tab-item-bottom-to-text-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-medium"
       }
     }
   },
@@ -3415,8 +3105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e0791360-b505-492b-bf71-dfa393abecfa",
-        "name": "tab-item-bottom-to-text-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-bottom-to-text-small"
       }
     }
   },
@@ -3426,8 +3115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "49130d66-edfb-48bd-8648-96c47f40a884",
-        "name": "tab-item-compact-height-extra-large",
-        "constant-token-duplicate": true
+        "name": "tab-item-compact-height-extra-large"
       }
     }
   },
@@ -3437,8 +3125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6d781a0e-e03d-4750-ae4f-67a29d731702",
-        "name": "tab-item-compact-height-large",
-        "constant-token-duplicate": true
+        "name": "tab-item-compact-height-large"
       }
     }
   },
@@ -3448,8 +3135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e8c7c826-548d-4037-b064-3cf699675d35",
-        "name": "tab-item-compact-height-medium",
-        "constant-token-duplicate": true
+        "name": "tab-item-compact-height-medium"
       }
     }
   },
@@ -3459,8 +3145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "25f7d9a5-9464-4447-97d9-97839b371f96",
-        "name": "tab-item-compact-height-small",
-        "constant-token-duplicate": true
+        "name": "tab-item-compact-height-small"
       }
     }
   },
@@ -3470,8 +3155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6c0aad05-5224-4ade-913a-3dc5ebceeb62",
-        "name": "tab-item-focus-indicator-gap-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-focus-indicator-gap-extra-large"
       }
     }
   },
@@ -3481,8 +3165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6c4d8c39-9f75-4c75-94e2-274a69a8f556",
-        "name": "tab-item-focus-indicator-gap-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-focus-indicator-gap-large"
       }
     }
   },
@@ -3492,8 +3175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "09ee234f-a596-47ba-89df-ab9ebc07ded8",
-        "name": "tab-item-focus-indicator-gap-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-focus-indicator-gap-medium"
       }
     }
   },
@@ -3503,8 +3185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5fbc924e-e79e-46c6-8544-c92d7f33bc26",
-        "name": "tab-item-focus-indicator-gap-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-focus-indicator-gap-small"
       }
     }
   },
@@ -3514,8 +3195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "42ed814c-5044-4c70-b82f-b49f8226241e",
-        "name": "tab-item-height-extra-large",
-        "constant-token-duplicate": true
+        "name": "tab-item-height-extra-large"
       }
     }
   },
@@ -3525,8 +3205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8abd0b0e-fd6d-4064-9d0e-1ab998fcb0ce",
-        "name": "tab-item-height-large",
-        "constant-token-duplicate": true
+        "name": "tab-item-height-large"
       }
     }
   },
@@ -3536,8 +3215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5d2288f4-f383-47fa-baca-0168cb46750a",
-        "name": "tab-item-height-medium",
-        "constant-token-duplicate": true
+        "name": "tab-item-height-medium"
       }
     }
   },
@@ -3547,8 +3225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7b31cf38-5bac-4f79-a4f1-172a4ea66e10",
-        "name": "tab-item-height-small",
-        "constant-token-duplicate": true
+        "name": "tab-item-height-small"
       }
     }
   },
@@ -3558,8 +3235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4e0b2015-06c8-41ab-9e2b-3a332a7625ff",
-        "name": "tab-item-start-to-edge-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-start-to-edge-extra-large"
       }
     }
   },
@@ -3569,8 +3245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2c85fa9a-e854-46f6-bc6b-547692d08290",
-        "name": "tab-item-start-to-edge-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-start-to-edge-large"
       }
     }
   },
@@ -3580,8 +3255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "229477d5-e21a-4f4b-a24d-580f0c60eec5",
-        "name": "tab-item-start-to-edge-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-start-to-edge-medium"
       }
     }
   },
@@ -3591,8 +3265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f869f703-a850-4c6c-b518-ec8a1b355046",
-        "name": "tab-item-start-to-edge-quiet",
-        "constant-token-duplicate": true
+        "name": "tab-item-start-to-edge-quiet"
       }
     }
   },
@@ -3602,8 +3275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8d413f56-6634-49c8-8d6a-53d0f57f1bbc",
-        "name": "tab-item-start-to-edge-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-start-to-edge-small"
       }
     }
   },
@@ -3613,8 +3285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "482ed7f6-ba60-4110-85c8-daf5bf352406",
-        "name": "tab-item-to-tab-item-horizontal-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-horizontal-extra-large"
       }
     }
   },
@@ -3624,8 +3295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "71bdfd06-4672-464f-b787-9a62137b1763",
-        "name": "tab-item-to-tab-item-horizontal-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-horizontal-large"
       }
     }
   },
@@ -3635,8 +3305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "885a7cc3-8873-4cb7-99e7-b17f42fb48f1",
-        "name": "tab-item-to-tab-item-horizontal-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-horizontal-medium"
       }
     }
   },
@@ -3646,8 +3315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8b5e1596-f13a-4786-b0c7-f01615423922",
-        "name": "tab-item-to-tab-item-horizontal-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-horizontal-small"
       }
     }
   },
@@ -3657,8 +3325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ea902ec1-25d5-47c3-896a-a95d9ca5bd62",
-        "name": "tab-item-to-tab-item-vertical-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-vertical-extra-large"
       }
     }
   },
@@ -3668,8 +3335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c193b2ee-a584-41dc-9ef8-3aebb38fb832",
-        "name": "tab-item-to-tab-item-vertical-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-vertical-large"
       }
     }
   },
@@ -3679,8 +3345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6b6c960f-adcf-48b0-8310-ba12b47f4d9a",
-        "name": "tab-item-to-tab-item-vertical-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-vertical-medium"
       }
     }
   },
@@ -3690,8 +3355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d51a6c05-67d0-425f-becf-86e783ab3305",
-        "name": "tab-item-to-tab-item-vertical-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-to-tab-item-vertical-small"
       }
     }
   },
@@ -3701,8 +3365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9694ebdc-cc88-4584-89f5-10a2c8de686f",
-        "name": "tab-item-top-to-text-compact-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-compact-extra-large"
       }
     }
   },
@@ -3712,8 +3375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fd20b444-38ac-4438-a9ef-32474222e45f",
-        "name": "tab-item-top-to-text-compact-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-compact-large"
       }
     }
   },
@@ -3723,8 +3385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "128757b0-d690-4886-95d5-e9df36182a0f",
-        "name": "tab-item-top-to-text-compact-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-compact-medium"
       }
     }
   },
@@ -3734,8 +3395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d37488c4-d489-45bd-9086-8157c5204ae4",
-        "name": "tab-item-top-to-text-compact-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-compact-small"
       }
     }
   },
@@ -3745,8 +3405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "174cc6c8-9c0a-44c0-b6c7-ea6d337c819b",
-        "name": "tab-item-top-to-text-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-extra-large"
       }
     }
   },
@@ -3756,8 +3415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7e3db5ca-cd32-464b-9a23-9d03e83faa9c",
-        "name": "tab-item-top-to-text-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-large"
       }
     }
   },
@@ -3767,8 +3425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a8c455e9-60e5-4838-bc9c-eaf7b39a4bf7",
-        "name": "tab-item-top-to-text-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-medium"
       }
     }
   },
@@ -3778,8 +3435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3e155b8c-6cea-4b59-817c-cf71a63e00c7",
-        "name": "tab-item-top-to-text-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-text-small"
       }
     }
   },
@@ -3789,8 +3445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f310e5d7-7435-41a0-b44d-ececff4844f2",
-        "name": "tab-item-top-to-workflow-icon-compact-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-compact-extra-large"
       }
     }
   },
@@ -3800,8 +3455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fad964d8-0020-4583-97ab-7d6565d01bdc",
-        "name": "tab-item-top-to-workflow-icon-compact-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-compact-large"
       }
     }
   },
@@ -3811,8 +3465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4fb0520b-8c74-4fb7-b279-a3586a06a57e",
-        "name": "tab-item-top-to-workflow-icon-compact-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-compact-medium"
       }
     }
   },
@@ -3822,8 +3475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b79002d2-bcff-4e8d-a406-e512c7e7d0e3",
-        "name": "tab-item-top-to-workflow-icon-compact-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-compact-small"
       }
     }
   },
@@ -3833,8 +3485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5afa2636-7d4c-4d83-b9fc-3c5a52ee4646",
-        "name": "tab-item-top-to-workflow-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-extra-large"
       }
     }
   },
@@ -3844,8 +3495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4dd99579-949b-4bf9-b022-e8f0c95eae33",
-        "name": "tab-item-top-to-workflow-icon-large",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-large"
       }
     }
   },
@@ -3855,8 +3505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "820baccf-af24-42a3-9729-99408bc9322f",
-        "name": "tab-item-top-to-workflow-icon-medium",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-medium"
       }
     }
   },
@@ -3866,8 +3515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "923fd09d-8d08-4465-961f-63ac12014206",
-        "name": "tab-item-top-to-workflow-icon-small",
-        "constant-token-duplicate": false
+        "name": "tab-item-top-to-workflow-icon-small"
       }
     }
   },
@@ -3877,8 +3525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b6f2536c-deda-409f-8667-a5a99abdfa46",
-        "name": "table-border-divider-width",
-        "constant-token-duplicate": true
+        "name": "table-border-divider-width"
       }
     }
   },
@@ -3888,8 +3535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cb7c89c0-9f31-43c4-8427-2e048f549ff7",
-        "name": "table-checkbox-to-text",
-        "constant-token-duplicate": false
+        "name": "table-checkbox-to-text"
       }
     }
   },
@@ -3899,8 +3545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c8bd103d-d952-4649-a7a0-09ae5242ea17",
-        "name": "table-column-header-row-bottom-to-text-extra-large",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-bottom-to-text-extra-large"
       }
     }
   },
@@ -3910,8 +3555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e465ee66-392f-469f-a46c-6c98df03b046",
-        "name": "table-column-header-row-bottom-to-text-large",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-bottom-to-text-large"
       }
     }
   },
@@ -3921,8 +3565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "631d14a5-1d2e-4e4a-90e8-146e8a397530",
-        "name": "table-column-header-row-bottom-to-text-medium",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-bottom-to-text-medium"
       }
     }
   },
@@ -3932,8 +3575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9cf85eae-ec15-4bb0-ba48-00ec946306a5",
-        "name": "table-column-header-row-bottom-to-text-small",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-bottom-to-text-small"
       }
     }
   },
@@ -3943,8 +3585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "265247a7-bbc3-42b8-910d-946e8d04aee2",
-        "name": "table-column-header-row-top-to-text-extra-large",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-top-to-text-extra-large"
       }
     }
   },
@@ -3954,8 +3595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a02666d8-4ae2-42d2-b48e-419d5070e7ca",
-        "name": "table-column-header-row-top-to-text-large",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-top-to-text-large"
       }
     }
   },
@@ -3965,8 +3605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ff3c5329-ccec-4b94-b200-29a377b34380",
-        "name": "table-column-header-row-top-to-text-medium",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-top-to-text-medium"
       }
     }
   },
@@ -3976,8 +3615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fdc8b7ae-2356-4d49-ba54-0ea471be2986",
-        "name": "table-column-header-row-top-to-text-small",
-        "constant-token-duplicate": false
+        "name": "table-column-header-row-top-to-text-small"
       }
     }
   },
@@ -3986,9 +3624,8 @@
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "7912ab09-70e2-4e08-8aa5-f985e05a4ba7",
-        "name": "table-edge-to-content",
-        "constant-token-duplicate": false
+        "uuid": "5e46672f-eab0-4ec3-bd14-68ffa4404ec1",
+        "name": "table-edge-to-content"
       }
     }
   },
@@ -3998,8 +3635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "42a78148-e111-4124-a7a6-d9baa2ca963f",
-        "name": "table-header-row-checkbox-to-top-extra-large",
-        "constant-token-duplicate": false
+        "name": "table-header-row-checkbox-to-top-extra-large"
       }
     }
   },
@@ -4009,8 +3645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f6648787-3cf1-4af8-aa4f-15669ea1626d",
-        "name": "table-header-row-checkbox-to-top-large",
-        "constant-token-duplicate": false
+        "name": "table-header-row-checkbox-to-top-large"
       }
     }
   },
@@ -4020,8 +3655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2e168a2b-46aa-453f-9ca1-746485216c84",
-        "name": "table-header-row-checkbox-to-top-medium",
-        "constant-token-duplicate": false
+        "name": "table-header-row-checkbox-to-top-medium"
       }
     }
   },
@@ -4031,8 +3665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "296d445c-243d-454c-9f5a-146c13d0cded",
-        "name": "table-header-row-checkbox-to-top-small",
-        "constant-token-duplicate": false
+        "name": "table-header-row-checkbox-to-top-small"
       }
     }
   },
@@ -4042,8 +3675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "effa3e3c-eb5b-4c0a-aca9-81331e6a08ac",
-        "name": "table-row-bottom-to-text-extra-large-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-bottom-to-text-extra-large-compact"
       }
     }
   },
@@ -4053,8 +3685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c9ac99be-86c3-4f6c-a2a5-3487041bc95e",
-        "name": "table-row-bottom-to-text-extra-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-extra-large-regular"
       }
     }
   },
@@ -4064,8 +3695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "06ada9fe-ceef-4fb4-88ee-37c2edee5418",
-        "name": "table-row-bottom-to-text-extra-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-extra-large-spacious"
       }
     }
   },
@@ -4075,8 +3705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "15e21448-3174-4565-aed7-ab84aa30d7ac",
-        "name": "table-row-bottom-to-text-large-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-bottom-to-text-large-compact"
       }
     }
   },
@@ -4086,8 +3715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "151bf172-2889-4c98-8f15-5b6cdcb30d4b",
-        "name": "table-row-bottom-to-text-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-large-regular"
       }
     }
   },
@@ -4097,8 +3725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4bc11bec-9c86-4a6c-85d1-382c71c1352d",
-        "name": "table-row-bottom-to-text-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-large-spacious"
       }
     }
   },
@@ -4108,8 +3735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d9d8fee2-9e0f-4c2b-8059-f9badb3b6482",
-        "name": "table-row-bottom-to-text-medium-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-bottom-to-text-medium-compact"
       }
     }
   },
@@ -4119,8 +3745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e80339a8-22c4-4b53-9a4a-a4456f6cab3f",
-        "name": "table-row-bottom-to-text-medium-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-medium-regular"
       }
     }
   },
@@ -4130,8 +3755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8273e28d-20b4-4575-9449-9178af111e38",
-        "name": "table-row-bottom-to-text-medium-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-medium-spacious"
       }
     }
   },
@@ -4141,8 +3765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5eb79adf-f94c-4bf8-9ec9-279f49ce5331",
-        "name": "table-row-bottom-to-text-small-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-bottom-to-text-small-compact"
       }
     }
   },
@@ -4152,8 +3775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d3147ee6-dc34-46e2-8379-02d9690ff80a",
-        "name": "table-row-bottom-to-text-small-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-small-regular"
       }
     }
   },
@@ -4163,8 +3785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "07dd5018-1999-4b95-9a59-fe1c2fcc380f",
-        "name": "table-row-bottom-to-text-small-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-bottom-to-text-small-spacious"
       }
     }
   },
@@ -4174,8 +3795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4069e932-339a-495d-bb36-c89f22af4f96",
-        "name": "table-row-checkbox-to-top-extra-large-compact",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-extra-large-compact"
       }
     }
   },
@@ -4185,8 +3805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2171aee7-d013-459e-a13f-33075090cbe3",
-        "name": "table-row-checkbox-to-top-extra-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-extra-large-regular"
       }
     }
   },
@@ -4196,8 +3815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "683be05e-f8d4-4910-8d07-20515f19fbbd",
-        "name": "table-row-checkbox-to-top-extra-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-extra-large-spacious"
       }
     }
   },
@@ -4207,8 +3825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5fde3b28-c553-4124-be3b-212d1407780c",
-        "name": "table-row-checkbox-to-top-large-compact",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-large-compact"
       }
     }
   },
@@ -4218,8 +3835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2e16e4ef-fec6-41fb-9d96-bc6bb6c88f69",
-        "name": "table-row-checkbox-to-top-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-large-regular"
       }
     }
   },
@@ -4229,8 +3845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cfbd6cb5-c8d3-4908-a77a-7a15cda932fb",
-        "name": "table-row-checkbox-to-top-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-large-spacious"
       }
     }
   },
@@ -4240,8 +3855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "84f00d87-c0ea-42fd-8477-9fff028bf79c",
-        "name": "table-row-checkbox-to-top-medium-compact",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-medium-compact"
       }
     }
   },
@@ -4251,8 +3865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "36505a4f-01b6-4b83-adf1-592818eb2c0d",
-        "name": "table-row-checkbox-to-top-medium-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-medium-regular"
       }
     }
   },
@@ -4262,8 +3875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a57d2d1a-5e0c-4d4c-84eb-dd2339366aad",
-        "name": "table-row-checkbox-to-top-medium-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-medium-spacious"
       }
     }
   },
@@ -4273,8 +3885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2444d220-a3d0-4565-a762-02cbc52f828a",
-        "name": "table-row-checkbox-to-top-small-compact",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-small-compact"
       }
     }
   },
@@ -4284,8 +3895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a63aa24e-c956-4af5-bf4f-4c5d44bd1e16",
-        "name": "table-row-checkbox-to-top-small-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-small-regular"
       }
     }
   },
@@ -4295,8 +3905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6ccbecd6-a1c4-4fcf-beb5-2b124ac3e75b",
-        "name": "table-row-checkbox-to-top-small-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-checkbox-to-top-small-spacious"
       }
     }
   },
@@ -4306,8 +3915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dcc5dd06-bb3d-46d3-adf2-133e5be942b7",
-        "name": "table-row-height-extra-large-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-height-extra-large-compact"
       }
     }
   },
@@ -4317,8 +3925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7753c9a-8854-4927-89dd-80d47bff5fa5",
-        "name": "table-row-height-extra-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-height-extra-large-regular"
       }
     }
   },
@@ -4328,8 +3935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6efd745f-2a9a-4eea-a0a3-ebe0d3fbc149",
-        "name": "table-row-height-extra-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-height-extra-large-spacious"
       }
     }
   },
@@ -4339,8 +3945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d576b4aa-e3df-4aa9-8260-fecfe6517bde",
-        "name": "table-row-height-large-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-height-large-compact"
       }
     }
   },
@@ -4350,8 +3955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b92bc058-27ea-4e86-a1a2-e5dbae3c2ee8",
-        "name": "table-row-height-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-height-large-regular"
       }
     }
   },
@@ -4361,8 +3965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e377fd73-62ca-481c-93f6-c62eb35ca720",
-        "name": "table-row-height-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-height-large-spacious"
       }
     }
   },
@@ -4372,8 +3975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b4b86a59-041d-451c-a0be-cc82e997a1d2",
-        "name": "table-row-height-medium-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-height-medium-compact"
       }
     }
   },
@@ -4383,8 +3985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "72e6564c-2acf-4f77-80d9-b21d2d55a580",
-        "name": "table-row-height-medium-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-height-medium-regular"
       }
     }
   },
@@ -4394,8 +3995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "572d1c5f-62a1-4bfc-a3e0-520a999545fe",
-        "name": "table-row-height-medium-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-height-medium-spacious"
       }
     }
   },
@@ -4405,8 +4005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a6dfc911-50fe-46dd-a7a3-cec3b115006a",
-        "name": "table-row-height-small-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-height-small-compact"
       }
     }
   },
@@ -4416,8 +4015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cdbb999d-c2a9-4325-9689-bede2ad3559a",
-        "name": "table-row-height-small-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-height-small-regular"
       }
     }
   },
@@ -4427,8 +4025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ab252e1f-a13a-4630-a6ff-0cfa6e6f0c03",
-        "name": "table-row-height-small-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-height-small-spacious"
       }
     }
   },
@@ -4438,8 +4035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2e8eff8c-60fa-4e0f-ae40-7b9f9b3679d6",
-        "name": "table-row-top-to-text-extra-large-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-top-to-text-extra-large-compact"
       }
     }
   },
@@ -4449,8 +4045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c381a3c4-e0a3-4e86-b279-f51ee6e9e532",
-        "name": "table-row-top-to-text-extra-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-extra-large-regular"
       }
     }
   },
@@ -4460,8 +4055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "90c39289-3112-49a3-8e65-d112c97f7479",
-        "name": "table-row-top-to-text-extra-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-extra-large-spacious"
       }
     }
   },
@@ -4471,8 +4065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "14437ed2-c60b-40ba-91e6-bed5353fc544",
-        "name": "table-row-top-to-text-large-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-top-to-text-large-compact"
       }
     }
   },
@@ -4482,8 +4075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0108018e-6146-45c9-b032-e3d44dfb8d84",
-        "name": "table-row-top-to-text-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-large-regular"
       }
     }
   },
@@ -4493,8 +4085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "769d6bbf-64ba-4c08-8a57-580838de1d48",
-        "name": "table-row-top-to-text-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-large-spacious"
       }
     }
   },
@@ -4504,8 +4095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "02c5faff-dbb4-4633-ae57-413b3666dfca",
-        "name": "table-row-top-to-text-medium-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-top-to-text-medium-compact"
       }
     }
   },
@@ -4515,8 +4105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7df1dc32-b96d-41e3-a372-9bcaec7c2ccb",
-        "name": "table-row-top-to-text-medium-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-medium-regular"
       }
     }
   },
@@ -4526,8 +4115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cfa36bf7-cce0-4049-970a-8f11c6d60673",
-        "name": "table-row-top-to-text-medium-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-medium-spacious"
       }
     }
   },
@@ -4537,8 +4125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7e7808a-16c6-481a-9257-9c1dc4e13b62",
-        "name": "table-row-top-to-text-small-compact",
-        "constant-token-duplicate": true
+        "name": "table-row-top-to-text-small-compact"
       }
     }
   },
@@ -4548,8 +4135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "98014297-14dc-4547-944a-8951c7f6f253",
-        "name": "table-row-top-to-text-small-regular",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-small-regular"
       }
     }
   },
@@ -4559,8 +4145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "625733b1-78b3-4dd0-9636-71d59c14e013",
-        "name": "table-row-top-to-text-small-spacious",
-        "constant-token-duplicate": false
+        "name": "table-row-top-to-text-small-spacious"
       }
     }
   },
@@ -4570,8 +4155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "06164331-9a76-4adf-b859-82074df19fbd",
-        "name": "table-section-header-row-height-extra-large",
-        "constant-token-duplicate": false
+        "name": "table-section-header-row-height-extra-large"
       }
     }
   },
@@ -4581,8 +4165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cc41c4f1-bfc5-4aa5-87af-97f191cc7af3",
-        "name": "table-section-header-row-height-large",
-        "constant-token-duplicate": false
+        "name": "table-section-header-row-height-large"
       }
     }
   },
@@ -4592,8 +4175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "07beb872-72a0-400e-b434-dd076c9be0a7",
-        "name": "table-section-header-row-height-medium",
-        "constant-token-duplicate": false
+        "name": "table-section-header-row-height-medium"
       }
     }
   },
@@ -4603,8 +4185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2cd8dc05-2f95-45b5-b8a4-0273baf3ba0e",
-        "name": "table-section-header-row-height-small",
-        "constant-token-duplicate": false
+        "name": "table-section-header-row-height-small"
       }
     }
   },
@@ -4614,8 +4195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "29ee801a-95bd-495c-9905-f2fd00ae0e19",
-        "name": "table-thumbnail-to-top-minimum-extra-large-compact",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-extra-large-compact"
       }
     }
   },
@@ -4625,8 +4205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b60c33b8-acc1-4af1-b30f-b467054ee417",
-        "name": "table-thumbnail-to-top-minimum-extra-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-extra-large-regular"
       }
     }
   },
@@ -4636,8 +4215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "28a5df8a-0fe4-4410-b804-9a6c26de4440",
-        "name": "table-thumbnail-to-top-minimum-extra-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-extra-large-spacious"
       }
     }
   },
@@ -4647,8 +4225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "891cf7bc-419a-4b78-8c7e-03685fbf36a4",
-        "name": "table-thumbnail-to-top-minimum-large-compact",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-large-compact"
       }
     }
   },
@@ -4658,8 +4235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fc7efe7c-ef97-424f-89c2-2211daf44b4a",
-        "name": "table-thumbnail-to-top-minimum-large-regular",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-large-regular"
       }
     }
   },
@@ -4669,8 +4245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e6689bf9-6ecc-4900-b8ad-85b103232e3e",
-        "name": "table-thumbnail-to-top-minimum-large-spacious",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-large-spacious"
       }
     }
   },
@@ -4680,8 +4255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b546eac7-00ad-4ea2-992d-0c4b8d087679",
-        "name": "table-thumbnail-to-top-minimum-medium-compact",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-medium-compact"
       }
     }
   },
@@ -4691,8 +4265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "75af7a67-e0ae-4f41-9c70-09babbc587d1",
-        "name": "table-thumbnail-to-top-minimum-medium-regular",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-medium-regular"
       }
     }
   },
@@ -4702,8 +4275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0cb1e46b-039b-46d2-a024-b72ddd82d0b4",
-        "name": "table-thumbnail-to-top-minimum-medium-spacious",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-medium-spacious"
       }
     }
   },
@@ -4713,8 +4285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "72ebb8a4-9bfb-4ff0-ba3a-232c885931e7",
-        "name": "table-thumbnail-to-top-minimum-small-compact",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-small-compact"
       }
     }
   },
@@ -4724,8 +4295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e25b14a7-cb9e-406b-bab6-b27575f00a52",
-        "name": "table-thumbnail-to-top-minimum-small-regular",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-small-regular"
       }
     }
   },
@@ -4735,8 +4305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b6684bce-531d-420a-befc-b4ad884059fc",
-        "name": "table-thumbnail-to-top-minimum-small-spacious",
-        "constant-token-duplicate": false
+        "name": "table-thumbnail-to-top-minimum-small-spacious"
       }
     }
   },
@@ -4746,8 +4315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9881ad7c-e9df-40b1-a368-4f8185042c3f",
-        "name": "tag-top-to-avatar-large",
-        "constant-token-duplicate": false
+        "name": "tag-top-to-avatar-large"
       }
     }
   },
@@ -4757,8 +4325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8dbabe33-52e7-4dc1-b2e3-81c1c62d98cb",
-        "name": "tag-top-to-avatar-medium",
-        "constant-token-duplicate": false
+        "name": "tag-top-to-avatar-medium"
       }
     }
   },
@@ -4768,8 +4335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a2c40238-1fda-4482-a419-b8092a385c9b",
-        "name": "tag-top-to-avatar-small",
-        "constant-token-duplicate": false
+        "name": "tag-top-to-avatar-small"
       }
     }
   },
@@ -4779,8 +4345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "af69e3d1-92b6-4e62-93f2-c1f1f10f0a63",
-        "name": "tag-top-to-cross-icon-large",
-        "constant-token-duplicate": false
+        "name": "tag-top-to-cross-icon-large"
       }
     }
   },
@@ -4790,8 +4355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ac7b17a2-99ef-45b3-ab3b-4d3eeaf99fb9",
-        "name": "tag-top-to-cross-icon-medium",
-        "constant-token-duplicate": false
+        "name": "tag-top-to-cross-icon-medium"
       }
     }
   },
@@ -4801,8 +4365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d93e04b9-1901-4ec4-947a-62c84205e61e",
-        "name": "tag-top-to-cross-icon-small",
-        "constant-token-duplicate": false
+        "name": "tag-top-to-cross-icon-small"
       }
     }
   },
@@ -4812,8 +4375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cb7270a7-8075-435c-81a5-469ef43860c0",
-        "name": "text-area-minimum-height",
-        "constant-token-duplicate": false
+        "name": "text-area-minimum-height"
       }
     }
   },
@@ -4823,8 +4385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c89bcff3-23ce-405c-a776-3ece7a2ac342",
-        "name": "text-area-minimum-width",
-        "constant-token-duplicate": false
+        "name": "text-area-minimum-width"
       }
     }
   },
@@ -4834,8 +4395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "875bbeaf-b4b7-41b9-8e6f-d6a57ec03049",
-        "name": "text-field-minimum-width-multiplier",
-        "constant-token-duplicate": true
+        "name": "text-field-minimum-width-multiplier"
       }
     }
   },
@@ -4845,8 +4405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7f33676b-63dd-4d16-b7e1-36520ade716d",
-        "name": "thumbnail-size-50",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-50"
       }
     }
   },
@@ -4856,8 +4415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "852fc55b-beb7-428c-bc0c-452abc204de3",
-        "name": "thumbnail-size-75",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-75"
       }
     }
   },
@@ -4867,8 +4425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "545604c8-484f-4697-907c-31e2b2cb46d0",
-        "name": "thumbnail-size-100",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-100"
       }
     }
   },
@@ -4878,8 +4435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0e548378-9633-49d2-90d8-b40e1ba7c98e",
-        "name": "thumbnail-size-200",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-200"
       }
     }
   },
@@ -4889,8 +4445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8f4dd02c-d3eb-4654-aea4-b3921048cdbe",
-        "name": "thumbnail-size-300",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-300"
       }
     }
   },
@@ -4900,8 +4455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b0351cf7-f0df-4044-ab26-5b6649ea2e1f",
-        "name": "thumbnail-size-400",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-400"
       }
     }
   },
@@ -4911,8 +4465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1798b58e-fce4-411d-ba8d-75006fa4f53e",
-        "name": "thumbnail-size-500",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-500"
       }
     }
   },
@@ -4922,8 +4475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "543dcd25-42cc-4198-b4ba-ba5524b08691",
-        "name": "thumbnail-size-600",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-600"
       }
     }
   },
@@ -4933,8 +4485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5eab16f9-5537-4a14-958d-d96200c5723f",
-        "name": "thumbnail-size-700",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-700"
       }
     }
   },
@@ -4944,8 +4495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "94ca9817-988a-4e4f-9163-954d29204049",
-        "name": "thumbnail-size-800",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-800"
       }
     }
   },
@@ -4955,8 +4505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "97f11dd2-0173-464c-9eef-c260c9e8cf22",
-        "name": "thumbnail-size-900",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-900"
       }
     }
   },
@@ -4966,8 +4515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cfbf3ec4-f51d-4a50-b81c-765fff84ce14",
-        "name": "thumbnail-size-1000",
-        "constant-token-duplicate": false
+        "name": "thumbnail-size-1000"
       }
     }
   },
@@ -4977,8 +4525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a790fd9e-4e5f-4f4c-a3ca-832540832580",
-        "name": "toast-bottom-to-text",
-        "constant-token-duplicate": false
+        "name": "toast-bottom-to-text"
       }
     }
   },
@@ -4988,8 +4535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "12c8ae92-16b9-48ec-801c-bf07785da4b3",
-        "name": "toast-height",
-        "constant-token-duplicate": false
+        "name": "toast-height"
       }
     }
   },
@@ -4999,8 +4545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a4de5997-1eb1-430f-9a9f-cf2637d02d34",
-        "name": "toast-maximum-width",
-        "constant-token-duplicate": false
+        "name": "toast-maximum-width"
       }
     }
   },
@@ -5010,8 +4555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9f0688f5-128f-47c3-8585-94d704214881",
-        "name": "toast-top-to-text",
-        "constant-token-duplicate": false
+        "name": "toast-top-to-text"
       }
     }
   },
@@ -5021,8 +4565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1f83245b-3d79-4326-b843-df7b6549cade",
-        "name": "toast-top-to-workflow-icon",
-        "constant-token-duplicate": false
+        "name": "toast-top-to-workflow-icon"
       }
     }
   },
@@ -5032,8 +4575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6d7623e1-65f5-4af5-8c08-b33b093b85ae",
-        "name": "tooltip-maximum-width",
-        "constant-token-duplicate": false
+        "name": "tooltip-maximum-width"
       }
     }
   },
@@ -5043,8 +4585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "70c9f65f-1e23-4c47-94dd-0c3ddde15743",
-        "name": "tooltip-tip-height",
-        "constant-token-duplicate": false
+        "name": "tooltip-tip-height"
       }
     }
   },
@@ -5054,8 +4595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ad2c09a6-c42e-4eef-94a3-6c2180c6e2af",
-        "name": "tooltip-tip-width",
-        "constant-token-duplicate": false
+        "name": "tooltip-tip-width"
       }
     }
   },
@@ -5065,8 +4605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "299db7d6-66f6-4fcb-890d-223406c85ae4",
-        "name": "divider-vertical-minimum-height",
-        "constant-token-duplicate": true
+        "name": "divider-vertical-minimum-height"
       }
     }
   },
@@ -5076,8 +4615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a0093378-0b2c-474b-9fe5-76940fd1398b",
-        "name": "divider-horizontal-minimum-width",
-        "constant-token-duplicate": true
+        "name": "divider-horizontal-minimum-width"
       }
     }
   },
@@ -5087,8 +4625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "794ad497-1725-4a03-a7c9-425eaee3178e",
-        "name": "tray-top-to-content-area",
-        "constant-token-duplicate": false
+        "name": "tray-top-to-content-area"
       }
     }
   },
@@ -5098,8 +4635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "53fef925-59e3-4df5-9ac2-e2b4d34d9bca",
-        "name": "tooltip-tip-corner-radius",
-        "constant-token-duplicate": true
+        "name": "tooltip-tip-corner-radius"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout/desktop.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f9456531-ab61-4c14-b7af-7016ce1c0d3e",
-        "name": "android-elevation",
-        "constant-token-duplicate": true
+        "name": "android-elevation"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b5525080-28e7-4eb7-aee9-fb2c71a16f68",
-        "name": "border-width-100",
-        "constant-token-duplicate": true
+        "name": "border-width-100"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cc8a43f4-0ba6-46e3-90af-653fbc59a328",
-        "name": "border-width-200",
-        "constant-token-duplicate": true
+        "name": "border-width-200"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "18b0ff0d-494c-4d33-acab-a62528c5ca66",
-        "name": "border-width-400",
-        "constant-token-duplicate": true
+        "name": "border-width-400"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8b5b5dce-a9c4-4c03-a194-8a5bc716b18a",
-        "name": "character-count-to-field-quiet-extra-large",
-        "constant-token-duplicate": false
+        "name": "character-count-to-field-quiet-extra-large"
       }
     }
   },
@@ -60,8 +55,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3f385135-015a-44dd-bde3-60389b14c2ff",
-        "name": "character-count-to-field-quiet-large",
-        "constant-token-duplicate": false
+        "name": "character-count-to-field-quiet-large"
       }
     }
   },
@@ -71,8 +65,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2ebe9ae0-3b74-47dc-af79-e1dd5f93b9bd",
-        "name": "character-count-to-field-quiet-medium",
-        "constant-token-duplicate": false
+        "name": "character-count-to-field-quiet-medium"
       }
     }
   },
@@ -82,8 +75,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f2f62625-dfd4-46b0-9113-033820745569",
-        "name": "character-count-to-field-quiet-small",
-        "constant-token-duplicate": false
+        "name": "character-count-to-field-quiet-small"
       }
     }
   },
@@ -93,8 +85,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "424db2a9-5795-400b-a98a-58081d311bff",
-        "name": "color-control-track-width",
-        "constant-token-duplicate": false
+        "name": "color-control-track-width"
       }
     }
   },
@@ -104,8 +95,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ee165c7d-3e9a-4a8d-a71f-3083fd7fdc4b",
-        "name": "component-bottom-to-text-50",
-        "constant-token-duplicate": false
+        "name": "component-bottom-to-text-50"
       }
     }
   },
@@ -115,8 +105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "923c46e1-b6f7-4d8a-844d-b4c0661b5e60",
-        "name": "component-bottom-to-text-75",
-        "constant-token-duplicate": false
+        "name": "component-bottom-to-text-75"
       }
     }
   },
@@ -126,8 +115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "24def269-4582-46f6-a00c-8b5a28410917",
-        "name": "component-bottom-to-text-100",
-        "constant-token-duplicate": false
+        "name": "component-bottom-to-text-100"
       }
     }
   },
@@ -137,8 +125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ae65b844-9758-4708-8781-2c8df35af1e9",
-        "name": "component-bottom-to-text-200",
-        "constant-token-duplicate": false
+        "name": "component-bottom-to-text-200"
       }
     }
   },
@@ -148,8 +135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4459554a-d872-4a6a-a620-4a1937605d29",
-        "name": "component-bottom-to-text-300",
-        "constant-token-duplicate": false
+        "name": "component-bottom-to-text-300"
       }
     }
   },
@@ -159,8 +145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b8af0ff9-1e4b-4298-907d-3ffcde88ba03",
-        "name": "component-edge-to-text-50",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-text-50"
       }
     }
   },
@@ -170,8 +155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "40778817-6e47-4b58-a495-c4f34cee78df",
-        "name": "component-edge-to-text-75",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-text-75"
       }
     }
   },
@@ -181,8 +165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0c0d6d38-6734-4312-9be5-dd48dd571841",
-        "name": "component-edge-to-text-100",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-text-100"
       }
     }
   },
@@ -192,8 +175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "44a668d6-e013-4138-a262-383994b0637f",
-        "name": "component-edge-to-text-200",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-text-200"
       }
     }
   },
@@ -203,8 +185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "11088de1-8e3b-4021-968d-a8c59c7b00bd",
-        "name": "component-edge-to-text-300",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-text-300"
       }
     }
   },
@@ -214,8 +195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a0b6c266-499d-4292-9be4-705ddd5e9fbc",
-        "name": "component-edge-to-visual-50",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-50"
       }
     }
   },
@@ -225,8 +205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8d128c7d-ab8e-4a4e-9243-a2e919cb6e6f",
-        "name": "component-edge-to-visual-75",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-75"
       }
     }
   },
@@ -236,8 +215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e220eb52-f821-4807-9ab7-b5f3905d769f",
-        "name": "component-edge-to-visual-100",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-100"
       }
     }
   },
@@ -247,8 +225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e0673a9f-7993-490c-b2db-e8e836837e83",
-        "name": "component-edge-to-visual-200",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-200"
       }
     }
   },
@@ -258,8 +235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a0ce87ca-29e0-40e3-b7dc-c53678effd9b",
-        "name": "component-edge-to-visual-300",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-300"
       }
     }
   },
@@ -269,8 +245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9c536051-7794-4282-bf07-c920cda83cbe",
-        "name": "component-edge-to-visual-only-50",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-only-50"
       }
     }
   },
@@ -280,8 +255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c38259e9-87f4-4e7d-a041-692ca676a638",
-        "name": "component-edge-to-visual-only-75",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-only-75"
       }
     }
   },
@@ -291,8 +265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8fec6012-7cba-4ac5-94d7-14f39fce7612",
-        "name": "component-edge-to-visual-only-100",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-only-100"
       }
     }
   },
@@ -302,8 +275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0bf1ad10-235a-4c81-aba7-5bf55acc877d",
-        "name": "component-edge-to-visual-only-200",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-only-200"
       }
     }
   },
@@ -313,8 +285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "815523cd-8c01-4125-bb22-3a548f1cc702",
-        "name": "component-edge-to-visual-only-300",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-only-300"
       }
     }
   },
@@ -324,8 +295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "81ebf2b1-01fd-45a3-a099-72048e7d7991",
-        "name": "component-height-50",
-        "constant-token-duplicate": false
+        "name": "component-height-50"
       }
     }
   },
@@ -335,8 +305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f70d4c16-f588-4fa9-9318-b7184a739193",
-        "name": "component-height-75",
-        "constant-token-duplicate": false
+        "name": "component-height-75"
       }
     }
   },
@@ -346,8 +315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3d7afc6a-f66b-4033-9ed4-e60cde661a18",
-        "name": "component-height-100",
-        "constant-token-duplicate": false
+        "name": "component-height-100"
       }
     }
   },
@@ -357,8 +325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8bf70f40-b282-4c5d-98f0-329245bdb6f9",
-        "name": "component-height-200",
-        "constant-token-duplicate": false
+        "name": "component-height-200"
       }
     }
   },
@@ -368,8 +335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f4aaa7bb-e724-42ad-8ddf-934cc972995a",
-        "name": "component-height-300",
-        "constant-token-duplicate": false
+        "name": "component-height-300"
       }
     }
   },
@@ -379,8 +345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e146c28f-3349-48fc-8281-6997ab9da222",
-        "name": "component-height-400",
-        "constant-token-duplicate": false
+        "name": "component-height-400"
       }
     }
   },
@@ -390,8 +355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b5211351-b7df-430a-93bf-906ac66ebf2e",
-        "name": "component-height-500",
-        "constant-token-duplicate": false
+        "name": "component-height-500"
       }
     }
   },
@@ -401,8 +365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5c80900c-ff68-4b78-86fa-571bbf1eb9aa",
-        "name": "component-pill-edge-to-text-75",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-text-75"
       }
     }
   },
@@ -412,8 +375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3c96bdad-6e05-4a1b-930b-92d35adf5d9d",
-        "name": "component-pill-edge-to-text-100",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-text-100"
       }
     }
   },
@@ -423,8 +385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4cca2097-286e-46d5-bc8e-273ea50354e7",
-        "name": "component-pill-edge-to-text-200",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-text-200"
       }
     }
   },
@@ -434,8 +395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "29fa8da5-3f74-4141-bfb1-0f2847655345",
-        "name": "component-pill-edge-to-text-300",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-text-300"
       }
     }
   },
@@ -445,8 +405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3eaca9fb-25c0-4a1d-8c44-320cc0e0305b",
-        "name": "component-pill-edge-to-visual-75",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-75"
       }
     }
   },
@@ -456,8 +415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fff86b73-4e28-4453-9ba3-7c40998ace07",
-        "name": "component-pill-edge-to-visual-100",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-100"
       }
     }
   },
@@ -467,8 +425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b9324a3c-557e-4832-8418-1d7783e7b9be",
-        "name": "component-pill-edge-to-visual-200",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-200"
       }
     }
   },
@@ -478,8 +435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4ccb4a02-6aa9-459a-a459-1d0ebbe2dc11",
-        "name": "component-pill-edge-to-visual-300",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-300"
       }
     }
   },
@@ -489,8 +445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "47f5ab02-22db-4d82-be1d-804669d7fbd4",
-        "name": "component-pill-edge-to-visual-only-75",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-only-75"
       }
     }
   },
@@ -500,8 +455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dd9e6e28-a382-46a1-a6e0-f73c8cc0ed70",
-        "name": "component-pill-edge-to-visual-only-100",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-only-100"
       }
     }
   },
@@ -511,8 +465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "64cdd254-d3fe-40e6-97a8-76dd8156afa8",
-        "name": "component-pill-edge-to-visual-only-200",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-only-200"
       }
     }
   },
@@ -522,8 +475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9654369a-5bf8-4436-a331-aeac1fd25a70",
-        "name": "component-pill-edge-to-visual-only-300",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-only-300"
       }
     }
   },
@@ -533,8 +485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9ef4a0a5-b81c-4f54-8927-286ece29a824",
-        "name": "component-size-difference-down",
-        "constant-token-duplicate": true
+        "name": "component-size-difference-down"
       }
     }
   },
@@ -544,8 +495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "103daec0-9711-4422-84d1-62ab77afa00d",
-        "name": "component-size-minimum-perspective-down",
-        "constant-token-duplicate": true
+        "name": "component-size-minimum-perspective-down"
       }
     }
   },
@@ -555,8 +505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4ee7342c-f2ef-4554-af0f-011052ff6177",
-        "name": "component-size-width-ratio-down",
-        "constant-token-duplicate": true
+        "name": "component-size-width-ratio-down"
       }
     }
   },
@@ -566,8 +515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e4ad85b2-97bf-48cf-a5a9-3ff3d1fada5b",
-        "name": "corner-radius-1000",
-        "constant-token-duplicate": false
+        "name": "corner-radius-1000"
       }
     }
   },
@@ -577,8 +525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "31f44472-9681-469c-8ba2-9efc27eb981d",
-        "name": "component-to-menu-extra-large",
-        "constant-token-duplicate": false
+        "name": "component-to-menu-extra-large"
       }
     }
   },
@@ -588,8 +535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d03d1199-f49d-4e57-8434-b94efe5da440",
-        "name": "component-to-menu-large",
-        "constant-token-duplicate": false
+        "name": "component-to-menu-large"
       }
     }
   },
@@ -599,8 +545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0190ca9d-9f28-45b2-9dc7-c715089faebb",
-        "name": "component-to-menu-medium",
-        "constant-token-duplicate": false
+        "name": "component-to-menu-medium"
       }
     }
   },
@@ -610,8 +555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4db24ebf-e169-4220-b895-787fe09f8658",
-        "name": "component-to-menu-small",
-        "constant-token-duplicate": false
+        "name": "component-to-menu-small"
       }
     }
   },
@@ -621,8 +565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c71c0953-d9da-4e22-93a1-6982c7665ed6",
-        "name": "component-top-to-text-50",
-        "constant-token-duplicate": false
+        "name": "component-top-to-text-50"
       }
     }
   },
@@ -632,8 +575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "477d659b-6489-4e90-84db-75a93174559a",
-        "name": "component-top-to-text-75",
-        "constant-token-duplicate": false
+        "name": "component-top-to-text-75"
       }
     }
   },
@@ -643,8 +585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "15bf492b-3a65-4577-8a3b-df09026b96a7",
-        "name": "component-top-to-text-100",
-        "constant-token-duplicate": false
+        "name": "component-top-to-text-100"
       }
     }
   },
@@ -654,8 +595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c7914376-3769-4172-8467-fb811b3c155f",
-        "name": "component-top-to-text-200",
-        "constant-token-duplicate": false
+        "name": "component-top-to-text-200"
       }
     }
   },
@@ -665,8 +605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9bf3970e-eb76-4be5-82c4-0df2538df753",
-        "name": "component-top-to-text-300",
-        "constant-token-duplicate": false
+        "name": "component-top-to-text-300"
       }
     }
   },
@@ -676,8 +615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0fafc819-d65b-4952-849a-b3c426e9a4a9",
-        "name": "component-top-to-workflow-icon-50",
-        "constant-token-duplicate": false
+        "name": "component-top-to-workflow-icon-50"
       }
     }
   },
@@ -687,8 +625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2bc8b2ca-9792-4034-a604-43ce28ce8ede",
-        "name": "component-top-to-workflow-icon-75",
-        "constant-token-duplicate": false
+        "name": "component-top-to-workflow-icon-75"
       }
     }
   },
@@ -698,8 +635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c3a280b0-bc84-4a7c-8048-c689f8deef86",
-        "name": "component-top-to-workflow-icon-100",
-        "constant-token-duplicate": false
+        "name": "component-top-to-workflow-icon-100"
       }
     }
   },
@@ -709,8 +645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ef82b92a-2cbd-4b70-920c-4b999b018e07",
-        "name": "component-top-to-workflow-icon-200",
-        "constant-token-duplicate": false
+        "name": "component-top-to-workflow-icon-200"
       }
     }
   },
@@ -720,8 +655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "72d6ae5c-e133-4e7f-bc96-3e4c28d586fd",
-        "name": "component-top-to-workflow-icon-300",
-        "constant-token-duplicate": false
+        "name": "component-top-to-workflow-icon-300"
       }
     }
   },
@@ -731,8 +665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bb9d8350-b1fb-4496-9c22-6ec9647ff117",
-        "name": "corner-radius-0",
-        "constant-token-duplicate": false
+        "name": "corner-radius-0"
       }
     }
   },
@@ -742,8 +675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ecb9d03a-7340-4b43-8aa7-f89eef9f3a20",
-        "name": "corner-radius-75",
-        "constant-token-duplicate": false
+        "name": "corner-radius-75"
       }
     }
   },
@@ -753,8 +685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bf24d15e-ad86-4b6a-a9e0-e8fd49a5ae30",
-        "name": "corner-radius-100",
-        "constant-token-duplicate": false
+        "name": "corner-radius-100"
       }
     }
   },
@@ -764,8 +695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "52ad01be-f512-4fa3-ae67-8c6cef70810c",
-        "name": "corner-radius-200",
-        "constant-token-duplicate": false
+        "name": "corner-radius-200"
       }
     }
   },
@@ -775,8 +705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "154642d7-c23d-44fd-9d79-b719ef32922e",
-        "name": "corner-radius-300",
-        "constant-token-duplicate": false
+        "name": "corner-radius-300"
       }
     }
   },
@@ -786,8 +715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "690db7ae-cae8-49bb-8777-b4f1829b2f0b",
-        "name": "corner-radius-400",
-        "constant-token-duplicate": false
+        "name": "corner-radius-400"
       }
     }
   },
@@ -797,8 +725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ada2ea1d-1728-411a-8aae-a198ce390a25",
-        "name": "corner-radius-500",
-        "constant-token-duplicate": false
+        "name": "corner-radius-500"
       }
     }
   },
@@ -808,8 +735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "abc0f309-3bd2-4800-af12-b27386e86617",
-        "name": "corner-radius-600",
-        "constant-token-duplicate": false
+        "name": "corner-radius-600"
       }
     }
   },
@@ -819,8 +745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cb6b72ed-a9a1-4113-b147-1ef369fe6269",
-        "name": "corner-radius-700",
-        "constant-token-duplicate": false
+        "name": "corner-radius-700"
       }
     }
   },
@@ -830,8 +755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8fc023ca-8aec-40fe-9130-087aa035bac7",
-        "name": "corner-radius-800",
-        "constant-token-duplicate": false
+        "name": "corner-radius-800"
       }
     }
   },
@@ -841,8 +765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7a11b308-bed2-4b6f-bb4a-c9ae4ef8e03d",
-        "name": "corner-radius-none",
-        "constant-token-duplicate": false
+        "name": "corner-radius-none"
       }
     }
   },
@@ -852,8 +775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b4971f86-aeea-42c9-9ba7-a74cf4d1a545",
-        "name": "corner-radius-small-default",
-        "constant-token-duplicate": false
+        "name": "corner-radius-small-default"
       }
     }
   },
@@ -863,8 +785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a83a882e-430c-46fc-a8be-5ade0dd8a4c6",
-        "name": "corner-radius-medium-default",
-        "constant-token-duplicate": false
+        "name": "corner-radius-medium-default"
       }
     }
   },
@@ -874,8 +795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "29981aef-aea6-4cde-849f-4bc67e320ea7",
-        "name": "corner-radius-large-default",
-        "constant-token-duplicate": false
+        "name": "corner-radius-large-default"
       }
     }
   },
@@ -885,8 +805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d639a0b5-16b4-4d75-ab37-d87815c7b500",
-        "name": "corner-radius-extra-large-default",
-        "constant-token-duplicate": false
+        "name": "corner-radius-extra-large-default"
       }
     }
   },
@@ -896,8 +815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4853520b-bda3-45d1-bd20-8508cac08847",
-        "name": "corner-radius-full",
-        "constant-token-duplicate": false
+        "name": "corner-radius-full"
       }
     }
   },
@@ -907,8 +825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3d39e5de-0800-4629-ae1a-99a34706a772",
-        "name": "corner-radius-small-size-small",
-        "constant-token-duplicate": false
+        "name": "corner-radius-small-size-small"
       }
     }
   },
@@ -918,8 +835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a62a43dd-cb2a-4e18-bb94-7a9518668400",
-        "name": "corner-radius-small-size-medium",
-        "constant-token-duplicate": false
+        "name": "corner-radius-small-size-medium"
       }
     }
   },
@@ -929,8 +845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f4f0bfc9-ce6d-473f-8dda-c9f21fb8a7b7",
-        "name": "corner-radius-small-size-large",
-        "constant-token-duplicate": false
+        "name": "corner-radius-small-size-large"
       }
     }
   },
@@ -940,8 +855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d59337d1-4cec-43c0-821e-06a56745cbcc",
-        "name": "corner-radius-small-size-extra-large",
-        "constant-token-duplicate": false
+        "name": "corner-radius-small-size-extra-large"
       }
     }
   },
@@ -951,8 +865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d0e02d98-e93f-4f81-8d81-8f95e06ad360",
-        "name": "corner-radius-medium-size-extra-small",
-        "constant-token-duplicate": false
+        "name": "corner-radius-medium-size-extra-small"
       }
     }
   },
@@ -962,8 +875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "892bc9de-16b2-4c51-9c18-b239e52ffd14",
-        "name": "corner-radius-medium-size-small",
-        "constant-token-duplicate": false
+        "name": "corner-radius-medium-size-small"
       }
     }
   },
@@ -973,8 +885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "67fb5355-6d7c-4e4e-a4cb-cdba10a85d84",
-        "name": "corner-radius-medium-size-medium",
-        "constant-token-duplicate": false
+        "name": "corner-radius-medium-size-medium"
       }
     }
   },
@@ -984,8 +895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ede17e00-83ef-40c5-a1d0-a46372d3fc90",
-        "name": "corner-radius-medium-size-large",
-        "constant-token-duplicate": false
+        "name": "corner-radius-medium-size-large"
       }
     }
   },
@@ -995,8 +905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "81752b3e-488a-4273-abb5-4ba8b7f278d9",
-        "name": "corner-radius-medium-size-extra-large",
-        "constant-token-duplicate": false
+        "name": "corner-radius-medium-size-extra-large"
       }
     }
   },
@@ -1006,8 +915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ba7492f3-1a19-4d75-98cc-34a0d46ea802",
-        "name": "disclosure-indicator-top-to-disclosure-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "disclosure-indicator-top-to-disclosure-icon-extra-large"
       }
     }
   },
@@ -1017,8 +925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ae9bbf8d-a896-4667-9034-2fd2dfeb1981",
-        "name": "disclosure-indicator-top-to-disclosure-icon-large",
-        "constant-token-duplicate": false
+        "name": "disclosure-indicator-top-to-disclosure-icon-large"
       }
     }
   },
@@ -1028,8 +935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1e644622-9b4a-4cce-9cf7-2474d58f4956",
-        "name": "disclosure-indicator-top-to-disclosure-icon-medium",
-        "constant-token-duplicate": false
+        "name": "disclosure-indicator-top-to-disclosure-icon-medium"
       }
     }
   },
@@ -1039,8 +945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e8e0164f-2588-4c8e-9b85-543ce5a8fadb",
-        "name": "disclosure-indicator-top-to-disclosure-icon-small",
-        "constant-token-duplicate": false
+        "name": "disclosure-indicator-top-to-disclosure-icon-small"
       }
     }
   },
@@ -1050,8 +955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ac20a6da-31a7-4c8b-b361-0ad820cd8429",
-        "name": "drop-shadow-blur",
-        "constant-token-duplicate": false
+        "name": "drop-shadow-blur"
       }
     }
   },
@@ -1061,8 +965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "81415747-aa3f-4ef3-b0bc-7c33f07a4316",
-        "name": "drop-shadow-x",
-        "constant-token-duplicate": false
+        "name": "drop-shadow-x"
       }
     }
   },
@@ -1072,8 +975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c530129f-248c-4e36-ba7f-05d6d6a53962",
-        "name": "drop-shadow-y",
-        "constant-token-duplicate": false
+        "name": "drop-shadow-y"
       }
     }
   },
@@ -1083,8 +985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7ea18d45-d6e1-4ef0-859d-4d39a3e0527a",
-        "name": "field-edge-to-alert-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-alert-icon-extra-large"
       }
     }
   },
@@ -1094,8 +995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e0b53a9a-e95a-45b8-b9b2-a16b70096c05",
-        "name": "field-edge-to-alert-icon-large",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-alert-icon-large"
       }
     }
   },
@@ -1105,8 +1005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dd684a30-2e49-4096-8b1c-40fbd6c8cac2",
-        "name": "field-edge-to-alert-icon-medium",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-alert-icon-medium"
       }
     }
   },
@@ -1116,8 +1015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7858fdf3-e35f-4bc5-997a-0d480ec1cb32",
-        "name": "field-edge-to-alert-icon-quiet",
-        "constant-token-duplicate": true
+        "name": "field-edge-to-alert-icon-quiet"
       }
     }
   },
@@ -1127,8 +1025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "20658099-94df-4c6c-a2f2-558c92174121",
-        "name": "field-edge-to-alert-icon-small",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-alert-icon-small"
       }
     }
   },
@@ -1138,8 +1035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7fb81dcf-3329-4353-917d-75de8f43c05d",
-        "name": "field-edge-to-border-quiet",
-        "constant-token-duplicate": true
+        "name": "field-edge-to-border-quiet"
       }
     }
   },
@@ -1149,8 +1045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7b68e88f-8ddd-496e-9fae-7fbe44317965",
-        "name": "field-edge-to-disclosure-icon-75",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-disclosure-icon-75"
       }
     }
   },
@@ -1160,8 +1055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "71b53c8b-fbbb-4f84-847a-45db5ad8006f",
-        "name": "field-edge-to-disclosure-icon-100",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-disclosure-icon-100"
       }
     }
   },
@@ -1171,8 +1065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "77792f9d-b462-48e6-a4de-abf804bed3cd",
-        "name": "field-edge-to-disclosure-icon-200",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-disclosure-icon-200"
       }
     }
   },
@@ -1182,8 +1075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e84ef1dc-392b-4ab9-a13b-76364484a28d",
-        "name": "field-edge-to-disclosure-icon-300",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-disclosure-icon-300"
       }
     }
   },
@@ -1193,8 +1085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3f7cee20-c187-4066-be4b-f5a1335736f5",
-        "name": "field-edge-to-text-quiet",
-        "constant-token-duplicate": true
+        "name": "field-edge-to-text-quiet"
       }
     }
   },
@@ -1204,8 +1095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9379019f-5498-45d1-8590-deb8a234a3d4",
-        "name": "field-edge-to-validation-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-validation-icon-extra-large"
       }
     }
   },
@@ -1215,8 +1105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "faf7879f-d9c1-4bf1-8af7-95f48240bcf0",
-        "name": "field-edge-to-validation-icon-large",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-validation-icon-large"
       }
     }
   },
@@ -1226,8 +1115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a93c8845-c89b-4e8d-b06e-c34e7c7b0e99",
-        "name": "field-edge-to-validation-icon-medium",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-validation-icon-medium"
       }
     }
   },
@@ -1237,8 +1125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "151915e5-f946-474f-9595-18d8a159a6ff",
-        "name": "field-edge-to-validation-icon-quiet",
-        "constant-token-duplicate": true
+        "name": "field-edge-to-validation-icon-quiet"
       }
     }
   },
@@ -1248,8 +1135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9ab112d7-af82-4b28-9bc2-a1216af87aea",
-        "name": "field-edge-to-validation-icon-small",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-validation-icon-small"
       }
     }
   },
@@ -1259,8 +1145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "89f16f89-fd7d-41d7-8e5c-464007fd0277",
-        "name": "field-edge-to-visual-quiet",
-        "constant-token-duplicate": true
+        "name": "field-edge-to-visual-quiet"
       }
     }
   },
@@ -1270,8 +1155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b79e5061-87c4-495c-ab01-90dcc5ae14ab",
-        "name": "field-end-edge-to-disclosure-icon-75",
-        "constant-token-duplicate": false
+        "name": "field-end-edge-to-disclosure-icon-75"
       }
     }
   },
@@ -1281,8 +1165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9fa71233-f98e-4d48-b2af-29552a62a479",
-        "name": "field-end-edge-to-disclosure-icon-100",
-        "constant-token-duplicate": false
+        "name": "field-end-edge-to-disclosure-icon-100"
       }
     }
   },
@@ -1292,8 +1175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "622a39c4-4ed1-4637-8e8d-e8e6a72099b2",
-        "name": "field-end-edge-to-disclosure-icon-200",
-        "constant-token-duplicate": false
+        "name": "field-end-edge-to-disclosure-icon-200"
       }
     }
   },
@@ -1303,8 +1185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "43ec5915-b039-4210-9bc0-ce547f90ce32",
-        "name": "field-end-edge-to-disclosure-icon-300",
-        "constant-token-duplicate": false
+        "name": "field-end-edge-to-disclosure-icon-300"
       }
     }
   },
@@ -1314,8 +1195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "248144ce-6640-40ce-96a3-162c406c7edf",
-        "name": "field-text-to-alert-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-text-to-alert-icon-extra-large"
       }
     }
   },
@@ -1325,8 +1205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0f40702e-876a-4fb4-aeb7-ea56c26c081b",
-        "name": "field-text-to-alert-icon-large",
-        "constant-token-duplicate": false
+        "name": "field-text-to-alert-icon-large"
       }
     }
   },
@@ -1336,8 +1215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cce2dfd4-b10f-4386-8f16-2bc2d47e49f5",
-        "name": "field-text-to-alert-icon-medium",
-        "constant-token-duplicate": false
+        "name": "field-text-to-alert-icon-medium"
       }
     }
   },
@@ -1347,8 +1225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2d900e70-913e-4d45-9ef4-2ef8d80798fc",
-        "name": "field-text-to-alert-icon-small",
-        "constant-token-duplicate": false
+        "name": "field-text-to-alert-icon-small"
       }
     }
   },
@@ -1358,8 +1235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8a573d4a-0543-4e77-8f54-5ad1706d87e7",
-        "name": "field-text-to-validation-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-text-to-validation-icon-extra-large"
       }
     }
   },
@@ -1369,8 +1245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f9729ef3-9807-4401-80dd-b1c209c00065",
-        "name": "field-text-to-validation-icon-large",
-        "constant-token-duplicate": false
+        "name": "field-text-to-validation-icon-large"
       }
     }
   },
@@ -1380,8 +1255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "da53a8e5-95c3-48dd-a9c0-5ed2de25240d",
-        "name": "field-text-to-validation-icon-medium",
-        "constant-token-duplicate": false
+        "name": "field-text-to-validation-icon-medium"
       }
     }
   },
@@ -1391,8 +1265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "574ddef0-b45b-49a1-b057-fb2eacfbd36f",
-        "name": "field-text-to-validation-icon-small",
-        "constant-token-duplicate": false
+        "name": "field-text-to-validation-icon-small"
       }
     }
   },
@@ -1402,8 +1275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "78286e58-d73a-42a8-a13c-a910d7fbb82d",
-        "name": "field-top-to-alert-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-top-to-alert-icon-extra-large"
       }
     }
   },
@@ -1413,8 +1285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7e21ccc7-ba55-4e0f-b5a5-1bd95406546f",
-        "name": "field-top-to-alert-icon-large",
-        "constant-token-duplicate": false
+        "name": "field-top-to-alert-icon-large"
       }
     }
   },
@@ -1424,8 +1295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "adac6224-8e2f-4cdb-8684-9365164a1499",
-        "name": "field-top-to-alert-icon-medium",
-        "constant-token-duplicate": false
+        "name": "field-top-to-alert-icon-medium"
       }
     }
   },
@@ -1435,8 +1305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f265e6d5-8bbd-464e-b6c7-637224756e95",
-        "name": "field-top-to-alert-icon-small",
-        "constant-token-duplicate": false
+        "name": "field-top-to-alert-icon-small"
       }
     }
   },
@@ -1446,8 +1315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c5778e77-0ff1-431a-a72e-37f3066d3257",
-        "name": "field-top-to-disclosure-icon-75",
-        "constant-token-duplicate": false
+        "name": "field-top-to-disclosure-icon-75"
       }
     }
   },
@@ -1457,8 +1325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "62c3618c-f28f-4b56-9227-a061dc54d19d",
-        "name": "field-top-to-disclosure-icon-100",
-        "constant-token-duplicate": false
+        "name": "field-top-to-disclosure-icon-100"
       }
     }
   },
@@ -1468,8 +1335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bdf0fc6a-404c-492c-86bb-5d2ba06714e6",
-        "name": "field-top-to-disclosure-icon-200",
-        "constant-token-duplicate": false
+        "name": "field-top-to-disclosure-icon-200"
       }
     }
   },
@@ -1479,8 +1345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d5db6c17-700e-4782-9c29-001269b50200",
-        "name": "field-top-to-disclosure-icon-300",
-        "constant-token-duplicate": false
+        "name": "field-top-to-disclosure-icon-300"
       }
     }
   },
@@ -1490,8 +1355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "efcd740a-033e-493a-a902-e2f657897bd4",
-        "name": "field-top-to-progress-circle-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-top-to-progress-circle-extra-large"
       }
     }
   },
@@ -1501,8 +1365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "24784275-a117-4767-98ee-5d8a08c89296",
-        "name": "field-top-to-progress-circle-large",
-        "constant-token-duplicate": false
+        "name": "field-top-to-progress-circle-large"
       }
     }
   },
@@ -1512,8 +1375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7a3120a8-3c98-4227-afb4-5d6a8aa78e14",
-        "name": "field-top-to-progress-circle-medium",
-        "constant-token-duplicate": false
+        "name": "field-top-to-progress-circle-medium"
       }
     }
   },
@@ -1523,8 +1385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9aac1df2-1693-43f1-ae43-b23c21a42f71",
-        "name": "field-top-to-progress-circle-small",
-        "constant-token-duplicate": false
+        "name": "field-top-to-progress-circle-small"
       }
     }
   },
@@ -1534,8 +1395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "aa10c6ff-8cf6-4e68-8181-ca5e64f5c26f",
-        "name": "field-top-to-validation-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-top-to-validation-icon-extra-large"
       }
     }
   },
@@ -1545,8 +1405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "97435915-44ba-4ace-993f-a0fac52e41f2",
-        "name": "field-top-to-validation-icon-large",
-        "constant-token-duplicate": false
+        "name": "field-top-to-validation-icon-large"
       }
     }
   },
@@ -1556,8 +1415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2cdb6de8-d494-467d-bf9d-7fa96829bf82",
-        "name": "field-top-to-validation-icon-medium",
-        "constant-token-duplicate": false
+        "name": "field-top-to-validation-icon-medium"
       }
     }
   },
@@ -1567,8 +1425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2aad124e-19f5-404c-921e-e2060bc48f07",
-        "name": "field-top-to-validation-icon-small",
-        "constant-token-duplicate": false
+        "name": "field-top-to-validation-icon-small"
       }
     }
   },
@@ -1578,8 +1435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "096ddcb7-5afd-416f-9a11-4275556c4b52",
-        "name": "field-width",
-        "constant-token-duplicate": false
+        "name": "field-width"
       }
     }
   },
@@ -1589,8 +1445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "693651ef-71c7-4096-91a5-1c84cb861021",
-        "name": "focus-indicator-gap",
-        "constant-token-duplicate": true
+        "name": "focus-indicator-gap"
       }
     }
   },
@@ -1600,8 +1455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b6148878-b78d-4fe7-bf78-e01e7cb314c2",
-        "name": "focus-indicator-thickness",
-        "constant-token-duplicate": true
+        "name": "focus-indicator-thickness"
       }
     }
   },
@@ -1611,8 +1465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ac4d18d5-361c-4425-82c3-83979d58f682",
-        "name": "navigational-indicator-top-to-back-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "navigational-indicator-top-to-back-icon-extra-large"
       }
     }
   },
@@ -1622,8 +1475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c0e06d21-7372-401f-9ec2-926e2b1faf26",
-        "name": "navigational-indicator-top-to-back-icon-large",
-        "constant-token-duplicate": false
+        "name": "navigational-indicator-top-to-back-icon-large"
       }
     }
   },
@@ -1633,8 +1485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5561a148-fd77-44d3-b29d-3ed7389122a1",
-        "name": "navigational-indicator-top-to-back-icon-medium",
-        "constant-token-duplicate": false
+        "name": "navigational-indicator-top-to-back-icon-medium"
       }
     }
   },
@@ -1644,8 +1495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "70de4f97-bc4a-44af-9995-1042e3c7c78f",
-        "name": "navigational-indicator-top-to-back-icon-small",
-        "constant-token-duplicate": false
+        "name": "navigational-indicator-top-to-back-icon-small"
       }
     }
   },
@@ -1655,8 +1505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "146add82-4f20-46c3-bacf-4d24d60d0e10",
-        "name": "side-label-character-count-to-field",
-        "constant-token-duplicate": false
+        "name": "side-label-character-count-to-field"
       }
     }
   },
@@ -1666,8 +1515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9b1f15bf-ea4f-4f82-8c4f-3770b7f47353",
-        "name": "side-label-character-count-top-margin-extra-large",
-        "constant-token-duplicate": false
+        "name": "side-label-character-count-top-margin-extra-large"
       }
     }
   },
@@ -1677,8 +1525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e2d9e241-469a-4b03-bd6a-a105a8ed5e00",
-        "name": "side-label-character-count-top-margin-large",
-        "constant-token-duplicate": false
+        "name": "side-label-character-count-top-margin-large"
       }
     }
   },
@@ -1688,8 +1535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4d93210f-f01a-4d1c-8c10-2cb4b9d14626",
-        "name": "side-label-character-count-top-margin-medium",
-        "constant-token-duplicate": false
+        "name": "side-label-character-count-top-margin-medium"
       }
     }
   },
@@ -1699,8 +1545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a86ae363-b6b4-4da0-9630-97336922b3a1",
-        "name": "side-label-character-count-top-margin-small",
-        "constant-token-duplicate": false
+        "name": "side-label-character-count-top-margin-small"
       }
     }
   },
@@ -1710,8 +1555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1b06f6e2-d9be-4934-b3da-bed75986d104",
-        "name": "spacing-50",
-        "constant-token-duplicate": true
+        "name": "spacing-50"
       }
     }
   },
@@ -1721,8 +1565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "576a60a3-ca80-46c5-a066-ba7b6197decd",
-        "name": "spacing-75",
-        "constant-token-duplicate": true
+        "name": "spacing-75"
       }
     }
   },
@@ -1732,8 +1575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
-        "name": "spacing-100",
-        "constant-token-duplicate": true
+        "name": "spacing-100"
       }
     }
   },
@@ -1743,8 +1585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
-        "name": "spacing-200",
-        "constant-token-duplicate": true
+        "name": "spacing-200"
       }
     }
   },
@@ -1754,8 +1595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ba632ede-84a7-4e56-91ef-8143b2499452",
-        "name": "spacing-300",
-        "constant-token-duplicate": true
+        "name": "spacing-300"
       }
     }
   },
@@ -1765,8 +1605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ec565065-0820-460f-9a1b-b81911c48cb5",
-        "name": "spacing-400",
-        "constant-token-duplicate": true
+        "name": "spacing-400"
       }
     }
   },
@@ -1776,8 +1615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "490b4010-1561-4b12-8cbb-cdb4b650ba74",
-        "name": "spacing-500",
-        "constant-token-duplicate": true
+        "name": "spacing-500"
       }
     }
   },
@@ -1787,8 +1625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b6d0b881-d25e-452c-9069-c18745d21f33",
-        "name": "spacing-600",
-        "constant-token-duplicate": true
+        "name": "spacing-600"
       }
     }
   },
@@ -1798,8 +1635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "26639049-ec07-430d-983f-4d036758564a",
-        "name": "spacing-700",
-        "constant-token-duplicate": true
+        "name": "spacing-700"
       }
     }
   },
@@ -1809,8 +1645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "eeb099cb-707f-4e5e-97b9-1fdba35b2314",
-        "name": "spacing-800",
-        "constant-token-duplicate": true
+        "name": "spacing-800"
       }
     }
   },
@@ -1820,8 +1655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d04e5d81-0b6e-48e7-9e47-744753dfcff3",
-        "name": "spacing-900",
-        "constant-token-duplicate": true
+        "name": "spacing-900"
       }
     }
   },
@@ -1831,8 +1665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9d688a67-5ff6-4b72-8398-964c0337dce1",
-        "name": "spacing-1000",
-        "constant-token-duplicate": true
+        "name": "spacing-1000"
       }
     }
   },
@@ -1842,8 +1675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "aa27af6e-baef-4d7c-bf8c-f9a972e51713",
-        "name": "text-to-control-75",
-        "constant-token-duplicate": false
+        "name": "text-to-control-75"
       }
     }
   },
@@ -1853,8 +1685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "24a438ce-be6a-477e-aa0e-a3e97e286904",
-        "name": "text-to-control-100",
-        "constant-token-duplicate": false
+        "name": "text-to-control-100"
       }
     }
   },
@@ -1864,8 +1695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "307fb510-8759-41ee-89d2-fcfe4d554b85",
-        "name": "text-to-control-200",
-        "constant-token-duplicate": false
+        "name": "text-to-control-200"
       }
     }
   },
@@ -1875,8 +1705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7cde8c74-2ac9-4468-a25e-06c1a6cd9cbe",
-        "name": "text-to-control-300",
-        "constant-token-duplicate": false
+        "name": "text-to-control-300"
       }
     }
   },
@@ -1886,8 +1715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ff1fadc2-9ec0-456f-a054-4512e51c85c8",
-        "name": "text-to-visual-50",
-        "constant-token-duplicate": false
+        "name": "text-to-visual-50"
       }
     }
   },
@@ -1897,8 +1725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "50763a0d-c6eb-47f0-8b56-4c86ee22a430",
-        "name": "text-to-visual-75",
-        "constant-token-duplicate": false
+        "name": "text-to-visual-75"
       }
     }
   },
@@ -1908,8 +1735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1d601d0a-d6d0-4711-9fb9-71898c2bcc9a",
-        "name": "text-to-visual-100",
-        "constant-token-duplicate": false
+        "name": "text-to-visual-100"
       }
     }
   },
@@ -1919,8 +1745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7ce11af3-b94b-4239-a310-f8d09635779a",
-        "name": "text-to-visual-200",
-        "constant-token-duplicate": false
+        "name": "text-to-visual-200"
       }
     }
   },
@@ -1930,8 +1755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4366909e-3bfb-481c-abdc-4ae71f965bc3",
-        "name": "text-to-visual-300",
-        "constant-token-duplicate": false
+        "name": "text-to-visual-300"
       }
     }
   },
@@ -1941,8 +1765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d9d51235-f3fe-4e2a-bdca-b6a104d9a9e5",
-        "name": "text-underline-gap",
-        "constant-token-duplicate": true
+        "name": "text-underline-gap"
       }
     }
   },
@@ -1952,8 +1775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "13f36ce1-84bb-41db-bec8-6d6e8f5c6ed3",
-        "name": "text-underline-thickness",
-        "constant-token-duplicate": true
+        "name": "text-underline-thickness"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout/mobile.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f9456531-ab61-4c14-b7af-7016ce1c0d3e",
-        "name": "android-elevation",
-        "constant-token-duplicate": true
+        "name": "android-elevation"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b5525080-28e7-4eb7-aee9-fb2c71a16f68",
-        "name": "border-width-100",
-        "constant-token-duplicate": true
+        "name": "border-width-100"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cc8a43f4-0ba6-46e3-90af-653fbc59a328",
-        "name": "border-width-200",
-        "constant-token-duplicate": true
+        "name": "border-width-200"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "18b0ff0d-494c-4d33-acab-a62528c5ca66",
-        "name": "border-width-400",
-        "constant-token-duplicate": true
+        "name": "border-width-400"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2cfe025b-8bf8-47a3-8ff1-733cf62dd182",
-        "name": "character-count-to-field-quiet-extra-large",
-        "constant-token-duplicate": false
+        "name": "character-count-to-field-quiet-extra-large"
       }
     }
   },
@@ -60,8 +55,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cef58f98-9fb0-4fbb-b6aa-dc5786d7658a",
-        "name": "character-count-to-field-quiet-large",
-        "constant-token-duplicate": false
+        "name": "character-count-to-field-quiet-large"
       }
     }
   },
@@ -71,8 +65,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1cecea81-8c7f-4658-b3a2-0e1282f7eac9",
-        "name": "character-count-to-field-quiet-medium",
-        "constant-token-duplicate": false
+        "name": "character-count-to-field-quiet-medium"
       }
     }
   },
@@ -82,8 +75,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "819cdbf4-9e26-4fdf-895d-8f60c06efa2a",
-        "name": "character-count-to-field-quiet-small",
-        "constant-token-duplicate": false
+        "name": "character-count-to-field-quiet-small"
       }
     }
   },
@@ -93,8 +85,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "07e3ac46-3f96-4c00-aa6a-09840ee04bdd",
-        "name": "color-control-track-width",
-        "constant-token-duplicate": false
+        "name": "color-control-track-width"
       }
     }
   },
@@ -104,8 +95,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "80f01183-a152-4c55-ac11-24edae62df64",
-        "name": "component-bottom-to-text-50",
-        "constant-token-duplicate": false
+        "name": "component-bottom-to-text-50"
       }
     }
   },
@@ -115,8 +105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0f1a6c63-bc4f-444c-9a18-67b6c35464b1",
-        "name": "component-bottom-to-text-75",
-        "constant-token-duplicate": false
+        "name": "component-bottom-to-text-75"
       }
     }
   },
@@ -126,8 +115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c8590269-dcaa-44f6-9c2d-d33274c3fe5e",
-        "name": "component-bottom-to-text-100",
-        "constant-token-duplicate": false
+        "name": "component-bottom-to-text-100"
       }
     }
   },
@@ -137,8 +125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a39cef5c-631c-4942-b5d2-9121e05d47f8",
-        "name": "component-bottom-to-text-200",
-        "constant-token-duplicate": false
+        "name": "component-bottom-to-text-200"
       }
     }
   },
@@ -148,8 +135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a6aac364-d617-4e21-a1db-5523daaa3c6c",
-        "name": "component-bottom-to-text-300",
-        "constant-token-duplicate": false
+        "name": "component-bottom-to-text-300"
       }
     }
   },
@@ -159,8 +145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d660beeb-278b-4157-b6fc-852c680ecae7",
-        "name": "component-edge-to-text-50",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-text-50"
       }
     }
   },
@@ -170,8 +155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "942f0f34-611a-4318-9b0e-3632e7f520b3",
-        "name": "component-edge-to-text-75",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-text-75"
       }
     }
   },
@@ -181,8 +165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0b3ecfcf-8fb9-4faf-ab7f-ff4baf733df5",
-        "name": "component-edge-to-text-100",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-text-100"
       }
     }
   },
@@ -192,8 +175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c567f435-928c-4bf8-b9c0-ac2f22d58348",
-        "name": "component-edge-to-text-200",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-text-200"
       }
     }
   },
@@ -203,8 +185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "616de468-71fc-4315-87ea-47cdc508a599",
-        "name": "component-edge-to-text-300",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-text-300"
       }
     }
   },
@@ -214,8 +195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0b157417-e40f-481c-87e3-8563d55b3135",
-        "name": "component-edge-to-visual-50",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-50"
       }
     }
   },
@@ -225,8 +205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "acc3e1b9-532d-485e-84e4-06e744c744b3",
-        "name": "component-edge-to-visual-75",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-75"
       }
     }
   },
@@ -236,8 +215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e77f525e-5043-49c1-a663-9f6c30067043",
-        "name": "component-edge-to-visual-100",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-100"
       }
     }
   },
@@ -247,8 +225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "85f7f49a-7b87-4e2f-b44e-70e3ccde6291",
-        "name": "component-edge-to-visual-200",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-200"
       }
     }
   },
@@ -258,8 +235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4973c83c-792d-4bc1-9e3d-d047993292ba",
-        "name": "component-edge-to-visual-300",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-300"
       }
     }
   },
@@ -269,8 +245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fd1c11a6-53d5-4253-a7d7-c4131c4b1a5e",
-        "name": "component-edge-to-visual-only-50",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-only-50"
       }
     }
   },
@@ -280,8 +255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5c4f1f7a-2218-4d03-ac83-9750c2c9336b",
-        "name": "component-edge-to-visual-only-75",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-only-75"
       }
     }
   },
@@ -291,8 +265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "93e42bfc-c2f0-40cd-a561-9045c68cb5d1",
-        "name": "component-edge-to-visual-only-100",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-only-100"
       }
     }
   },
@@ -302,8 +275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9dffd6f3-6230-425e-9208-296cf4d5c185",
-        "name": "component-edge-to-visual-only-200",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-only-200"
       }
     }
   },
@@ -313,8 +285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "090b3da5-0aa3-4bf8-b3bd-dd8dabb40721",
-        "name": "component-edge-to-visual-only-300",
-        "constant-token-duplicate": false
+        "name": "component-edge-to-visual-only-300"
       }
     }
   },
@@ -324,8 +295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fede8012-f00b-412b-8981-16f60a6133ab",
-        "name": "component-height-50",
-        "constant-token-duplicate": false
+        "name": "component-height-50"
       }
     }
   },
@@ -335,8 +305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5f363452-6317-4e7c-965a-291b3dfa8a8f",
-        "name": "component-height-75",
-        "constant-token-duplicate": false
+        "name": "component-height-75"
       }
     }
   },
@@ -346,8 +315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5c31197d-0412-469d-a2dd-684efbd4b7e6",
-        "name": "component-height-100",
-        "constant-token-duplicate": false
+        "name": "component-height-100"
       }
     }
   },
@@ -357,8 +325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7c69efb5-bde7-4ee0-ad1e-2f20e85ebc24",
-        "name": "component-height-200",
-        "constant-token-duplicate": false
+        "name": "component-height-200"
       }
     }
   },
@@ -368,8 +335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "53c665a4-83ae-45f2-b90d-33ce52430b84",
-        "name": "component-height-300",
-        "constant-token-duplicate": false
+        "name": "component-height-300"
       }
     }
   },
@@ -379,8 +345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4fcbb85f-afbe-41bc-a979-dc09fb98946a",
-        "name": "component-height-400",
-        "constant-token-duplicate": false
+        "name": "component-height-400"
       }
     }
   },
@@ -390,8 +355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8135e75c-9536-4743-ab6d-05ed5adb0448",
-        "name": "component-height-500",
-        "constant-token-duplicate": false
+        "name": "component-height-500"
       }
     }
   },
@@ -401,8 +365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8a23edfc-b993-48bb-917f-377051e02dff",
-        "name": "component-pill-edge-to-text-75",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-text-75"
       }
     }
   },
@@ -412,8 +375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "10e326b3-bcce-47df-a1ab-0e3ab9964dd2",
-        "name": "component-pill-edge-to-text-100",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-text-100"
       }
     }
   },
@@ -423,8 +385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c77f6b68-32b7-499c-81d9-50855cc68279",
-        "name": "component-pill-edge-to-text-200",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-text-200"
       }
     }
   },
@@ -434,8 +395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dd7bc474-d5f1-46fe-8a6e-b1645c34c982",
-        "name": "component-pill-edge-to-text-300",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-text-300"
       }
     }
   },
@@ -445,8 +405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "64343da6-f1a6-4615-b2b8-41f9509679e5",
-        "name": "component-pill-edge-to-visual-75",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-75"
       }
     }
   },
@@ -456,8 +415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "14624bfc-b08f-4637-991b-94a703a7b808",
-        "name": "component-pill-edge-to-visual-100",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-100"
       }
     }
   },
@@ -467,8 +425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "053363f2-5b8e-4365-8353-3cffac169608",
-        "name": "component-pill-edge-to-visual-200",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-200"
       }
     }
   },
@@ -478,8 +435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7ae3b6ee-2f80-4596-9d4a-08a5bf9612a7",
-        "name": "component-pill-edge-to-visual-300",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-300"
       }
     }
   },
@@ -489,8 +445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7332a4d3-3775-4247-a4c0-fb01f0604d63",
-        "name": "component-pill-edge-to-visual-only-75",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-only-75"
       }
     }
   },
@@ -500,8 +455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cf58ae75-8f3f-4b9e-809b-ee78abbb2f2f",
-        "name": "component-pill-edge-to-visual-only-100",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-only-100"
       }
     }
   },
@@ -511,8 +465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "989aee4c-5c90-454a-b68d-a7564669c2bd",
-        "name": "component-pill-edge-to-visual-only-200",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-only-200"
       }
     }
   },
@@ -522,8 +475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cb4f356c-2dcd-4043-8f5c-3da904716b48",
-        "name": "component-pill-edge-to-visual-only-300",
-        "constant-token-duplicate": false
+        "name": "component-pill-edge-to-visual-only-300"
       }
     }
   },
@@ -533,8 +485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9ef4a0a5-b81c-4f54-8927-286ece29a824",
-        "name": "component-size-difference-down",
-        "constant-token-duplicate": true
+        "name": "component-size-difference-down"
       }
     }
   },
@@ -544,8 +495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "103daec0-9711-4422-84d1-62ab77afa00d",
-        "name": "component-size-minimum-perspective-down",
-        "constant-token-duplicate": true
+        "name": "component-size-minimum-perspective-down"
       }
     }
   },
@@ -555,8 +505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4ee7342c-f2ef-4554-af0f-011052ff6177",
-        "name": "component-size-width-ratio-down",
-        "constant-token-duplicate": true
+        "name": "component-size-width-ratio-down"
       }
     }
   },
@@ -565,9 +514,8 @@
     "type": "number",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "9cd69903-8417-4d6a-92cf-7ec759d5f60f",
-        "name": "corner-radius-1000",
-        "constant-token-duplicate": false
+        "uuid": "e4ad85b2-97bf-48cf-a5a9-3ff3d1fada5b",
+        "name": "corner-radius-1000"
       }
     }
   },
@@ -577,8 +525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9fa90167-54ec-4343-a14c-4cd18963dcc5",
-        "name": "component-to-menu-extra-large",
-        "constant-token-duplicate": false
+        "name": "component-to-menu-extra-large"
       }
     }
   },
@@ -588,8 +535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b33acdfa-525e-45c6-ab2b-c959760c4024",
-        "name": "component-to-menu-large",
-        "constant-token-duplicate": false
+        "name": "component-to-menu-large"
       }
     }
   },
@@ -599,8 +545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e8602fbe-1bf9-4aec-9cb0-5b4e994558c9",
-        "name": "component-to-menu-medium",
-        "constant-token-duplicate": false
+        "name": "component-to-menu-medium"
       }
     }
   },
@@ -610,8 +555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cc2c2606-500a-45e2-b460-2b498dcddb26",
-        "name": "component-to-menu-small",
-        "constant-token-duplicate": false
+        "name": "component-to-menu-small"
       }
     }
   },
@@ -621,8 +565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cb2a6539-4cee-420c-aeef-dbdd3220039d",
-        "name": "component-top-to-text-50",
-        "constant-token-duplicate": false
+        "name": "component-top-to-text-50"
       }
     }
   },
@@ -632,8 +575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "54a0e5cf-3e4a-454b-9dba-a6a2c277fa5e",
-        "name": "component-top-to-text-75",
-        "constant-token-duplicate": false
+        "name": "component-top-to-text-75"
       }
     }
   },
@@ -643,8 +585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bed358a2-0559-4501-a147-b375887f25af",
-        "name": "component-top-to-text-100",
-        "constant-token-duplicate": false
+        "name": "component-top-to-text-100"
       }
     }
   },
@@ -654,8 +595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "621c9cf1-02e2-478b-9f47-0804f0183531",
-        "name": "component-top-to-text-200",
-        "constant-token-duplicate": false
+        "name": "component-top-to-text-200"
       }
     }
   },
@@ -665,8 +605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e0ae8c97-73ee-4b09-839f-5ebfb6eb0d7a",
-        "name": "component-top-to-text-300",
-        "constant-token-duplicate": false
+        "name": "component-top-to-text-300"
       }
     }
   },
@@ -676,8 +615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "24853983-c1b0-422d-84b6-05b9313066ed",
-        "name": "component-top-to-workflow-icon-50",
-        "constant-token-duplicate": false
+        "name": "component-top-to-workflow-icon-50"
       }
     }
   },
@@ -687,8 +625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9d1b0ef4-5433-43fe-aa33-0274ff29f6f3",
-        "name": "component-top-to-workflow-icon-75",
-        "constant-token-duplicate": false
+        "name": "component-top-to-workflow-icon-75"
       }
     }
   },
@@ -698,8 +635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a3d3f9e9-a784-445a-a052-22f84b832512",
-        "name": "component-top-to-workflow-icon-100",
-        "constant-token-duplicate": false
+        "name": "component-top-to-workflow-icon-100"
       }
     }
   },
@@ -709,8 +645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "259c0cf5-d321-4a6b-a3ae-b8c58fc1c9d6",
-        "name": "component-top-to-workflow-icon-200",
-        "constant-token-duplicate": false
+        "name": "component-top-to-workflow-icon-200"
       }
     }
   },
@@ -720,8 +655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bac14298-68f0-4fb6-a152-c95ab19fd27f",
-        "name": "component-top-to-workflow-icon-300",
-        "constant-token-duplicate": false
+        "name": "component-top-to-workflow-icon-300"
       }
     }
   },
@@ -730,9 +664,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "8db9a268-95ee-4d25-a664-41b7ff06bea2",
-        "name": "corner-radius-0",
-        "constant-token-duplicate": false
+        "uuid": "bb9d8350-b1fb-4496-9c22-6ec9647ff117",
+        "name": "corner-radius-0"
       }
     }
   },
@@ -741,9 +674,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "cddbb2f6-b3a8-4416-90ed-0d7cd1bc7248",
-        "name": "corner-radius-75",
-        "constant-token-duplicate": false
+        "uuid": "ecb9d03a-7340-4b43-8aa7-f89eef9f3a20",
+        "name": "corner-radius-75"
       }
     }
   },
@@ -752,9 +684,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "e22537bb-a29f-47e5-be13-7e2775ee1103",
-        "name": "corner-radius-100",
-        "constant-token-duplicate": false
+        "uuid": "bf24d15e-ad86-4b6a-a9e0-e8fd49a5ae30",
+        "name": "corner-radius-100"
       }
     }
   },
@@ -763,9 +694,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "23f751eb-a076-487d-a5e1-1c0eb2937018",
-        "name": "corner-radius-200",
-        "constant-token-duplicate": false
+        "uuid": "52ad01be-f512-4fa3-ae67-8c6cef70810c",
+        "name": "corner-radius-200"
       }
     }
   },
@@ -774,9 +704,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "262d7b06-a9b2-4656-8175-fbe80fdc64ab",
-        "name": "corner-radius-300",
-        "constant-token-duplicate": false
+        "uuid": "154642d7-c23d-44fd-9d79-b719ef32922e",
+        "name": "corner-radius-300"
       }
     }
   },
@@ -785,9 +714,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "76cd22ed-1466-48fd-bcac-55c06ee56e22",
-        "name": "corner-radius-400",
-        "constant-token-duplicate": false
+        "uuid": "690db7ae-cae8-49bb-8777-b4f1829b2f0b",
+        "name": "corner-radius-400"
       }
     }
   },
@@ -796,9 +724,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "fdfdb85e-6b60-4630-af09-415db7057791",
-        "name": "corner-radius-500",
-        "constant-token-duplicate": false
+        "uuid": "ada2ea1d-1728-411a-8aae-a198ce390a25",
+        "name": "corner-radius-500"
       }
     }
   },
@@ -807,9 +734,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "5538f603-bf69-4a30-bfe1-ea6f91a8b13a",
-        "name": "corner-radius-600",
-        "constant-token-duplicate": false
+        "uuid": "abc0f309-3bd2-4800-af12-b27386e86617",
+        "name": "corner-radius-600"
       }
     }
   },
@@ -818,9 +744,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "1aacac8f-8fbc-4045-9b98-f260b1e1aa7e",
-        "name": "corner-radius-700",
-        "constant-token-duplicate": false
+        "uuid": "cb6b72ed-a9a1-4113-b147-1ef369fe6269",
+        "name": "corner-radius-700"
       }
     }
   },
@@ -829,9 +754,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "0032ebbf-3428-4fc3-aa5a-9dd57a6ce566",
-        "name": "corner-radius-800",
-        "constant-token-duplicate": false
+        "uuid": "8fc023ca-8aec-40fe-9130-087aa035bac7",
+        "name": "corner-radius-800"
       }
     }
   },
@@ -840,9 +764,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "497ee71e-792d-449e-acc2-41c9de0d7f16",
-        "name": "corner-radius-none",
-        "constant-token-duplicate": false
+        "uuid": "7a11b308-bed2-4b6f-bb4a-c9ae4ef8e03d",
+        "name": "corner-radius-none"
       }
     }
   },
@@ -851,9 +774,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "b7bdc7fe-093e-4357-8df8-595872a0c600",
-        "name": "corner-radius-small-default",
-        "constant-token-duplicate": false
+        "uuid": "b4971f86-aeea-42c9-9ba7-a74cf4d1a545",
+        "name": "corner-radius-small-default"
       }
     }
   },
@@ -862,9 +784,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "db528ae2-76c1-4685-9148-d1945f1e76e8",
-        "name": "corner-radius-medium-default",
-        "constant-token-duplicate": false
+        "uuid": "a83a882e-430c-46fc-a8be-5ade0dd8a4c6",
+        "name": "corner-radius-medium-default"
       }
     }
   },
@@ -873,9 +794,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "470498fa-d118-4960-930e-30f8cc6bae8b",
-        "name": "corner-radius-large-default",
-        "constant-token-duplicate": false
+        "uuid": "29981aef-aea6-4cde-849f-4bc67e320ea7",
+        "name": "corner-radius-large-default"
       }
     }
   },
@@ -884,9 +804,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "f7720ff5-c618-4e55-9acf-83b1e171e20c",
-        "name": "corner-radius-extra-large-default",
-        "constant-token-duplicate": false
+        "uuid": "d639a0b5-16b4-4d75-ab37-d87815c7b500",
+        "name": "corner-radius-extra-large-default"
       }
     }
   },
@@ -895,9 +814,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "258f18c4-7c48-4087-bdcc-6cf625e11802",
-        "name": "corner-radius-full",
-        "constant-token-duplicate": false
+        "uuid": "4853520b-bda3-45d1-bd20-8508cac08847",
+        "name": "corner-radius-full"
       }
     }
   },
@@ -906,9 +824,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "244d7ce4-3dfd-481b-b416-2b779a7d1d79",
-        "name": "corner-radius-small-size-small",
-        "constant-token-duplicate": false
+        "uuid": "3d39e5de-0800-4629-ae1a-99a34706a772",
+        "name": "corner-radius-small-size-small"
       }
     }
   },
@@ -917,9 +834,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "07c45d1f-38be-4223-9f0e-f8ec768c43ff",
-        "name": "corner-radius-small-size-medium",
-        "constant-token-duplicate": false
+        "uuid": "a62a43dd-cb2a-4e18-bb94-7a9518668400",
+        "name": "corner-radius-small-size-medium"
       }
     }
   },
@@ -928,9 +844,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "12641f31-6e63-41ed-994c-af20210795c4",
-        "name": "corner-radius-small-size-large",
-        "constant-token-duplicate": false
+        "uuid": "f4f0bfc9-ce6d-473f-8dda-c9f21fb8a7b7",
+        "name": "corner-radius-small-size-large"
       }
     }
   },
@@ -939,9 +854,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "c0413c6b-e7c3-4964-b4e9-1d9aaacdd6f4",
-        "name": "corner-radius-small-size-extra-large",
-        "constant-token-duplicate": false
+        "uuid": "d59337d1-4cec-43c0-821e-06a56745cbcc",
+        "name": "corner-radius-small-size-extra-large"
       }
     }
   },
@@ -950,9 +864,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "7bea2457-9377-4919-a5ff-3c098c95651e",
-        "name": "corner-radius-medium-size-extra-small",
-        "constant-token-duplicate": false
+        "uuid": "d0e02d98-e93f-4f81-8d81-8f95e06ad360",
+        "name": "corner-radius-medium-size-extra-small"
       }
     }
   },
@@ -961,9 +874,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "92a31673-beba-4f48-a54d-fd9bd7e23907",
-        "name": "corner-radius-medium-size-small",
-        "constant-token-duplicate": false
+        "uuid": "892bc9de-16b2-4c51-9c18-b239e52ffd14",
+        "name": "corner-radius-medium-size-small"
       }
     }
   },
@@ -972,9 +884,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "bc2c9277-6927-4655-9160-4f41011874c1",
-        "name": "corner-radius-medium-size-medium",
-        "constant-token-duplicate": false
+        "uuid": "67fb5355-6d7c-4e4e-a4cb-cdba10a85d84",
+        "name": "corner-radius-medium-size-medium"
       }
     }
   },
@@ -983,9 +894,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "d56562a1-6958-4a3b-a1b4-e5fd159cf311",
-        "name": "corner-radius-medium-size-large",
-        "constant-token-duplicate": false
+        "uuid": "ede17e00-83ef-40c5-a1d0-a46372d3fc90",
+        "name": "corner-radius-medium-size-large"
       }
     }
   },
@@ -994,9 +904,8 @@
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "c63c5111-11b1-420e-b09e-26053802e0cd",
-        "name": "corner-radius-medium-size-extra-large",
-        "constant-token-duplicate": false
+        "uuid": "81752b3e-488a-4273-abb5-4ba8b7f278d9",
+        "name": "corner-radius-medium-size-extra-large"
       }
     }
   },
@@ -1006,8 +915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9c38e8f6-cca7-4f7f-a7c3-9d4ee7af24b8",
-        "name": "disclosure-indicator-top-to-disclosure-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "disclosure-indicator-top-to-disclosure-icon-extra-large"
       }
     }
   },
@@ -1017,8 +925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "24dd2c12-17f0-4d38-9af3-a3b112c40c74",
-        "name": "disclosure-indicator-top-to-disclosure-icon-large",
-        "constant-token-duplicate": false
+        "name": "disclosure-indicator-top-to-disclosure-icon-large"
       }
     }
   },
@@ -1028,8 +935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "049e0fe7-03d4-4d9b-bdcd-9c8a06852010",
-        "name": "disclosure-indicator-top-to-disclosure-icon-medium",
-        "constant-token-duplicate": false
+        "name": "disclosure-indicator-top-to-disclosure-icon-medium"
       }
     }
   },
@@ -1039,8 +945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d7c1f2a1-b679-42ae-8512-27883d9789f9",
-        "name": "disclosure-indicator-top-to-disclosure-icon-small",
-        "constant-token-duplicate": false
+        "name": "disclosure-indicator-top-to-disclosure-icon-small"
       }
     }
   },
@@ -1050,8 +955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "374f321e-8b0b-442b-9494-6a2ae9936c6b",
-        "name": "drop-shadow-blur",
-        "constant-token-duplicate": false
+        "name": "drop-shadow-blur"
       }
     }
   },
@@ -1060,9 +964,8 @@
     "type": "other",
     "$extensions": {
       "spectrum-tokens": {
-        "uuid": "4e20cec6-96b6-4e9c-8b25-c819731b89ba",
-        "name": "drop-shadow-x",
-        "constant-token-duplicate": false
+        "uuid": "81415747-aa3f-4ef3-b0bc-7c33f07a4316",
+        "name": "drop-shadow-x"
       }
     }
   },
@@ -1072,8 +975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "32950bbd-7292-452d-a445-4eb6de66c77d",
-        "name": "drop-shadow-y",
-        "constant-token-duplicate": false
+        "name": "drop-shadow-y"
       }
     }
   },
@@ -1083,8 +985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2a77de7a-20cb-40a2-b3a9-252fcaa7a7d2",
-        "name": "field-edge-to-alert-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-alert-icon-extra-large"
       }
     }
   },
@@ -1094,8 +995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a7c0e1fc-bc57-450e-bdc2-1c2cf2823d98",
-        "name": "field-edge-to-alert-icon-large",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-alert-icon-large"
       }
     }
   },
@@ -1105,8 +1005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b98d3a2d-94fb-4491-9650-1c9a62365a19",
-        "name": "field-edge-to-alert-icon-medium",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-alert-icon-medium"
       }
     }
   },
@@ -1116,8 +1015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7858fdf3-e35f-4bc5-997a-0d480ec1cb32",
-        "name": "field-edge-to-alert-icon-quiet",
-        "constant-token-duplicate": true
+        "name": "field-edge-to-alert-icon-quiet"
       }
     }
   },
@@ -1127,8 +1025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "68c4dc34-49cb-4174-bd06-5f5dfbd0b64e",
-        "name": "field-edge-to-alert-icon-small",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-alert-icon-small"
       }
     }
   },
@@ -1138,8 +1035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7fb81dcf-3329-4353-917d-75de8f43c05d",
-        "name": "field-edge-to-border-quiet",
-        "constant-token-duplicate": true
+        "name": "field-edge-to-border-quiet"
       }
     }
   },
@@ -1149,8 +1045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "87d3f491-f45f-4bee-9dbd-00086cca5858",
-        "name": "field-edge-to-disclosure-icon-75",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-disclosure-icon-75"
       }
     }
   },
@@ -1160,8 +1055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "26d578cb-9228-4643-b042-8b00ba4d9b61",
-        "name": "field-edge-to-disclosure-icon-100",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-disclosure-icon-100"
       }
     }
   },
@@ -1171,8 +1065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fcc139c1-08ed-4641-932d-5050237abfaa",
-        "name": "field-edge-to-disclosure-icon-200",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-disclosure-icon-200"
       }
     }
   },
@@ -1182,8 +1075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0d3045e2-a493-406a-a247-8d20f35db2d9",
-        "name": "field-edge-to-disclosure-icon-300",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-disclosure-icon-300"
       }
     }
   },
@@ -1193,8 +1085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3f7cee20-c187-4066-be4b-f5a1335736f5",
-        "name": "field-edge-to-text-quiet",
-        "constant-token-duplicate": true
+        "name": "field-edge-to-text-quiet"
       }
     }
   },
@@ -1204,8 +1095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "539800f6-7bbc-4b67-8b61-99d1ee2f69a4",
-        "name": "field-edge-to-validation-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-validation-icon-extra-large"
       }
     }
   },
@@ -1215,8 +1105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9525d928-4cdb-4cf5-8616-2024ed6fb7c0",
-        "name": "field-edge-to-validation-icon-large",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-validation-icon-large"
       }
     }
   },
@@ -1226,8 +1115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c51f02a2-35d4-460f-9f14-a97d9e8e6616",
-        "name": "field-edge-to-validation-icon-medium",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-validation-icon-medium"
       }
     }
   },
@@ -1237,8 +1125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "151915e5-f946-474f-9595-18d8a159a6ff",
-        "name": "field-edge-to-validation-icon-quiet",
-        "constant-token-duplicate": true
+        "name": "field-edge-to-validation-icon-quiet"
       }
     }
   },
@@ -1248,8 +1135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a1c55785-3ae3-4c23-81e2-f088e76e4e04",
-        "name": "field-edge-to-validation-icon-small",
-        "constant-token-duplicate": false
+        "name": "field-edge-to-validation-icon-small"
       }
     }
   },
@@ -1259,8 +1145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "89f16f89-fd7d-41d7-8e5c-464007fd0277",
-        "name": "field-edge-to-visual-quiet",
-        "constant-token-duplicate": true
+        "name": "field-edge-to-visual-quiet"
       }
     }
   },
@@ -1270,8 +1155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "927e7b5a-57b4-4d47-9ad8-e287199e68a3",
-        "name": "field-end-edge-to-disclosure-icon-75",
-        "constant-token-duplicate": false
+        "name": "field-end-edge-to-disclosure-icon-75"
       }
     }
   },
@@ -1281,8 +1165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7b3ab0f8-8bde-461f-b658-6848d64de0e3",
-        "name": "field-end-edge-to-disclosure-icon-100",
-        "constant-token-duplicate": false
+        "name": "field-end-edge-to-disclosure-icon-100"
       }
     }
   },
@@ -1292,8 +1175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "417eb2ee-3fe9-47fc-a122-d466eb4e7b26",
-        "name": "field-end-edge-to-disclosure-icon-200",
-        "constant-token-duplicate": false
+        "name": "field-end-edge-to-disclosure-icon-200"
       }
     }
   },
@@ -1303,8 +1185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7c2b5cc0-01c0-4e5f-a157-1d2432f8bbc1",
-        "name": "field-end-edge-to-disclosure-icon-300",
-        "constant-token-duplicate": false
+        "name": "field-end-edge-to-disclosure-icon-300"
       }
     }
   },
@@ -1314,8 +1195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ec794a47-71af-42ea-87f2-048fab8dbf9d",
-        "name": "field-text-to-alert-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-text-to-alert-icon-extra-large"
       }
     }
   },
@@ -1325,8 +1205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "73025a05-6203-460b-830b-458f8109abce",
-        "name": "field-text-to-alert-icon-large",
-        "constant-token-duplicate": false
+        "name": "field-text-to-alert-icon-large"
       }
     }
   },
@@ -1336,8 +1215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "03d088d2-4ec9-45bc-896d-8423bf72317e",
-        "name": "field-text-to-alert-icon-medium",
-        "constant-token-duplicate": false
+        "name": "field-text-to-alert-icon-medium"
       }
     }
   },
@@ -1347,8 +1225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "01ad9b7d-926e-4db4-a86a-a804fdfc7d68",
-        "name": "field-text-to-alert-icon-small",
-        "constant-token-duplicate": false
+        "name": "field-text-to-alert-icon-small"
       }
     }
   },
@@ -1358,8 +1235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8926578a-c326-4a75-aafb-d90112aaedb5",
-        "name": "field-text-to-validation-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-text-to-validation-icon-extra-large"
       }
     }
   },
@@ -1369,8 +1245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b28a0156-4930-484c-a518-ee00e0292db5",
-        "name": "field-text-to-validation-icon-large",
-        "constant-token-duplicate": false
+        "name": "field-text-to-validation-icon-large"
       }
     }
   },
@@ -1380,8 +1255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "87e221ab-fb8c-4d59-9d4b-9815a672cc23",
-        "name": "field-text-to-validation-icon-medium",
-        "constant-token-duplicate": false
+        "name": "field-text-to-validation-icon-medium"
       }
     }
   },
@@ -1391,8 +1265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c2181581-6aa1-4e1f-80bc-1ca2e85ea01b",
-        "name": "field-text-to-validation-icon-small",
-        "constant-token-duplicate": false
+        "name": "field-text-to-validation-icon-small"
       }
     }
   },
@@ -1402,8 +1275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "246058b4-e152-4673-91ab-34384fceb798",
-        "name": "field-top-to-alert-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-top-to-alert-icon-extra-large"
       }
     }
   },
@@ -1413,8 +1285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6247903e-2c00-4242-b2d5-da2864b6aa87",
-        "name": "field-top-to-alert-icon-large",
-        "constant-token-duplicate": false
+        "name": "field-top-to-alert-icon-large"
       }
     }
   },
@@ -1424,8 +1295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1def1d88-0098-4e00-987f-17a8656047da",
-        "name": "field-top-to-alert-icon-medium",
-        "constant-token-duplicate": false
+        "name": "field-top-to-alert-icon-medium"
       }
     }
   },
@@ -1435,8 +1305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "580b677d-5d7e-4306-87ee-640a4613254b",
-        "name": "field-top-to-alert-icon-small",
-        "constant-token-duplicate": false
+        "name": "field-top-to-alert-icon-small"
       }
     }
   },
@@ -1446,8 +1315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2f62718d-3df8-498b-9520-baf8be65f3bd",
-        "name": "field-top-to-disclosure-icon-75",
-        "constant-token-duplicate": false
+        "name": "field-top-to-disclosure-icon-75"
       }
     }
   },
@@ -1457,8 +1325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1357cf8e-6e41-4d3c-be39-9aa87d010b78",
-        "name": "field-top-to-disclosure-icon-100",
-        "constant-token-duplicate": false
+        "name": "field-top-to-disclosure-icon-100"
       }
     }
   },
@@ -1468,8 +1335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2af47c9c-dba6-4340-b5fc-af00dcbaa05c",
-        "name": "field-top-to-disclosure-icon-200",
-        "constant-token-duplicate": false
+        "name": "field-top-to-disclosure-icon-200"
       }
     }
   },
@@ -1479,8 +1345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "631146ab-f3f2-4ea0-aac1-2bea622d0c85",
-        "name": "field-top-to-disclosure-icon-300",
-        "constant-token-duplicate": false
+        "name": "field-top-to-disclosure-icon-300"
       }
     }
   },
@@ -1490,8 +1355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "263428f7-3b5a-449a-87d1-874cebf50fa8",
-        "name": "field-top-to-progress-circle-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-top-to-progress-circle-extra-large"
       }
     }
   },
@@ -1501,8 +1365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7a17cc60-fa76-4234-a99e-c4f711e63f5f",
-        "name": "field-top-to-progress-circle-large",
-        "constant-token-duplicate": false
+        "name": "field-top-to-progress-circle-large"
       }
     }
   },
@@ -1512,8 +1375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7b4b7283-1223-4d2e-9f24-5ed6dada4711",
-        "name": "field-top-to-progress-circle-medium",
-        "constant-token-duplicate": false
+        "name": "field-top-to-progress-circle-medium"
       }
     }
   },
@@ -1523,8 +1385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5da7e575-d0c3-44e7-bbfa-6fa58972343b",
-        "name": "field-top-to-progress-circle-small",
-        "constant-token-duplicate": false
+        "name": "field-top-to-progress-circle-small"
       }
     }
   },
@@ -1534,8 +1395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a6da1cb9-6085-4c58-b3dc-3b1377f64fa4",
-        "name": "field-top-to-validation-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "field-top-to-validation-icon-extra-large"
       }
     }
   },
@@ -1545,8 +1405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f4f9d889-130a-4e71-9a9c-1ee82c2a4a4b",
-        "name": "field-top-to-validation-icon-large",
-        "constant-token-duplicate": false
+        "name": "field-top-to-validation-icon-large"
       }
     }
   },
@@ -1556,8 +1415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7bb6c4c7-4157-4da9-bf06-1d2527022d6a",
-        "name": "field-top-to-validation-icon-medium",
-        "constant-token-duplicate": false
+        "name": "field-top-to-validation-icon-medium"
       }
     }
   },
@@ -1567,8 +1425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1a5b6e87-12a8-4fda-a8f7-2928b0b68a46",
-        "name": "field-top-to-validation-icon-small",
-        "constant-token-duplicate": false
+        "name": "field-top-to-validation-icon-small"
       }
     }
   },
@@ -1578,8 +1435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "08c2390a-353b-4e6b-b025-dbaeaa5fdff2",
-        "name": "field-width",
-        "constant-token-duplicate": false
+        "name": "field-width"
       }
     }
   },
@@ -1589,8 +1445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "693651ef-71c7-4096-91a5-1c84cb861021",
-        "name": "focus-indicator-gap",
-        "constant-token-duplicate": true
+        "name": "focus-indicator-gap"
       }
     }
   },
@@ -1600,8 +1455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b6148878-b78d-4fe7-bf78-e01e7cb314c2",
-        "name": "focus-indicator-thickness",
-        "constant-token-duplicate": true
+        "name": "focus-indicator-thickness"
       }
     }
   },
@@ -1611,8 +1465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e68f2798-6a55-499a-b591-0cfc130607ba",
-        "name": "navigational-indicator-top-to-back-icon-extra-large",
-        "constant-token-duplicate": false
+        "name": "navigational-indicator-top-to-back-icon-extra-large"
       }
     }
   },
@@ -1622,8 +1475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e84bc865-c89f-403e-bb14-2a11f03fd364",
-        "name": "navigational-indicator-top-to-back-icon-large",
-        "constant-token-duplicate": false
+        "name": "navigational-indicator-top-to-back-icon-large"
       }
     }
   },
@@ -1633,8 +1485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "74f8a686-0e06-4f7c-9e3d-694749beb420",
-        "name": "navigational-indicator-top-to-back-icon-medium",
-        "constant-token-duplicate": false
+        "name": "navigational-indicator-top-to-back-icon-medium"
       }
     }
   },
@@ -1644,8 +1495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d11ab0de-19bd-4f56-8798-0192fd0cfe0e",
-        "name": "navigational-indicator-top-to-back-icon-small",
-        "constant-token-duplicate": false
+        "name": "navigational-indicator-top-to-back-icon-small"
       }
     }
   },
@@ -1655,8 +1505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ec387876-31d5-42a5-99aa-02c5d35e6223",
-        "name": "side-label-character-count-to-field",
-        "constant-token-duplicate": false
+        "name": "side-label-character-count-to-field"
       }
     }
   },
@@ -1666,8 +1515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c2c4ddf3-f273-4e23-9be0-e1227e9999a8",
-        "name": "side-label-character-count-top-margin-extra-large",
-        "constant-token-duplicate": false
+        "name": "side-label-character-count-top-margin-extra-large"
       }
     }
   },
@@ -1677,8 +1525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ca10a5d6-a8b2-414d-978a-14481e2a21cb",
-        "name": "side-label-character-count-top-margin-large",
-        "constant-token-duplicate": false
+        "name": "side-label-character-count-top-margin-large"
       }
     }
   },
@@ -1688,8 +1535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a2b20c88-d28c-4261-8160-62630c5e0da8",
-        "name": "side-label-character-count-top-margin-medium",
-        "constant-token-duplicate": false
+        "name": "side-label-character-count-top-margin-medium"
       }
     }
   },
@@ -1699,8 +1545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9196a2ad-67cd-44d8-b4c6-bca25e37eb4a",
-        "name": "side-label-character-count-top-margin-small",
-        "constant-token-duplicate": false
+        "name": "side-label-character-count-top-margin-small"
       }
     }
   },
@@ -1710,8 +1555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1b06f6e2-d9be-4934-b3da-bed75986d104",
-        "name": "spacing-50",
-        "constant-token-duplicate": true
+        "name": "spacing-50"
       }
     }
   },
@@ -1721,8 +1565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "576a60a3-ca80-46c5-a066-ba7b6197decd",
-        "name": "spacing-75",
-        "constant-token-duplicate": true
+        "name": "spacing-75"
       }
     }
   },
@@ -1732,8 +1575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "507c0b4a-9dbc-4242-89fd-5efc4d1c35b9",
-        "name": "spacing-100",
-        "constant-token-duplicate": true
+        "name": "spacing-100"
       }
     }
   },
@@ -1743,8 +1585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "79fca32b-214b-4760-9d3a-28f4d1bdf86f",
-        "name": "spacing-200",
-        "constant-token-duplicate": true
+        "name": "spacing-200"
       }
     }
   },
@@ -1754,8 +1595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ba632ede-84a7-4e56-91ef-8143b2499452",
-        "name": "spacing-300",
-        "constant-token-duplicate": true
+        "name": "spacing-300"
       }
     }
   },
@@ -1765,8 +1605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ec565065-0820-460f-9a1b-b81911c48cb5",
-        "name": "spacing-400",
-        "constant-token-duplicate": true
+        "name": "spacing-400"
       }
     }
   },
@@ -1776,8 +1615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "490b4010-1561-4b12-8cbb-cdb4b650ba74",
-        "name": "spacing-500",
-        "constant-token-duplicate": true
+        "name": "spacing-500"
       }
     }
   },
@@ -1787,8 +1625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b6d0b881-d25e-452c-9069-c18745d21f33",
-        "name": "spacing-600",
-        "constant-token-duplicate": true
+        "name": "spacing-600"
       }
     }
   },
@@ -1798,8 +1635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "26639049-ec07-430d-983f-4d036758564a",
-        "name": "spacing-700",
-        "constant-token-duplicate": true
+        "name": "spacing-700"
       }
     }
   },
@@ -1809,8 +1645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "eeb099cb-707f-4e5e-97b9-1fdba35b2314",
-        "name": "spacing-800",
-        "constant-token-duplicate": true
+        "name": "spacing-800"
       }
     }
   },
@@ -1820,8 +1655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d04e5d81-0b6e-48e7-9e47-744753dfcff3",
-        "name": "spacing-900",
-        "constant-token-duplicate": true
+        "name": "spacing-900"
       }
     }
   },
@@ -1831,8 +1665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9d688a67-5ff6-4b72-8398-964c0337dce1",
-        "name": "spacing-1000",
-        "constant-token-duplicate": true
+        "name": "spacing-1000"
       }
     }
   },
@@ -1842,8 +1675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "45f94495-0f53-42b2-94f6-7a6d91eb2ca1",
-        "name": "text-to-control-75",
-        "constant-token-duplicate": false
+        "name": "text-to-control-75"
       }
     }
   },
@@ -1853,8 +1685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b4ce04fa-bc03-44c9-afef-a38810ac9c65",
-        "name": "text-to-control-100",
-        "constant-token-duplicate": false
+        "name": "text-to-control-100"
       }
     }
   },
@@ -1864,8 +1695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8991287c-763f-4a39-ad5b-7ccdbc39b3f6",
-        "name": "text-to-control-200",
-        "constant-token-duplicate": false
+        "name": "text-to-control-200"
       }
     }
   },
@@ -1875,8 +1705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "53a33d46-8d81-4f13-8c79-c4d9257a5b68",
-        "name": "text-to-control-300",
-        "constant-token-duplicate": false
+        "name": "text-to-control-300"
       }
     }
   },
@@ -1886,8 +1715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8588bf80-96df-40fb-8b6f-61d06899f8dd",
-        "name": "text-to-visual-50",
-        "constant-token-duplicate": false
+        "name": "text-to-visual-50"
       }
     }
   },
@@ -1897,8 +1725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "77dc4cd4-8e4e-4873-b6f3-d573eb7fc315",
-        "name": "text-to-visual-75",
-        "constant-token-duplicate": false
+        "name": "text-to-visual-75"
       }
     }
   },
@@ -1908,8 +1735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "09d55113-8d94-429f-b0c8-ffabe8ccba27",
-        "name": "text-to-visual-100",
-        "constant-token-duplicate": false
+        "name": "text-to-visual-100"
       }
     }
   },
@@ -1919,8 +1745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dc4ec555-72eb-4328-aba4-e8d594102f45",
-        "name": "text-to-visual-200",
-        "constant-token-duplicate": false
+        "name": "text-to-visual-200"
       }
     }
   },
@@ -1930,8 +1755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "205f0c77-6588-4cc7-927f-3ba767200bac",
-        "name": "text-to-visual-300",
-        "constant-token-duplicate": false
+        "name": "text-to-visual-300"
       }
     }
   },
@@ -1941,8 +1765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d9d51235-f3fe-4e2a-bdca-b6a104d9a9e5",
-        "name": "text-underline-gap",
-        "constant-token-duplicate": true
+        "name": "text-underline-gap"
       }
     }
   },
@@ -1952,8 +1775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "13f36ce1-84bb-41db-bec8-6d6e8f5c6ed3",
-        "name": "text-underline-thickness",
-        "constant-token-duplicate": true
+        "name": "text-underline-thickness"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/opacity.alias/dark.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/opacity.alias/dark.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7b25005-7188-4936-8dbc-e2dd15213f47",
-        "name": "background-opacity-default",
-        "constant-token-duplicate": true
+        "name": "background-opacity-default"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0718c9fc-3bb2-4887-97bd-e23b8ad308c5",
-        "name": "background-opacity-down",
-        "constant-token-duplicate": true
+        "name": "background-opacity-down"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "048c326d-93b1-435f-a9e3-a4cbd3144fdd",
-        "name": "background-opacity-hover",
-        "constant-token-duplicate": true
+        "name": "background-opacity-hover"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a35883a9-43fd-4be5-97ee-62fdf3a33f39",
-        "name": "background-opacity-key-focus",
-        "constant-token-duplicate": true
+        "name": "background-opacity-key-focus"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fdf6fd5d-55a0-4428-a258-4e8fafc74b74",
-        "name": "opacity-disabled",
-        "constant-token-duplicate": true
+        "name": "opacity-disabled"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/opacity.alias/light.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/opacity.alias/light.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7b25005-7188-4936-8dbc-e2dd15213f47",
-        "name": "background-opacity-default",
-        "constant-token-duplicate": true
+        "name": "background-opacity-default"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0718c9fc-3bb2-4887-97bd-e23b8ad308c5",
-        "name": "background-opacity-down",
-        "constant-token-duplicate": true
+        "name": "background-opacity-down"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "048c326d-93b1-435f-a9e3-a4cbd3144fdd",
-        "name": "background-opacity-hover",
-        "constant-token-duplicate": true
+        "name": "background-opacity-hover"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a35883a9-43fd-4be5-97ee-62fdf3a33f39",
-        "name": "background-opacity-key-focus",
-        "constant-token-duplicate": true
+        "name": "background-opacity-key-focus"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fdf6fd5d-55a0-4428-a258-4e8fafc74b74",
-        "name": "opacity-disabled",
-        "constant-token-duplicate": true
+        "name": "opacity-disabled"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/opacity.component/dark.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/opacity.component/dark.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "84d25d1b-f9e4-4a9e-8cd0-92367ff00637",
-        "name": "avatar-opacity-disabled",
-        "constant-token-duplicate": true
+        "name": "avatar-opacity-disabled"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ac039445-0bf8-4821-b02e-e7e06a416576",
-        "name": "card-selection-background-color-opacity",
-        "constant-token-duplicate": true
+        "name": "card-selection-background-color-opacity"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fba1851e-0056-4cdf-938d-6d61550bbe3c",
-        "name": "color-area-border-opacity",
-        "constant-token-duplicate": true
+        "name": "color-area-border-opacity"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "72b473c6-ec9b-4830-a0f8-48b80070e7b8",
-        "name": "color-handle-inner-border-opacity",
-        "constant-token-duplicate": true
+        "name": "color-handle-inner-border-opacity"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0a0eff89-7e7d-4b7f-bcfa-a85e33e5798a",
-        "name": "color-handle-outer-border-opacity",
-        "constant-token-duplicate": true
+        "name": "color-handle-outer-border-opacity"
       }
     }
   },
@@ -60,8 +55,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8271b69e-6542-4b17-b0f0-72567e16c41b",
-        "name": "color-slider-border-opacity",
-        "constant-token-duplicate": true
+        "name": "color-slider-border-opacity"
       }
     }
   },
@@ -71,8 +65,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ee5ed78b-230c-4b37-9d76-1787a975bb63",
-        "name": "drop-zone-background-color-opacity",
-        "constant-token-duplicate": true
+        "name": "drop-zone-background-color-opacity"
       }
     }
   },
@@ -82,8 +75,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ca70550a-b11a-438f-9c70-ff1eeba532cc",
-        "name": "drop-zone-background-color-opacity-filled",
-        "constant-token-duplicate": true
+        "name": "drop-zone-background-color-opacity-filled"
       }
     }
   },
@@ -93,8 +85,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0e397a80-cf33-44ed-8b7d-1abaf4426bf5",
-        "name": "swatch-border-opacity",
-        "constant-token-duplicate": true
+        "name": "swatch-border-opacity"
       }
     }
   },
@@ -104,8 +95,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cdbba3b6-cb51-4fec-88f0-273d4bb59a18",
-        "name": "swatch-disabled-icon-border-opacity",
-        "constant-token-duplicate": true
+        "name": "swatch-disabled-icon-border-opacity"
       }
     }
   },
@@ -115,8 +105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "75ae742c-e96e-494f-9880-746bb2849575",
-        "name": "table-row-down-opacity",
-        "constant-token-duplicate": true
+        "name": "table-row-down-opacity"
       }
     }
   },
@@ -126,8 +115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e287d553-3712-4d6e-98f0-6075107e85fe",
-        "name": "table-row-hover-opacity",
-        "constant-token-duplicate": true
+        "name": "table-row-hover-opacity"
       }
     }
   },
@@ -137,8 +125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "61b3aa04-0e7e-44b8-a4c8-8442a4ebf549",
-        "name": "table-selected-row-background-opacity",
-        "constant-token-duplicate": true
+        "name": "table-selected-row-background-opacity"
       }
     }
   },
@@ -148,8 +135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ce2851bc-8ae1-4b27-8cd6-f191c9cd7fe9",
-        "name": "table-selected-row-background-opacity-hover",
-        "constant-token-duplicate": true
+        "name": "table-selected-row-background-opacity-hover"
       }
     }
   },
@@ -159,8 +145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1ef41e27-3dea-4589-ad7a-140a03a77384",
-        "name": "table-selected-row-background-opacity-non-emphasized",
-        "constant-token-duplicate": true
+        "name": "table-selected-row-background-opacity-non-emphasized"
       }
     }
   },
@@ -170,8 +155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6a093ea1-f07e-4673-b52f-5b28a2e080d0",
-        "name": "table-selected-row-background-opacity-non-emphasized-hover",
-        "constant-token-duplicate": true
+        "name": "table-selected-row-background-opacity-non-emphasized-hover"
       }
     }
   },
@@ -181,8 +165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "58bd04e9-5b85-44d8-8474-96e157701070",
-        "name": "thumbnail-border-opacity",
-        "constant-token-duplicate": true
+        "name": "thumbnail-border-opacity"
       }
     }
   },
@@ -192,8 +175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "92418bcd-5f0f-4f26-9a96-51f8c9e871bf",
-        "name": "thumbnail-opacity-disabled",
-        "constant-token-duplicate": true
+        "name": "thumbnail-opacity-disabled"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/opacity.component/light.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/opacity.component/light.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "84d25d1b-f9e4-4a9e-8cd0-92367ff00637",
-        "name": "avatar-opacity-disabled",
-        "constant-token-duplicate": true
+        "name": "avatar-opacity-disabled"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ac039445-0bf8-4821-b02e-e7e06a416576",
-        "name": "card-selection-background-color-opacity",
-        "constant-token-duplicate": true
+        "name": "card-selection-background-color-opacity"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fba1851e-0056-4cdf-938d-6d61550bbe3c",
-        "name": "color-area-border-opacity",
-        "constant-token-duplicate": true
+        "name": "color-area-border-opacity"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "72b473c6-ec9b-4830-a0f8-48b80070e7b8",
-        "name": "color-handle-inner-border-opacity",
-        "constant-token-duplicate": true
+        "name": "color-handle-inner-border-opacity"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0a0eff89-7e7d-4b7f-bcfa-a85e33e5798a",
-        "name": "color-handle-outer-border-opacity",
-        "constant-token-duplicate": true
+        "name": "color-handle-outer-border-opacity"
       }
     }
   },
@@ -60,8 +55,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8271b69e-6542-4b17-b0f0-72567e16c41b",
-        "name": "color-slider-border-opacity",
-        "constant-token-duplicate": true
+        "name": "color-slider-border-opacity"
       }
     }
   },
@@ -71,8 +65,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ee5ed78b-230c-4b37-9d76-1787a975bb63",
-        "name": "drop-zone-background-color-opacity",
-        "constant-token-duplicate": true
+        "name": "drop-zone-background-color-opacity"
       }
     }
   },
@@ -82,8 +75,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ca70550a-b11a-438f-9c70-ff1eeba532cc",
-        "name": "drop-zone-background-color-opacity-filled",
-        "constant-token-duplicate": true
+        "name": "drop-zone-background-color-opacity-filled"
       }
     }
   },
@@ -93,8 +85,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0e397a80-cf33-44ed-8b7d-1abaf4426bf5",
-        "name": "swatch-border-opacity",
-        "constant-token-duplicate": true
+        "name": "swatch-border-opacity"
       }
     }
   },
@@ -104,8 +95,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cdbba3b6-cb51-4fec-88f0-273d4bb59a18",
-        "name": "swatch-disabled-icon-border-opacity",
-        "constant-token-duplicate": true
+        "name": "swatch-disabled-icon-border-opacity"
       }
     }
   },
@@ -115,8 +105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "75ae742c-e96e-494f-9880-746bb2849575",
-        "name": "table-row-down-opacity",
-        "constant-token-duplicate": true
+        "name": "table-row-down-opacity"
       }
     }
   },
@@ -126,8 +115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e287d553-3712-4d6e-98f0-6075107e85fe",
-        "name": "table-row-hover-opacity",
-        "constant-token-duplicate": true
+        "name": "table-row-hover-opacity"
       }
     }
   },
@@ -137,8 +125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "61b3aa04-0e7e-44b8-a4c8-8442a4ebf549",
-        "name": "table-selected-row-background-opacity",
-        "constant-token-duplicate": true
+        "name": "table-selected-row-background-opacity"
       }
     }
   },
@@ -148,8 +135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ce2851bc-8ae1-4b27-8cd6-f191c9cd7fe9",
-        "name": "table-selected-row-background-opacity-hover",
-        "constant-token-duplicate": true
+        "name": "table-selected-row-background-opacity-hover"
       }
     }
   },
@@ -159,8 +145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1ef41e27-3dea-4589-ad7a-140a03a77384",
-        "name": "table-selected-row-background-opacity-non-emphasized",
-        "constant-token-duplicate": true
+        "name": "table-selected-row-background-opacity-non-emphasized"
       }
     }
   },
@@ -170,8 +155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6a093ea1-f07e-4673-b52f-5b28a2e080d0",
-        "name": "table-selected-row-background-opacity-non-emphasized-hover",
-        "constant-token-duplicate": true
+        "name": "table-selected-row-background-opacity-non-emphasized-hover"
       }
     }
   },
@@ -181,8 +165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "58bd04e9-5b85-44d8-8474-96e157701070",
-        "name": "thumbnail-border-opacity",
-        "constant-token-duplicate": true
+        "name": "thumbnail-border-opacity"
       }
     }
   },
@@ -192,8 +175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "92418bcd-5f0f-4f26-9a96-51f8c9e871bf",
-        "name": "thumbnail-opacity-disabled",
-        "constant-token-duplicate": true
+        "name": "thumbnail-opacity-disabled"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/typography.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/typography.component/desktop.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3e90be19-62fd-4e53-abf9-4c697baba5da",
-        "name": "body-cjk-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "body-cjk-emphasized-font-style"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0d8ada2f-272d-4f76-bf37-095e0b48cdae",
-        "name": "body-cjk-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-cjk-emphasized-font-weight"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "06d5790c-21e9-4135-843d-05007b046677",
-        "name": "body-cjk-font-family",
-        "constant-token-duplicate": true
+        "name": "body-cjk-font-family"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "41389b62-c449-485b-bfa8-1659bacc8c42",
-        "name": "body-cjk-font-style",
-        "constant-token-duplicate": true
+        "name": "body-cjk-font-style"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a754c16b-2f0c-485f-813d-d472ee650660",
-        "name": "body-cjk-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-cjk-font-weight"
       }
     }
   },
@@ -60,8 +55,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2106b188-8520-4261-968b-2eb2928857f9",
-        "name": "body-cjk-line-height",
-        "constant-token-duplicate": true
+        "name": "body-cjk-line-height"
       }
     }
   },
@@ -71,8 +65,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f792aac0-62f2-47e3-b6ac-158ae009d9c3",
-        "name": "body-cjk-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "body-cjk-strong-emphasized-font-style"
       }
     }
   },
@@ -82,8 +75,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "54020791-a975-4e5d-a905-8bffcc9d2d93",
-        "name": "body-cjk-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-cjk-strong-emphasized-font-weight"
       }
     }
   },
@@ -93,8 +85,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "11fe09ad-92eb-4d7d-8872-467cdd69659b",
-        "name": "body-cjk-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "body-cjk-strong-font-style"
       }
     }
   },
@@ -104,8 +95,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d79de2c4-ca7c-4316-ac44-fee1a66983d7",
-        "name": "body-cjk-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-cjk-strong-font-weight"
       }
     }
   },
@@ -115,8 +105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "39accad7-3de1-4850-9773-4e0ff8080049",
-        "name": "body-line-height",
-        "constant-token-duplicate": true
+        "name": "body-line-height"
       }
     }
   },
@@ -126,8 +115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8f2e9283-4cbc-4374-9757-ed8d68542c89",
-        "name": "body-margin-multiplier",
-        "constant-token-duplicate": true
+        "name": "body-margin-multiplier"
       }
     }
   },
@@ -137,8 +125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "717c067c-55d1-4927-ad9c-8784769f581d",
-        "name": "body-sans-serif-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-emphasized-font-style"
       }
     }
   },
@@ -148,8 +135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5640ac73-a482-4787-9ab2-035b57a87833",
-        "name": "body-sans-serif-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-emphasized-font-weight"
       }
     }
   },
@@ -159,8 +145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "32c3d84f-2b0d-4ccd-ba3c-b8475d82550b",
-        "name": "body-sans-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-font-family"
       }
     }
   },
@@ -170,8 +155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e1da0eff-7482-46a0-8190-4c54c6b1e1dd",
-        "name": "body-sans-serif-font-style",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-font-style"
       }
     }
   },
@@ -181,8 +165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6813005d-9df4-459b-9fab-b2a054c32c31",
-        "name": "body-sans-serif-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-font-weight"
       }
     }
   },
@@ -192,8 +175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b87e6738-af38-49be-9945-f3a307ce7b6f",
-        "name": "body-sans-serif-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-strong-emphasized-font-style"
       }
     }
   },
@@ -203,8 +185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "421dc907-5862-4ed5-95f4-41d654b2fdc0",
-        "name": "body-sans-serif-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-strong-emphasized-font-weight"
       }
     }
   },
@@ -214,8 +195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b36db31f-eaaa-4310-9f54-f7b509d5f571",
-        "name": "body-sans-serif-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-strong-font-style"
       }
     }
   },
@@ -225,8 +205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "633953a9-c61b-44cc-9dee-aebece97ccbc",
-        "name": "body-sans-serif-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-strong-font-weight"
       }
     }
   },
@@ -236,8 +215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c817210d-2b1a-4648-bff3-33fa212491f1",
-        "name": "body-serif-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "body-serif-emphasized-font-style"
       }
     }
   },
@@ -247,8 +225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "be2a8ff3-6117-4235-bcb8-72257b75d622",
-        "name": "body-serif-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-serif-emphasized-font-weight"
       }
     }
   },
@@ -258,8 +235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "20df8bd4-5a61-4614-aa86-5b76c5976860",
-        "name": "body-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "body-serif-font-family"
       }
     }
   },
@@ -269,8 +245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d317d387-9bc8-4258-a79a-a0dd4e22d952",
-        "name": "body-serif-font-style",
-        "constant-token-duplicate": true
+        "name": "body-serif-font-style"
       }
     }
   },
@@ -280,8 +255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f049ba7a-c52f-4d39-b38e-911b2b91d031",
-        "name": "body-serif-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-serif-font-weight"
       }
     }
   },
@@ -291,8 +265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b940bdc8-d373-4bd0-8620-d6c04134698b",
-        "name": "body-serif-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "body-serif-strong-emphasized-font-style"
       }
     }
   },
@@ -302,8 +275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a87b77ff-5b27-47e0-a7df-f15092fb783e",
-        "name": "body-serif-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-serif-strong-emphasized-font-weight"
       }
     }
   },
@@ -313,8 +285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c8b531d1-949e-4492-9897-450a477983ce",
-        "name": "body-serif-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "body-serif-strong-font-style"
       }
     }
   },
@@ -324,8 +295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "be263571-bd6b-4383-bdf9-3cdf80248b6a",
-        "name": "body-serif-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-serif-strong-font-weight"
       }
     }
   },
@@ -335,8 +305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "884b74cb-d247-491d-acb9-d3dc84bfd9a6",
-        "name": "body-size-l",
-        "constant-token-duplicate": true
+        "name": "body-size-l"
       }
     }
   },
@@ -346,8 +315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4f7f6878-5304-48d3-8a42-5bb452c2163b",
-        "name": "body-size-m",
-        "constant-token-duplicate": true
+        "name": "body-size-m"
       }
     }
   },
@@ -357,8 +325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
-        "name": "body-size-s",
-        "constant-token-duplicate": true
+        "name": "body-size-s"
       }
     }
   },
@@ -368,8 +335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3927604f-eaf3-4605-aa34-80b7bc88ac0f",
-        "name": "body-size-xl",
-        "constant-token-duplicate": true
+        "name": "body-size-xl"
       }
     }
   },
@@ -379,8 +345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "25e93322-8f0b-45f8-ae9a-18668251f064",
-        "name": "body-size-xs",
-        "constant-token-duplicate": true
+        "name": "body-size-xs"
       }
     }
   },
@@ -390,8 +355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4d0d4ed9-af14-4d88-98f1-9237f65e192a",
-        "name": "body-size-xxl",
-        "constant-token-duplicate": true
+        "name": "body-size-xxl"
       }
     }
   },
@@ -401,8 +365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e0b8ceea-3404-4c4b-9145-fe5d445020fe",
-        "name": "body-size-xxxl",
-        "constant-token-duplicate": true
+        "name": "body-size-xxxl"
       }
     }
   },
@@ -412,8 +375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f892e676-5218-4dc9-870b-c9d2df6f3152",
-        "name": "code-cjk-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "code-cjk-emphasized-font-style"
       }
     }
   },
@@ -423,8 +385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "61f8b443-95fa-46fd-8876-b4d7a2244af9",
-        "name": "code-cjk-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-cjk-emphasized-font-weight"
       }
     }
   },
@@ -434,8 +395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "322cb744-5837-4d0a-94a8-3c885d54568d",
-        "name": "code-cjk-font-family",
-        "constant-token-duplicate": true
+        "name": "code-cjk-font-family"
       }
     }
   },
@@ -445,8 +405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b26477bc-8bf1-41aa-b849-cfde54e27780",
-        "name": "code-cjk-font-style",
-        "constant-token-duplicate": true
+        "name": "code-cjk-font-style"
       }
     }
   },
@@ -456,8 +415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8455f34c-0c79-4699-aa7c-c77d28bfa617",
-        "name": "code-cjk-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-cjk-font-weight"
       }
     }
   },
@@ -467,8 +425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "35580910-cb91-44df-9613-7b2e40a75a7c",
-        "name": "code-cjk-line-height",
-        "constant-token-duplicate": true
+        "name": "code-cjk-line-height"
       }
     }
   },
@@ -478,8 +435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "38006d42-4f02-46ff-917f-6c0163525642",
-        "name": "code-cjk-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "code-cjk-strong-emphasized-font-style"
       }
     }
   },
@@ -489,8 +445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8ed5c5e0-ff72-4937-98fd-fd09f1fab288",
-        "name": "code-cjk-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-cjk-strong-emphasized-font-weight"
       }
     }
   },
@@ -500,8 +455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a30c9a18-1a49-4b16-87a0-e882c81dd1bd",
-        "name": "code-cjk-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "code-cjk-strong-font-style"
       }
     }
   },
@@ -511,8 +465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ed73f5fc-5b7a-4414-8f1c-325e7944a9e1",
-        "name": "code-cjk-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-cjk-strong-font-weight"
       }
     }
   },
@@ -522,8 +475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9d3151ad-4a37-4eeb-aadd-7389ccb09345",
-        "name": "code-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "code-emphasized-font-style"
       }
     }
   },
@@ -533,8 +485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "948436ba-23d7-4eec-a3fe-ef5829ccadb0",
-        "name": "code-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-emphasized-font-weight"
       }
     }
   },
@@ -544,8 +495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "79b6c1f9-d1d5-4053-be47-36ecb666d0c1",
-        "name": "code-font-family",
-        "constant-token-duplicate": true
+        "name": "code-font-family"
       }
     }
   },
@@ -555,8 +505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b98a9c39-7d39-4b6d-ad35-46c8b1725c0c",
-        "name": "code-font-style",
-        "constant-token-duplicate": true
+        "name": "code-font-style"
       }
     }
   },
@@ -566,8 +515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bf02dd59-4b3c-435a-b33b-49fff22674a3",
-        "name": "code-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-font-weight"
       }
     }
   },
@@ -577,8 +525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0d33b30d-96d6-4b5a-90d2-2a708bdae623",
-        "name": "code-line-height",
-        "constant-token-duplicate": true
+        "name": "code-line-height"
       }
     }
   },
@@ -588,8 +535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7010f1a-c994-4b19-b273-3f609fe4be2b",
-        "name": "code-size-l",
-        "constant-token-duplicate": true
+        "name": "code-size-l"
       }
     }
   },
@@ -599,8 +545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e5b76091-7cbb-4d1e-8d27-48f00759c9f3",
-        "name": "code-size-m",
-        "constant-token-duplicate": true
+        "name": "code-size-m"
       }
     }
   },
@@ -610,8 +555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "efa9311b-27c5-45ea-93a7-bef6f9370179",
-        "name": "code-size-s",
-        "constant-token-duplicate": true
+        "name": "code-size-s"
       }
     }
   },
@@ -621,8 +565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7879adbc-6c38-4d29-9a90-a4ad91c75b90",
-        "name": "code-size-xl",
-        "constant-token-duplicate": true
+        "name": "code-size-xl"
       }
     }
   },
@@ -632,8 +575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f0c5e6fb-fb48-45d2-a043-558b3dc28bc7",
-        "name": "code-size-xs",
-        "constant-token-duplicate": true
+        "name": "code-size-xs"
       }
     }
   },
@@ -643,8 +585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "83d53fe1-372f-46ba-b8e0-f90ca2e59647",
-        "name": "code-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "code-strong-emphasized-font-style"
       }
     }
   },
@@ -654,8 +595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4d5f1937-552d-44a4-be8e-2edafefa46aa",
-        "name": "code-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-strong-emphasized-font-weight"
       }
     }
   },
@@ -665,8 +605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dac3d8d5-3005-4fa6-b71a-6679470176cf",
-        "name": "code-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "code-strong-font-style"
       }
     }
   },
@@ -676,8 +615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "48d2b9b8-beac-4185-827d-0c552e47663f",
-        "name": "code-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-strong-font-weight"
       }
     }
   },
@@ -687,8 +625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3dca0579-91c4-4f60-a2a6-25f16eb673b3",
-        "name": "detail-cjk-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-emphasized-font-style"
       }
     }
   },
@@ -698,8 +635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "aa70fa2d-87ee-4e67-b230-85f400ddd7d1",
-        "name": "detail-cjk-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-emphasized-font-weight"
       }
     }
   },
@@ -709,8 +645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6cc647ab-1474-4094-974d-d079d7ef7565",
-        "name": "detail-cjk-font-family",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-font-family"
       }
     }
   },
@@ -720,8 +655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4d2a9b37-101b-4025-95d6-aba18b701a58",
-        "name": "detail-cjk-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-font-style"
       }
     }
   },
@@ -731,8 +665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9b11f80a-7600-4a6b-a366-218ba320a5cc",
-        "name": "detail-cjk-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-font-weight"
       }
     }
   },
@@ -742,8 +675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c7b1b312-cd81-4c65-8a67-017f91aee40b",
-        "name": "detail-cjk-light-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-emphasized-font-style"
       }
     }
   },
@@ -753,8 +685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "279d9a16-279f-4788-b5b0-af825a4b5d40",
-        "name": "detail-cjk-light-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-emphasized-font-weight"
       }
     }
   },
@@ -764,8 +695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4cc06d86-326e-4b6f-a751-99445bb1d131",
-        "name": "detail-cjk-light-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-font-style"
       }
     }
   },
@@ -775,8 +705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3b531775-a1fd-4a40-b169-7c42b8c6de38",
-        "name": "detail-cjk-light-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-font-weight"
       }
     }
   },
@@ -786,8 +715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1d4235ff-c183-4d6c-8277-9783e3e1ce7a",
-        "name": "detail-cjk-light-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-strong-emphasized-font-style"
       }
     }
   },
@@ -797,8 +725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0bc51146-a3e5-48c4-8324-4490b9d30f4d",
-        "name": "detail-cjk-light-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-strong-emphasized-font-weight"
       }
     }
   },
@@ -808,8 +735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ec87fefe-f35f-41a0-9be1-6d076f0db230",
-        "name": "detail-cjk-light-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-strong-font-style"
       }
     }
   },
@@ -819,8 +745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "91231878-73dc-46ce-a277-1d14e0e36842",
-        "name": "detail-cjk-light-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-strong-font-weight"
       }
     }
   },
@@ -830,8 +755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "93434006-5ed7-4656-96b7-8f355a1f07b2",
-        "name": "detail-cjk-line-height",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-line-height"
       }
     }
   },
@@ -841,8 +765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "75a3a4ec-2b57-4a49-b3bd-84b41a3cd314",
-        "name": "detail-cjk-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-strong-emphasized-font-style"
       }
     }
   },
@@ -852,8 +775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a7007c07-15a4-4671-bd3b-7406f4b374bb",
-        "name": "detail-cjk-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-strong-emphasized-font-weight"
       }
     }
   },
@@ -863,8 +785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "653358fc-5ee4-4e97-affc-c56896d370c0",
-        "name": "detail-cjk-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-strong-font-style"
       }
     }
   },
@@ -874,8 +795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ef2997f3-276c-4662-8644-9514590114f4",
-        "name": "detail-cjk-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-strong-font-weight"
       }
     }
   },
@@ -885,8 +805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c4dbe044-dc8c-4722-b36c-5442cd2bc279",
-        "name": "detail-letter-spacing",
-        "constant-token-duplicate": true
+        "name": "detail-letter-spacing"
       }
     }
   },
@@ -896,8 +815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4ca9965a-24f9-454e-b0a7-dd5a0c5ae170",
-        "name": "detail-line-height",
-        "constant-token-duplicate": true
+        "name": "detail-line-height"
       }
     }
   },
@@ -907,8 +825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "35ac24a4-0338-44c6-b780-120a0af0fc51",
-        "name": "detail-margin-bottom-multiplier",
-        "constant-token-duplicate": true
+        "name": "detail-margin-bottom-multiplier"
       }
     }
   },
@@ -918,8 +835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5d34c3b5-fddd-420b-bfe4-0dee4e07701c",
-        "name": "detail-margin-top-multiplier",
-        "constant-token-duplicate": true
+        "name": "detail-margin-top-multiplier"
       }
     }
   },
@@ -929,8 +845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5c7dcef1-514e-4d43-b2ef-76639e214b8c",
-        "name": "detail-sans-serif-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-emphasized-font-style"
       }
     }
   },
@@ -940,8 +855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6ca600be-010a-4aaa-a815-e5bfdbe36b21",
-        "name": "detail-sans-serif-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-emphasized-font-weight"
       }
     }
   },
@@ -951,8 +865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "34101c26-b4cd-43aa-bddd-0758d21fef01",
-        "name": "detail-sans-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-font-family"
       }
     }
   },
@@ -962,8 +875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "21a9500c-f9a4-4ff3-9eb5-6da81bf314f6",
-        "name": "detail-sans-serif-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-font-style"
       }
     }
   },
@@ -973,8 +885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d06a4346-ec24-4922-8985-4b8a05e0bfc6",
-        "name": "detail-sans-serif-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-font-weight"
       }
     }
   },
@@ -984,8 +895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fc6098a2-3263-433c-8378-ba609629ef53",
-        "name": "detail-sans-serif-light-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-emphasized-font-style"
       }
     }
   },
@@ -995,8 +905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "64972012-5050-41d0-9c9b-269b533a58b7",
-        "name": "detail-sans-serif-light-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-emphasized-font-weight"
       }
     }
   },
@@ -1006,8 +915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a6b7c26e-3ff5-4241-b9cc-3026604fe30e",
-        "name": "detail-sans-serif-light-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-font-style"
       }
     }
   },
@@ -1017,8 +925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cf8f93e2-2b79-4a4c-bb31-313e013148e3",
-        "name": "detail-sans-serif-light-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-font-weight"
       }
     }
   },
@@ -1028,8 +935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7364639-2686-4e12-9ede-d6543d0d0d6d",
-        "name": "detail-sans-serif-light-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-strong-emphasized-font-style"
       }
     }
   },
@@ -1039,8 +945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "53f16a1c-9d44-4384-9a7e-88a2c4319486",
-        "name": "detail-sans-serif-light-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-strong-emphasized-font-weight"
       }
     }
   },
@@ -1050,8 +955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c1966f09-1c6e-4fe0-89ad-8fb8e847e3ba",
-        "name": "detail-sans-serif-light-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-strong-font-style"
       }
     }
   },
@@ -1061,8 +965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4f0f95d3-098a-4852-bd21-785f5bf054b5",
-        "name": "detail-sans-serif-light-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-strong-font-weight"
       }
     }
   },
@@ -1072,8 +975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "82d04795-da5f-4868-a90d-980f5376a878",
-        "name": "detail-sans-serif-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-strong-emphasized-font-style"
       }
     }
   },
@@ -1083,8 +985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c57f8682-52d2-43fa-a306-a588a13ead6b",
-        "name": "detail-sans-serif-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-strong-emphasized-font-weight"
       }
     }
   },
@@ -1094,8 +995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c56642f3-043c-4738-bed0-61b324221f4e",
-        "name": "detail-sans-serif-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-strong-font-style"
       }
     }
   },
@@ -1105,8 +1005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a150e66c-daf4-4c71-a2e2-577600878988",
-        "name": "detail-sans-serif-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-strong-font-weight"
       }
     }
   },
@@ -1116,8 +1015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8646d403-21f9-4e77-8a21-92289c303715",
-        "name": "detail-sans-serif-text-transform",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-text-transform"
       }
     }
   },
@@ -1127,8 +1025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cfaf6a70-3eb5-4887-bae6-8ae41c094192",
-        "name": "detail-serif-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-emphasized-font-style"
       }
     }
   },
@@ -1138,8 +1035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "247b2004-e0bc-42b9-ba83-6edbe417c4cb",
-        "name": "detail-serif-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-emphasized-font-weight"
       }
     }
   },
@@ -1149,8 +1045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "365c6166-e17d-40bd-841e-495aa9c6acd7",
-        "name": "detail-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "detail-serif-font-family"
       }
     }
   },
@@ -1160,8 +1055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "524c5101-f745-47e6-b233-62cd005850f8",
-        "name": "detail-serif-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-font-style"
       }
     }
   },
@@ -1171,8 +1065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "87ef8843-f44e-4526-80cd-9635f3e0261e",
-        "name": "detail-serif-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-font-weight"
       }
     }
   },
@@ -1182,8 +1075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "320bcd8e-2bb8-4e9e-9b1d-4838b2966857",
-        "name": "detail-serif-light-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-emphasized-font-style"
       }
     }
   },
@@ -1193,8 +1085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3d27f76e-b068-4f06-bea8-ee31fcbc49b2",
-        "name": "detail-serif-light-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-emphasized-font-weight"
       }
     }
   },
@@ -1204,8 +1095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f6478d1d-5dcf-43eb-a4fc-498479b29aa7",
-        "name": "detail-serif-light-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-font-style"
       }
     }
   },
@@ -1215,8 +1105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2a15a805-fd08-4f8e-82e6-9264ef8937cb",
-        "name": "detail-serif-light-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-font-weight"
       }
     }
   },
@@ -1226,8 +1115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "42d2049f-cda2-4ae4-8d0a-41f7789f768b",
-        "name": "detail-serif-light-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-strong-emphasized-font-style"
       }
     }
   },
@@ -1237,8 +1125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1c524d85-9fca-433c-b5c4-5eaa456cc3a2",
-        "name": "detail-serif-light-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-strong-emphasized-font-weight"
       }
     }
   },
@@ -1248,8 +1135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7a878a3f-b663-41ee-8357-6e62f2e51d80",
-        "name": "detail-serif-light-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-strong-font-style"
       }
     }
   },
@@ -1259,8 +1145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fc5df058-f678-4dc8-953f-e2738798ee2b",
-        "name": "detail-serif-light-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-strong-font-weight"
       }
     }
   },
@@ -1270,8 +1155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7fdffa4e-4370-45cf-aab0-316561a56a24",
-        "name": "detail-serif-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-strong-emphasized-font-style"
       }
     }
   },
@@ -1281,8 +1165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "863cf841-7b83-4f66-a01f-12dccd47fee6",
-        "name": "detail-serif-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-strong-emphasized-font-weight"
       }
     }
   },
@@ -1292,8 +1175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3b2124e3-e50b-4ab7-8340-f97b1f8fef1e",
-        "name": "detail-serif-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-strong-font-style"
       }
     }
   },
@@ -1303,8 +1185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d737931b-f63c-4874-8fa5-872b95048727",
-        "name": "detail-serif-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-strong-font-weight"
       }
     }
   },
@@ -1314,8 +1195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0e161c32-c412-4cda-bacb-7eaa548b5534",
-        "name": "detail-serif-text-transform",
-        "constant-token-duplicate": true
+        "name": "detail-serif-text-transform"
       }
     }
   },
@@ -1325,8 +1205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "613da587-5c48-4efa-abb5-36378c1e81f0",
-        "name": "detail-size-l",
-        "constant-token-duplicate": true
+        "name": "detail-size-l"
       }
     }
   },
@@ -1336,8 +1215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "07840554-1ec1-4823-b119-474ec9cc31f0",
-        "name": "detail-size-m",
-        "constant-token-duplicate": true
+        "name": "detail-size-m"
       }
     }
   },
@@ -1347,8 +1225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "585e1bec-ee93-4983-b0bb-3a1f6ec28218",
-        "name": "detail-size-s",
-        "constant-token-duplicate": true
+        "name": "detail-size-s"
       }
     }
   },
@@ -1358,8 +1235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ab476eec-b592-4890-af8f-74de808cb87f",
-        "name": "detail-size-xl",
-        "constant-token-duplicate": true
+        "name": "detail-size-xl"
       }
     }
   },
@@ -1369,8 +1245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "05c74b28-3051-498c-874a-5dc523bc27e5",
-        "name": "heading-cjk-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-emphasized-font-style"
       }
     }
   },
@@ -1380,8 +1255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d854afd2-290a-40ae-a627-c4cdabeb546a",
-        "name": "heading-cjk-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-emphasized-font-weight"
       }
     }
   },
@@ -1391,8 +1265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b6652ee5-466f-4117-a77c-a93a40f2a791",
-        "name": "heading-cjk-font-family",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-font-family"
       }
     }
   },
@@ -1402,8 +1275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c93b39df-82e9-4e87-920f-1747e5d48e8e",
-        "name": "heading-cjk-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-font-style"
       }
     }
   },
@@ -1413,8 +1285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bd54516c-2fda-4421-ab62-720c3a887a34",
-        "name": "heading-cjk-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-font-weight"
       }
     }
   },
@@ -1424,8 +1295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "aef21944-3dac-4b2d-ba7b-0a4df3f406bb",
-        "name": "heading-cjk-heavy-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-emphasized-font-style"
       }
     }
   },
@@ -1435,8 +1305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9315971c-6e83-42c8-9c24-d1bc6fa5e106",
-        "name": "heading-cjk-heavy-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-emphasized-font-weight"
       }
     }
   },
@@ -1446,8 +1315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b2f50ba2-e694-47ba-b81a-ea8fc813247e",
-        "name": "heading-cjk-heavy-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-font-style"
       }
     }
   },
@@ -1457,8 +1325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "73c20d2f-1227-46bc-8548-102358405b0b",
-        "name": "heading-cjk-heavy-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-font-weight"
       }
     }
   },
@@ -1468,8 +1335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "619a15ba-f74e-4ff4-a604-312b810f1a50",
-        "name": "heading-cjk-heavy-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-strong-emphasized-font-style"
       }
     }
   },
@@ -1479,8 +1345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a0f680fa-2453-4bcc-b06c-9ff82de50c0c",
-        "name": "heading-cjk-heavy-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-strong-emphasized-font-weight"
       }
     }
   },
@@ -1490,8 +1355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "26817f91-2742-4170-aa01-1e1e67ef01e8",
-        "name": "heading-cjk-heavy-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-strong-font-style"
       }
     }
   },
@@ -1501,8 +1365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7d2203c-c651-493e-80c2-b71b7c7c2692",
-        "name": "heading-cjk-heavy-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-strong-font-weight"
       }
     }
   },
@@ -1512,8 +1375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dac03eec-6910-4176-bfca-33f8a57cf3d7",
-        "name": "heading-cjk-light-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-emphasized-font-style"
       }
     }
   },
@@ -1523,8 +1385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "aea9787b-ee0b-40cc-9089-5973e52b18bd",
-        "name": "heading-cjk-light-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-emphasized-font-weight"
       }
     }
   },
@@ -1534,8 +1395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b5704c75-2914-4268-9023-7f7452e826c1",
-        "name": "heading-cjk-light-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-font-style"
       }
     }
   },
@@ -1545,8 +1405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9da0ba4c-b4e3-4052-8b2e-d2fde714bb9d",
-        "name": "heading-cjk-light-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-font-weight"
       }
     }
   },
@@ -1556,8 +1415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9136e25e-563b-4485-bad7-41809d5317de",
-        "name": "heading-cjk-light-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-strong-emphasized-font-style"
       }
     }
   },
@@ -1567,8 +1425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "83cc347c-7a1a-4665-9de4-cf19903f1043",
-        "name": "heading-cjk-light-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-strong-emphasized-font-weight"
       }
     }
   },
@@ -1578,8 +1435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "be854057-43b1-40ce-bdc7-69960cd7638c",
-        "name": "heading-cjk-light-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-strong-font-style"
       }
     }
   },
@@ -1589,8 +1445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5ca91bc2-215b-4cbb-b966-80bfffd569ad",
-        "name": "heading-cjk-light-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-strong-font-weight"
       }
     }
   },
@@ -1600,8 +1455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3e038db9-c5f7-4b8b-b1af-31075a31e0cc",
-        "name": "heading-cjk-line-height",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-line-height"
       }
     }
   },
@@ -1611,8 +1465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f57ffe02-2e41-46f3-a0ac-1feb63bdd748",
-        "name": "heading-cjk-size-l",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-l"
       }
     }
   },
@@ -1622,8 +1475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "43f45659-314b-45aa-9886-1beb096fc4ce",
-        "name": "heading-cjk-size-m",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-m"
       }
     }
   },
@@ -1633,8 +1485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c1242a8c-ca10-40d0-8fc4-67bbbce8fc5f",
-        "name": "heading-cjk-size-s",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-s"
       }
     }
   },
@@ -1644,8 +1495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "43535e5f-607e-43f4-bd37-8230b1f7993f",
-        "name": "heading-cjk-size-xl",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-xl"
       }
     }
   },
@@ -1655,8 +1505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "132688a7-917d-44b9-a34f-a7135599b299",
-        "name": "heading-cjk-size-xs",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-xs"
       }
     }
   },
@@ -1666,8 +1515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fbf59302-1ad2-4327-bfde-d638a0ca2429",
-        "name": "heading-cjk-size-xxl",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-xxl"
       }
     }
   },
@@ -1677,8 +1525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bddd6a96-c280-47ca-8858-20df055e488d",
-        "name": "heading-cjk-size-xxs",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-xxs"
       }
     }
   },
@@ -1688,8 +1535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5a44e177-2478-4bb0-9212-ba2df64c8b00",
-        "name": "heading-cjk-size-xxxl",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-xxxl"
       }
     }
   },
@@ -1699,8 +1545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "22934d4d-4952-40a7-a5e5-256a7a3c9371",
-        "name": "heading-cjk-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-strong-emphasized-font-style"
       }
     }
   },
@@ -1710,8 +1555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0080a817-b26f-42f1-84c4-5ed1ac08c12c",
-        "name": "heading-cjk-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-strong-emphasized-font-weight"
       }
     }
   },
@@ -1721,8 +1565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4f061165-0e86-46b9-83c3-c95eeb8ff956",
-        "name": "heading-cjk-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-strong-font-style"
       }
     }
   },
@@ -1732,8 +1575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "eaf179aa-4514-4206-b3e2-a99b7d4d2029",
-        "name": "heading-cjk-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-strong-font-weight"
       }
     }
   },
@@ -1743,8 +1585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "64f28fe4-20f7-48cb-baeb-ff1898573727",
-        "name": "heading-line-height",
-        "constant-token-duplicate": true
+        "name": "heading-line-height"
       }
     }
   },
@@ -1754,8 +1595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dd2035b4-506f-41ab-a656-de3668d44e0f",
-        "name": "heading-margin-bottom-multiplier",
-        "constant-token-duplicate": true
+        "name": "heading-margin-bottom-multiplier"
       }
     }
   },
@@ -1765,8 +1605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "008fa04b-6d74-416b-a6ae-ceec90f08642",
-        "name": "heading-margin-top-multiplier",
-        "constant-token-duplicate": true
+        "name": "heading-margin-top-multiplier"
       }
     }
   },
@@ -1776,8 +1615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2f17833a-28a4-4152-8999-12b077557797",
-        "name": "heading-sans-serif-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-emphasized-font-style"
       }
     }
   },
@@ -1787,8 +1625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e4a183fd-53c5-4dbb-afd1-6308e2e74f80",
-        "name": "heading-sans-serif-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-emphasized-font-weight"
       }
     }
   },
@@ -1798,8 +1635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "234d7b9d-bddc-4988-8be5-ef5e41e08185",
-        "name": "heading-sans-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-font-family"
       }
     }
   },
@@ -1809,8 +1645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "561d905e-7f44-43da-b2b4-26e12551ef6d",
-        "name": "heading-sans-serif-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-font-style"
       }
     }
   },
@@ -1820,8 +1655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1d4d09b4-021a-48e8-a724-bfecc13df325",
-        "name": "heading-sans-serif-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-font-weight"
       }
     }
   },
@@ -1831,8 +1665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "924c338f-7141-490a-a842-ad632c26160c",
-        "name": "heading-sans-serif-heavy-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-emphasized-font-style"
       }
     }
   },
@@ -1842,8 +1675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a7cb3274-e48e-435b-a066-32027ac19e84",
-        "name": "heading-sans-serif-heavy-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-emphasized-font-weight"
       }
     }
   },
@@ -1853,8 +1685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0c4cdd06-8180-40b1-9b1f-d7d973a7b772",
-        "name": "heading-sans-serif-heavy-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-font-style"
       }
     }
   },
@@ -1864,8 +1695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ef13b8f0-f686-492d-990f-691ec91ebb96",
-        "name": "heading-sans-serif-heavy-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-font-weight"
       }
     }
   },
@@ -1875,8 +1705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c20ea22a-c34d-4c7c-a816-75b533e28c92",
-        "name": "heading-sans-serif-heavy-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-strong-emphasized-font-style"
       }
     }
   },
@@ -1886,8 +1715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8779e773-7b37-4eb0-ae7a-2ba0104ad9d5",
-        "name": "heading-sans-serif-heavy-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-strong-emphasized-font-weight"
       }
     }
   },
@@ -1897,8 +1725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "86775b10-5682-49fb-9d38-6bdb857da801",
-        "name": "heading-sans-serif-heavy-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-strong-font-style"
       }
     }
   },
@@ -1908,8 +1735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2104c3c2-d834-436a-a26d-508056f1013d",
-        "name": "heading-sans-serif-heavy-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-strong-font-weight"
       }
     }
   },
@@ -1919,8 +1745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5f88eb81-7052-4c21-9896-f14cb09f0e70",
-        "name": "heading-sans-serif-light-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-emphasized-font-style"
       }
     }
   },
@@ -1930,8 +1755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e882ea46-8f0a-4313-84f5-85bb8d9f1f5e",
-        "name": "heading-sans-serif-light-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-emphasized-font-weight"
       }
     }
   },
@@ -1941,8 +1765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c5551fd5-4ee2-4c93-b91f-9ed295fa63a4",
-        "name": "heading-sans-serif-light-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-font-style"
       }
     }
   },
@@ -1952,8 +1775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ff84a748-5923-451d-967c-a346d2dee46c",
-        "name": "heading-sans-serif-light-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-font-weight"
       }
     }
   },
@@ -1963,8 +1785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bc5d65e0-e13a-424c-a260-9268a0dee66c",
-        "name": "heading-sans-serif-light-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-strong-emphasized-font-style"
       }
     }
   },
@@ -1974,8 +1795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c297a503-fc3c-4939-8c5a-6611b9b04719",
-        "name": "heading-sans-serif-light-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-strong-emphasized-font-weight"
       }
     }
   },
@@ -1985,8 +1805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "67271ca0-c9fd-4047-a615-6314d7333f7a",
-        "name": "heading-sans-serif-light-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-strong-font-style"
       }
     }
   },
@@ -1996,8 +1815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "75437f9a-7ee8-4194-b4b3-0746be097396",
-        "name": "heading-sans-serif-light-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-strong-font-weight"
       }
     }
   },
@@ -2007,8 +1825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f692d35f-1b11-43d1-ad29-967436b90928",
-        "name": "heading-sans-serif-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-strong-emphasized-font-style"
       }
     }
   },
@@ -2018,8 +1835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9d834e30-53c1-4cea-9e17-2326038cb6cb",
-        "name": "heading-sans-serif-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-strong-emphasized-font-weight"
       }
     }
   },
@@ -2029,8 +1845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2117cb6e-67f7-4509-b4fb-e9e442b6dc0e",
-        "name": "heading-sans-serif-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-strong-font-style"
       }
     }
   },
@@ -2040,8 +1855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "79275989-91ed-408a-b884-a31d9f8bac26",
-        "name": "heading-sans-serif-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-strong-font-weight"
       }
     }
   },
@@ -2051,8 +1865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fe694554-832d-457d-a320-f02629f9c441",
-        "name": "heading-serif-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-emphasized-font-style"
       }
     }
   },
@@ -2062,8 +1875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a0983216-b0c5-4a3f-97dc-96ee711acb1f",
-        "name": "heading-serif-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-emphasized-font-weight"
       }
     }
   },
@@ -2073,8 +1885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f2430818-41b5-439a-8347-6b384e78d141",
-        "name": "heading-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "heading-serif-font-family"
       }
     }
   },
@@ -2084,8 +1895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "938f3684-44c6-4ae2-935a-b88921fcd7fe",
-        "name": "heading-serif-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-font-style"
       }
     }
   },
@@ -2095,8 +1905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "350aa193-9996-49c8-b5e4-54d4f7bef3c2",
-        "name": "heading-serif-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-font-weight"
       }
     }
   },
@@ -2106,8 +1915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a18ac621-eade-4224-9660-3e9a080219ec",
-        "name": "heading-serif-heavy-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-emphasized-font-style"
       }
     }
   },
@@ -2117,8 +1925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "82e9d579-8918-4114-bafa-3a9757556f84",
-        "name": "heading-serif-heavy-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-emphasized-font-weight"
       }
     }
   },
@@ -2128,8 +1935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "14532cb8-6c88-46ce-886b-96fac971e7b9",
-        "name": "heading-serif-heavy-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-font-style"
       }
     }
   },
@@ -2139,8 +1945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6b74c5ea-6bf4-46bb-bee1-3841606f1500",
-        "name": "heading-serif-heavy-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-font-weight"
       }
     }
   },
@@ -2150,8 +1955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "adf303e8-1e27-4aec-9bbc-5abe166358ec",
-        "name": "heading-serif-heavy-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-strong-emphasized-font-style"
       }
     }
   },
@@ -2161,8 +1965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2d8e76cd-f123-488d-893d-54a9f48f679e",
-        "name": "heading-serif-heavy-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-strong-emphasized-font-weight"
       }
     }
   },
@@ -2172,8 +1975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b2875bbe-b5cb-452f-b7d6-3dcb4fc59921",
-        "name": "heading-serif-heavy-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-strong-font-style"
       }
     }
   },
@@ -2183,8 +1985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "af0010c7-5134-4fe4-bee1-bbb7dd31de3a",
-        "name": "heading-serif-heavy-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-strong-font-weight"
       }
     }
   },
@@ -2194,8 +1995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7bd831cd-3fe0-402b-a105-f65b8e8023e2",
-        "name": "heading-serif-light-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-emphasized-font-style"
       }
     }
   },
@@ -2205,8 +2005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b5f79fde-07f7-4c07-897e-0bfdf27e2839",
-        "name": "heading-serif-light-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-emphasized-font-weight"
       }
     }
   },
@@ -2216,8 +2015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5f30418a-aa76-434e-bca9-902d5be0d929",
-        "name": "heading-serif-light-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-font-style"
       }
     }
   },
@@ -2227,8 +2025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "66958795-6459-4750-8c68-dc39ab383837",
-        "name": "heading-serif-light-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-font-weight"
       }
     }
   },
@@ -2238,8 +2035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "71c8e302-6bc1-4f45-b804-c847dd153d1b",
-        "name": "heading-serif-light-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-strong-emphasized-font-style"
       }
     }
   },
@@ -2249,8 +2045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "98c61df3-057d-4345-881e-0c04628757f3",
-        "name": "heading-serif-light-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-strong-emphasized-font-weight"
       }
     }
   },
@@ -2260,8 +2055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "73906871-24e5-48cc-9140-ec700c08d144",
-        "name": "heading-serif-light-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-strong-font-style"
       }
     }
   },
@@ -2271,8 +2065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "29ad1c96-62e4-4143-88e8-fc8e08913a52",
-        "name": "heading-serif-light-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-strong-font-weight"
       }
     }
   },
@@ -2282,8 +2075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "da6e1593-9d2a-4fd8-8877-d30d6e1d1c07",
-        "name": "heading-serif-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-strong-emphasized-font-style"
       }
     }
   },
@@ -2293,8 +2085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cd32f2b7-3e9f-47ae-ad34-2c7783dd5b2f",
-        "name": "heading-serif-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-strong-emphasized-font-weight"
       }
     }
   },
@@ -2304,8 +2095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2e0ef484-406a-4902-995d-9a3d5177ec12",
-        "name": "heading-serif-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-strong-font-style"
       }
     }
   },
@@ -2315,8 +2105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6df0fb95-4aa0-4c67-896d-fa6aa3d34e95",
-        "name": "heading-serif-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-strong-font-weight"
       }
     }
   },
@@ -2326,8 +2115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "336e434c-9026-4bb3-96b1-5bb44376b868",
-        "name": "heading-size-l",
-        "constant-token-duplicate": true
+        "name": "heading-size-l"
       }
     }
   },
@@ -2337,8 +2125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4cdcefe1-2006-4560-839f-5bdef6db8c1a",
-        "name": "heading-size-m",
-        "constant-token-duplicate": true
+        "name": "heading-size-m"
       }
     }
   },
@@ -2348,8 +2135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "96673fee-b75c-4867-9041-48362af044bc",
-        "name": "heading-size-s",
-        "constant-token-duplicate": true
+        "name": "heading-size-s"
       }
     }
   },
@@ -2359,8 +2145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "94bb5ad9-503a-428a-a8ba-6cf3f70592ac",
-        "name": "heading-size-xl",
-        "constant-token-duplicate": true
+        "name": "heading-size-xl"
       }
     }
   },
@@ -2370,8 +2155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4f179af6-c31f-48f8-927c-a45150668ad3",
-        "name": "heading-size-xs",
-        "constant-token-duplicate": true
+        "name": "heading-size-xs"
       }
     }
   },
@@ -2381,8 +2165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "464e34cd-e768-4a38-a72b-cae1a4852ef3",
-        "name": "heading-size-xxl",
-        "constant-token-duplicate": true
+        "name": "heading-size-xxl"
       }
     }
   },
@@ -2392,8 +2175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "82a831b4-b624-475b-b2be-4eb949e48626",
-        "name": "heading-size-xxs",
-        "constant-token-duplicate": true
+        "name": "heading-size-xxs"
       }
     }
   },
@@ -2403,8 +2185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "db884bf9-e7b5-420a-b408-bd9a4d6bb0a4",
-        "name": "heading-size-xxxl",
-        "constant-token-duplicate": true
+        "name": "heading-size-xxxl"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/typography.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/typography.component/mobile.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3e90be19-62fd-4e53-abf9-4c697baba5da",
-        "name": "body-cjk-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "body-cjk-emphasized-font-style"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0d8ada2f-272d-4f76-bf37-095e0b48cdae",
-        "name": "body-cjk-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-cjk-emphasized-font-weight"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "06d5790c-21e9-4135-843d-05007b046677",
-        "name": "body-cjk-font-family",
-        "constant-token-duplicate": true
+        "name": "body-cjk-font-family"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "41389b62-c449-485b-bfa8-1659bacc8c42",
-        "name": "body-cjk-font-style",
-        "constant-token-duplicate": true
+        "name": "body-cjk-font-style"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a754c16b-2f0c-485f-813d-d472ee650660",
-        "name": "body-cjk-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-cjk-font-weight"
       }
     }
   },
@@ -60,8 +55,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2106b188-8520-4261-968b-2eb2928857f9",
-        "name": "body-cjk-line-height",
-        "constant-token-duplicate": true
+        "name": "body-cjk-line-height"
       }
     }
   },
@@ -71,8 +65,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f792aac0-62f2-47e3-b6ac-158ae009d9c3",
-        "name": "body-cjk-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "body-cjk-strong-emphasized-font-style"
       }
     }
   },
@@ -82,8 +75,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "54020791-a975-4e5d-a905-8bffcc9d2d93",
-        "name": "body-cjk-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-cjk-strong-emphasized-font-weight"
       }
     }
   },
@@ -93,8 +85,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "11fe09ad-92eb-4d7d-8872-467cdd69659b",
-        "name": "body-cjk-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "body-cjk-strong-font-style"
       }
     }
   },
@@ -104,8 +95,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d79de2c4-ca7c-4316-ac44-fee1a66983d7",
-        "name": "body-cjk-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-cjk-strong-font-weight"
       }
     }
   },
@@ -115,8 +105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "39accad7-3de1-4850-9773-4e0ff8080049",
-        "name": "body-line-height",
-        "constant-token-duplicate": true
+        "name": "body-line-height"
       }
     }
   },
@@ -126,8 +115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8f2e9283-4cbc-4374-9757-ed8d68542c89",
-        "name": "body-margin-multiplier",
-        "constant-token-duplicate": true
+        "name": "body-margin-multiplier"
       }
     }
   },
@@ -137,8 +125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "717c067c-55d1-4927-ad9c-8784769f581d",
-        "name": "body-sans-serif-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-emphasized-font-style"
       }
     }
   },
@@ -148,8 +135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5640ac73-a482-4787-9ab2-035b57a87833",
-        "name": "body-sans-serif-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-emphasized-font-weight"
       }
     }
   },
@@ -159,8 +145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "32c3d84f-2b0d-4ccd-ba3c-b8475d82550b",
-        "name": "body-sans-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-font-family"
       }
     }
   },
@@ -170,8 +155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e1da0eff-7482-46a0-8190-4c54c6b1e1dd",
-        "name": "body-sans-serif-font-style",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-font-style"
       }
     }
   },
@@ -181,8 +165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6813005d-9df4-459b-9fab-b2a054c32c31",
-        "name": "body-sans-serif-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-font-weight"
       }
     }
   },
@@ -192,8 +175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b87e6738-af38-49be-9945-f3a307ce7b6f",
-        "name": "body-sans-serif-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-strong-emphasized-font-style"
       }
     }
   },
@@ -203,8 +185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "421dc907-5862-4ed5-95f4-41d654b2fdc0",
-        "name": "body-sans-serif-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-strong-emphasized-font-weight"
       }
     }
   },
@@ -214,8 +195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b36db31f-eaaa-4310-9f54-f7b509d5f571",
-        "name": "body-sans-serif-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-strong-font-style"
       }
     }
   },
@@ -225,8 +205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "633953a9-c61b-44cc-9dee-aebece97ccbc",
-        "name": "body-sans-serif-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-sans-serif-strong-font-weight"
       }
     }
   },
@@ -236,8 +215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c817210d-2b1a-4648-bff3-33fa212491f1",
-        "name": "body-serif-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "body-serif-emphasized-font-style"
       }
     }
   },
@@ -247,8 +225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "be2a8ff3-6117-4235-bcb8-72257b75d622",
-        "name": "body-serif-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-serif-emphasized-font-weight"
       }
     }
   },
@@ -258,8 +235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "20df8bd4-5a61-4614-aa86-5b76c5976860",
-        "name": "body-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "body-serif-font-family"
       }
     }
   },
@@ -269,8 +245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d317d387-9bc8-4258-a79a-a0dd4e22d952",
-        "name": "body-serif-font-style",
-        "constant-token-duplicate": true
+        "name": "body-serif-font-style"
       }
     }
   },
@@ -280,8 +255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f049ba7a-c52f-4d39-b38e-911b2b91d031",
-        "name": "body-serif-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-serif-font-weight"
       }
     }
   },
@@ -291,8 +265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b940bdc8-d373-4bd0-8620-d6c04134698b",
-        "name": "body-serif-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "body-serif-strong-emphasized-font-style"
       }
     }
   },
@@ -302,8 +275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a87b77ff-5b27-47e0-a7df-f15092fb783e",
-        "name": "body-serif-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-serif-strong-emphasized-font-weight"
       }
     }
   },
@@ -313,8 +285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c8b531d1-949e-4492-9897-450a477983ce",
-        "name": "body-serif-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "body-serif-strong-font-style"
       }
     }
   },
@@ -324,8 +295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "be263571-bd6b-4383-bdf9-3cdf80248b6a",
-        "name": "body-serif-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "body-serif-strong-font-weight"
       }
     }
   },
@@ -335,8 +305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "884b74cb-d247-491d-acb9-d3dc84bfd9a6",
-        "name": "body-size-l",
-        "constant-token-duplicate": true
+        "name": "body-size-l"
       }
     }
   },
@@ -346,8 +315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4f7f6878-5304-48d3-8a42-5bb452c2163b",
-        "name": "body-size-m",
-        "constant-token-duplicate": true
+        "name": "body-size-m"
       }
     }
   },
@@ -357,8 +325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1194f7e3-e4c3-4a3a-bd19-50f4b48e1a6e",
-        "name": "body-size-s",
-        "constant-token-duplicate": true
+        "name": "body-size-s"
       }
     }
   },
@@ -368,8 +335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3927604f-eaf3-4605-aa34-80b7bc88ac0f",
-        "name": "body-size-xl",
-        "constant-token-duplicate": true
+        "name": "body-size-xl"
       }
     }
   },
@@ -379,8 +345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "25e93322-8f0b-45f8-ae9a-18668251f064",
-        "name": "body-size-xs",
-        "constant-token-duplicate": true
+        "name": "body-size-xs"
       }
     }
   },
@@ -390,8 +355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4d0d4ed9-af14-4d88-98f1-9237f65e192a",
-        "name": "body-size-xxl",
-        "constant-token-duplicate": true
+        "name": "body-size-xxl"
       }
     }
   },
@@ -401,8 +365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e0b8ceea-3404-4c4b-9145-fe5d445020fe",
-        "name": "body-size-xxxl",
-        "constant-token-duplicate": true
+        "name": "body-size-xxxl"
       }
     }
   },
@@ -412,8 +375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f892e676-5218-4dc9-870b-c9d2df6f3152",
-        "name": "code-cjk-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "code-cjk-emphasized-font-style"
       }
     }
   },
@@ -423,8 +385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "61f8b443-95fa-46fd-8876-b4d7a2244af9",
-        "name": "code-cjk-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-cjk-emphasized-font-weight"
       }
     }
   },
@@ -434,8 +395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "322cb744-5837-4d0a-94a8-3c885d54568d",
-        "name": "code-cjk-font-family",
-        "constant-token-duplicate": true
+        "name": "code-cjk-font-family"
       }
     }
   },
@@ -445,8 +405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b26477bc-8bf1-41aa-b849-cfde54e27780",
-        "name": "code-cjk-font-style",
-        "constant-token-duplicate": true
+        "name": "code-cjk-font-style"
       }
     }
   },
@@ -456,8 +415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8455f34c-0c79-4699-aa7c-c77d28bfa617",
-        "name": "code-cjk-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-cjk-font-weight"
       }
     }
   },
@@ -467,8 +425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "35580910-cb91-44df-9613-7b2e40a75a7c",
-        "name": "code-cjk-line-height",
-        "constant-token-duplicate": true
+        "name": "code-cjk-line-height"
       }
     }
   },
@@ -478,8 +435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "38006d42-4f02-46ff-917f-6c0163525642",
-        "name": "code-cjk-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "code-cjk-strong-emphasized-font-style"
       }
     }
   },
@@ -489,8 +445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8ed5c5e0-ff72-4937-98fd-fd09f1fab288",
-        "name": "code-cjk-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-cjk-strong-emphasized-font-weight"
       }
     }
   },
@@ -500,8 +455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a30c9a18-1a49-4b16-87a0-e882c81dd1bd",
-        "name": "code-cjk-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "code-cjk-strong-font-style"
       }
     }
   },
@@ -511,8 +465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ed73f5fc-5b7a-4414-8f1c-325e7944a9e1",
-        "name": "code-cjk-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-cjk-strong-font-weight"
       }
     }
   },
@@ -522,8 +475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9d3151ad-4a37-4eeb-aadd-7389ccb09345",
-        "name": "code-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "code-emphasized-font-style"
       }
     }
   },
@@ -533,8 +485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "948436ba-23d7-4eec-a3fe-ef5829ccadb0",
-        "name": "code-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-emphasized-font-weight"
       }
     }
   },
@@ -544,8 +495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "79b6c1f9-d1d5-4053-be47-36ecb666d0c1",
-        "name": "code-font-family",
-        "constant-token-duplicate": true
+        "name": "code-font-family"
       }
     }
   },
@@ -555,8 +505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b98a9c39-7d39-4b6d-ad35-46c8b1725c0c",
-        "name": "code-font-style",
-        "constant-token-duplicate": true
+        "name": "code-font-style"
       }
     }
   },
@@ -566,8 +515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bf02dd59-4b3c-435a-b33b-49fff22674a3",
-        "name": "code-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-font-weight"
       }
     }
   },
@@ -577,8 +525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0d33b30d-96d6-4b5a-90d2-2a708bdae623",
-        "name": "code-line-height",
-        "constant-token-duplicate": true
+        "name": "code-line-height"
       }
     }
   },
@@ -588,8 +535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7010f1a-c994-4b19-b273-3f609fe4be2b",
-        "name": "code-size-l",
-        "constant-token-duplicate": true
+        "name": "code-size-l"
       }
     }
   },
@@ -599,8 +545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e5b76091-7cbb-4d1e-8d27-48f00759c9f3",
-        "name": "code-size-m",
-        "constant-token-duplicate": true
+        "name": "code-size-m"
       }
     }
   },
@@ -610,8 +555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "efa9311b-27c5-45ea-93a7-bef6f9370179",
-        "name": "code-size-s",
-        "constant-token-duplicate": true
+        "name": "code-size-s"
       }
     }
   },
@@ -621,8 +565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7879adbc-6c38-4d29-9a90-a4ad91c75b90",
-        "name": "code-size-xl",
-        "constant-token-duplicate": true
+        "name": "code-size-xl"
       }
     }
   },
@@ -632,8 +575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f0c5e6fb-fb48-45d2-a043-558b3dc28bc7",
-        "name": "code-size-xs",
-        "constant-token-duplicate": true
+        "name": "code-size-xs"
       }
     }
   },
@@ -643,8 +585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "83d53fe1-372f-46ba-b8e0-f90ca2e59647",
-        "name": "code-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "code-strong-emphasized-font-style"
       }
     }
   },
@@ -654,8 +595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4d5f1937-552d-44a4-be8e-2edafefa46aa",
-        "name": "code-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-strong-emphasized-font-weight"
       }
     }
   },
@@ -665,8 +605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dac3d8d5-3005-4fa6-b71a-6679470176cf",
-        "name": "code-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "code-strong-font-style"
       }
     }
   },
@@ -676,8 +615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "48d2b9b8-beac-4185-827d-0c552e47663f",
-        "name": "code-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "code-strong-font-weight"
       }
     }
   },
@@ -687,8 +625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3dca0579-91c4-4f60-a2a6-25f16eb673b3",
-        "name": "detail-cjk-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-emphasized-font-style"
       }
     }
   },
@@ -698,8 +635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "aa70fa2d-87ee-4e67-b230-85f400ddd7d1",
-        "name": "detail-cjk-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-emphasized-font-weight"
       }
     }
   },
@@ -709,8 +645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6cc647ab-1474-4094-974d-d079d7ef7565",
-        "name": "detail-cjk-font-family",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-font-family"
       }
     }
   },
@@ -720,8 +655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4d2a9b37-101b-4025-95d6-aba18b701a58",
-        "name": "detail-cjk-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-font-style"
       }
     }
   },
@@ -731,8 +665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9b11f80a-7600-4a6b-a366-218ba320a5cc",
-        "name": "detail-cjk-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-font-weight"
       }
     }
   },
@@ -742,8 +675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c7b1b312-cd81-4c65-8a67-017f91aee40b",
-        "name": "detail-cjk-light-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-emphasized-font-style"
       }
     }
   },
@@ -753,8 +685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "279d9a16-279f-4788-b5b0-af825a4b5d40",
-        "name": "detail-cjk-light-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-emphasized-font-weight"
       }
     }
   },
@@ -764,8 +695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4cc06d86-326e-4b6f-a751-99445bb1d131",
-        "name": "detail-cjk-light-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-font-style"
       }
     }
   },
@@ -775,8 +705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3b531775-a1fd-4a40-b169-7c42b8c6de38",
-        "name": "detail-cjk-light-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-font-weight"
       }
     }
   },
@@ -786,8 +715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1d4235ff-c183-4d6c-8277-9783e3e1ce7a",
-        "name": "detail-cjk-light-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-strong-emphasized-font-style"
       }
     }
   },
@@ -797,8 +725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0bc51146-a3e5-48c4-8324-4490b9d30f4d",
-        "name": "detail-cjk-light-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-strong-emphasized-font-weight"
       }
     }
   },
@@ -808,8 +735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ec87fefe-f35f-41a0-9be1-6d076f0db230",
-        "name": "detail-cjk-light-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-strong-font-style"
       }
     }
   },
@@ -819,8 +745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "91231878-73dc-46ce-a277-1d14e0e36842",
-        "name": "detail-cjk-light-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-light-strong-font-weight"
       }
     }
   },
@@ -830,8 +755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "93434006-5ed7-4656-96b7-8f355a1f07b2",
-        "name": "detail-cjk-line-height",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-line-height"
       }
     }
   },
@@ -841,8 +765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "75a3a4ec-2b57-4a49-b3bd-84b41a3cd314",
-        "name": "detail-cjk-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-strong-emphasized-font-style"
       }
     }
   },
@@ -852,8 +775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a7007c07-15a4-4671-bd3b-7406f4b374bb",
-        "name": "detail-cjk-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-strong-emphasized-font-weight"
       }
     }
   },
@@ -863,8 +785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "653358fc-5ee4-4e97-affc-c56896d370c0",
-        "name": "detail-cjk-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-strong-font-style"
       }
     }
   },
@@ -874,8 +795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ef2997f3-276c-4662-8644-9514590114f4",
-        "name": "detail-cjk-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-cjk-strong-font-weight"
       }
     }
   },
@@ -885,8 +805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c4dbe044-dc8c-4722-b36c-5442cd2bc279",
-        "name": "detail-letter-spacing",
-        "constant-token-duplicate": true
+        "name": "detail-letter-spacing"
       }
     }
   },
@@ -896,8 +815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4ca9965a-24f9-454e-b0a7-dd5a0c5ae170",
-        "name": "detail-line-height",
-        "constant-token-duplicate": true
+        "name": "detail-line-height"
       }
     }
   },
@@ -907,8 +825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "35ac24a4-0338-44c6-b780-120a0af0fc51",
-        "name": "detail-margin-bottom-multiplier",
-        "constant-token-duplicate": true
+        "name": "detail-margin-bottom-multiplier"
       }
     }
   },
@@ -918,8 +835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5d34c3b5-fddd-420b-bfe4-0dee4e07701c",
-        "name": "detail-margin-top-multiplier",
-        "constant-token-duplicate": true
+        "name": "detail-margin-top-multiplier"
       }
     }
   },
@@ -929,8 +845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5c7dcef1-514e-4d43-b2ef-76639e214b8c",
-        "name": "detail-sans-serif-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-emphasized-font-style"
       }
     }
   },
@@ -940,8 +855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6ca600be-010a-4aaa-a815-e5bfdbe36b21",
-        "name": "detail-sans-serif-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-emphasized-font-weight"
       }
     }
   },
@@ -951,8 +865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "34101c26-b4cd-43aa-bddd-0758d21fef01",
-        "name": "detail-sans-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-font-family"
       }
     }
   },
@@ -962,8 +875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "21a9500c-f9a4-4ff3-9eb5-6da81bf314f6",
-        "name": "detail-sans-serif-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-font-style"
       }
     }
   },
@@ -973,8 +885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d06a4346-ec24-4922-8985-4b8a05e0bfc6",
-        "name": "detail-sans-serif-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-font-weight"
       }
     }
   },
@@ -984,8 +895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fc6098a2-3263-433c-8378-ba609629ef53",
-        "name": "detail-sans-serif-light-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-emphasized-font-style"
       }
     }
   },
@@ -995,8 +905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "64972012-5050-41d0-9c9b-269b533a58b7",
-        "name": "detail-sans-serif-light-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-emphasized-font-weight"
       }
     }
   },
@@ -1006,8 +915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a6b7c26e-3ff5-4241-b9cc-3026604fe30e",
-        "name": "detail-sans-serif-light-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-font-style"
       }
     }
   },
@@ -1017,8 +925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cf8f93e2-2b79-4a4c-bb31-313e013148e3",
-        "name": "detail-sans-serif-light-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-font-weight"
       }
     }
   },
@@ -1028,8 +935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7364639-2686-4e12-9ede-d6543d0d0d6d",
-        "name": "detail-sans-serif-light-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-strong-emphasized-font-style"
       }
     }
   },
@@ -1039,8 +945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "53f16a1c-9d44-4384-9a7e-88a2c4319486",
-        "name": "detail-sans-serif-light-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-strong-emphasized-font-weight"
       }
     }
   },
@@ -1050,8 +955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c1966f09-1c6e-4fe0-89ad-8fb8e847e3ba",
-        "name": "detail-sans-serif-light-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-strong-font-style"
       }
     }
   },
@@ -1061,8 +965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4f0f95d3-098a-4852-bd21-785f5bf054b5",
-        "name": "detail-sans-serif-light-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-light-strong-font-weight"
       }
     }
   },
@@ -1072,8 +975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "82d04795-da5f-4868-a90d-980f5376a878",
-        "name": "detail-sans-serif-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-strong-emphasized-font-style"
       }
     }
   },
@@ -1083,8 +985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c57f8682-52d2-43fa-a306-a588a13ead6b",
-        "name": "detail-sans-serif-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-strong-emphasized-font-weight"
       }
     }
   },
@@ -1094,8 +995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c56642f3-043c-4738-bed0-61b324221f4e",
-        "name": "detail-sans-serif-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-strong-font-style"
       }
     }
   },
@@ -1105,8 +1005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a150e66c-daf4-4c71-a2e2-577600878988",
-        "name": "detail-sans-serif-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-strong-font-weight"
       }
     }
   },
@@ -1116,8 +1015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8646d403-21f9-4e77-8a21-92289c303715",
-        "name": "detail-sans-serif-text-transform",
-        "constant-token-duplicate": true
+        "name": "detail-sans-serif-text-transform"
       }
     }
   },
@@ -1127,8 +1025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cfaf6a70-3eb5-4887-bae6-8ae41c094192",
-        "name": "detail-serif-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-emphasized-font-style"
       }
     }
   },
@@ -1138,8 +1035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "247b2004-e0bc-42b9-ba83-6edbe417c4cb",
-        "name": "detail-serif-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-emphasized-font-weight"
       }
     }
   },
@@ -1149,8 +1045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "365c6166-e17d-40bd-841e-495aa9c6acd7",
-        "name": "detail-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "detail-serif-font-family"
       }
     }
   },
@@ -1160,8 +1055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "524c5101-f745-47e6-b233-62cd005850f8",
-        "name": "detail-serif-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-font-style"
       }
     }
   },
@@ -1171,8 +1065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "87ef8843-f44e-4526-80cd-9635f3e0261e",
-        "name": "detail-serif-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-font-weight"
       }
     }
   },
@@ -1182,8 +1075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "320bcd8e-2bb8-4e9e-9b1d-4838b2966857",
-        "name": "detail-serif-light-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-emphasized-font-style"
       }
     }
   },
@@ -1193,8 +1085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3d27f76e-b068-4f06-bea8-ee31fcbc49b2",
-        "name": "detail-serif-light-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-emphasized-font-weight"
       }
     }
   },
@@ -1204,8 +1095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f6478d1d-5dcf-43eb-a4fc-498479b29aa7",
-        "name": "detail-serif-light-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-font-style"
       }
     }
   },
@@ -1215,8 +1105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2a15a805-fd08-4f8e-82e6-9264ef8937cb",
-        "name": "detail-serif-light-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-font-weight"
       }
     }
   },
@@ -1226,8 +1115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "42d2049f-cda2-4ae4-8d0a-41f7789f768b",
-        "name": "detail-serif-light-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-strong-emphasized-font-style"
       }
     }
   },
@@ -1237,8 +1125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1c524d85-9fca-433c-b5c4-5eaa456cc3a2",
-        "name": "detail-serif-light-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-strong-emphasized-font-weight"
       }
     }
   },
@@ -1248,8 +1135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7a878a3f-b663-41ee-8357-6e62f2e51d80",
-        "name": "detail-serif-light-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-strong-font-style"
       }
     }
   },
@@ -1259,8 +1145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fc5df058-f678-4dc8-953f-e2738798ee2b",
-        "name": "detail-serif-light-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-light-strong-font-weight"
       }
     }
   },
@@ -1270,8 +1155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7fdffa4e-4370-45cf-aab0-316561a56a24",
-        "name": "detail-serif-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-strong-emphasized-font-style"
       }
     }
   },
@@ -1281,8 +1165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "863cf841-7b83-4f66-a01f-12dccd47fee6",
-        "name": "detail-serif-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-strong-emphasized-font-weight"
       }
     }
   },
@@ -1292,8 +1175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3b2124e3-e50b-4ab7-8340-f97b1f8fef1e",
-        "name": "detail-serif-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "detail-serif-strong-font-style"
       }
     }
   },
@@ -1303,8 +1185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d737931b-f63c-4874-8fa5-872b95048727",
-        "name": "detail-serif-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "detail-serif-strong-font-weight"
       }
     }
   },
@@ -1314,8 +1195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0e161c32-c412-4cda-bacb-7eaa548b5534",
-        "name": "detail-serif-text-transform",
-        "constant-token-duplicate": true
+        "name": "detail-serif-text-transform"
       }
     }
   },
@@ -1325,8 +1205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "613da587-5c48-4efa-abb5-36378c1e81f0",
-        "name": "detail-size-l",
-        "constant-token-duplicate": true
+        "name": "detail-size-l"
       }
     }
   },
@@ -1336,8 +1215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "07840554-1ec1-4823-b119-474ec9cc31f0",
-        "name": "detail-size-m",
-        "constant-token-duplicate": true
+        "name": "detail-size-m"
       }
     }
   },
@@ -1347,8 +1225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "585e1bec-ee93-4983-b0bb-3a1f6ec28218",
-        "name": "detail-size-s",
-        "constant-token-duplicate": true
+        "name": "detail-size-s"
       }
     }
   },
@@ -1358,8 +1235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ab476eec-b592-4890-af8f-74de808cb87f",
-        "name": "detail-size-xl",
-        "constant-token-duplicate": true
+        "name": "detail-size-xl"
       }
     }
   },
@@ -1369,8 +1245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "05c74b28-3051-498c-874a-5dc523bc27e5",
-        "name": "heading-cjk-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-emphasized-font-style"
       }
     }
   },
@@ -1380,8 +1255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d854afd2-290a-40ae-a627-c4cdabeb546a",
-        "name": "heading-cjk-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-emphasized-font-weight"
       }
     }
   },
@@ -1391,8 +1265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b6652ee5-466f-4117-a77c-a93a40f2a791",
-        "name": "heading-cjk-font-family",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-font-family"
       }
     }
   },
@@ -1402,8 +1275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c93b39df-82e9-4e87-920f-1747e5d48e8e",
-        "name": "heading-cjk-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-font-style"
       }
     }
   },
@@ -1413,8 +1285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bd54516c-2fda-4421-ab62-720c3a887a34",
-        "name": "heading-cjk-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-font-weight"
       }
     }
   },
@@ -1424,8 +1295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "aef21944-3dac-4b2d-ba7b-0a4df3f406bb",
-        "name": "heading-cjk-heavy-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-emphasized-font-style"
       }
     }
   },
@@ -1435,8 +1305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9315971c-6e83-42c8-9c24-d1bc6fa5e106",
-        "name": "heading-cjk-heavy-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-emphasized-font-weight"
       }
     }
   },
@@ -1446,8 +1315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b2f50ba2-e694-47ba-b81a-ea8fc813247e",
-        "name": "heading-cjk-heavy-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-font-style"
       }
     }
   },
@@ -1457,8 +1325,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "73c20d2f-1227-46bc-8548-102358405b0b",
-        "name": "heading-cjk-heavy-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-font-weight"
       }
     }
   },
@@ -1468,8 +1335,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "619a15ba-f74e-4ff4-a604-312b810f1a50",
-        "name": "heading-cjk-heavy-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-strong-emphasized-font-style"
       }
     }
   },
@@ -1479,8 +1345,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a0f680fa-2453-4bcc-b06c-9ff82de50c0c",
-        "name": "heading-cjk-heavy-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-strong-emphasized-font-weight"
       }
     }
   },
@@ -1490,8 +1355,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "26817f91-2742-4170-aa01-1e1e67ef01e8",
-        "name": "heading-cjk-heavy-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-strong-font-style"
       }
     }
   },
@@ -1501,8 +1365,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7d2203c-c651-493e-80c2-b71b7c7c2692",
-        "name": "heading-cjk-heavy-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-heavy-strong-font-weight"
       }
     }
   },
@@ -1512,8 +1375,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dac03eec-6910-4176-bfca-33f8a57cf3d7",
-        "name": "heading-cjk-light-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-emphasized-font-style"
       }
     }
   },
@@ -1523,8 +1385,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "aea9787b-ee0b-40cc-9089-5973e52b18bd",
-        "name": "heading-cjk-light-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-emphasized-font-weight"
       }
     }
   },
@@ -1534,8 +1395,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b5704c75-2914-4268-9023-7f7452e826c1",
-        "name": "heading-cjk-light-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-font-style"
       }
     }
   },
@@ -1545,8 +1405,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9da0ba4c-b4e3-4052-8b2e-d2fde714bb9d",
-        "name": "heading-cjk-light-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-font-weight"
       }
     }
   },
@@ -1556,8 +1415,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9136e25e-563b-4485-bad7-41809d5317de",
-        "name": "heading-cjk-light-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-strong-emphasized-font-style"
       }
     }
   },
@@ -1567,8 +1425,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "83cc347c-7a1a-4665-9de4-cf19903f1043",
-        "name": "heading-cjk-light-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-strong-emphasized-font-weight"
       }
     }
   },
@@ -1578,8 +1435,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "be854057-43b1-40ce-bdc7-69960cd7638c",
-        "name": "heading-cjk-light-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-strong-font-style"
       }
     }
   },
@@ -1589,8 +1445,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5ca91bc2-215b-4cbb-b966-80bfffd569ad",
-        "name": "heading-cjk-light-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-light-strong-font-weight"
       }
     }
   },
@@ -1600,8 +1455,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3e038db9-c5f7-4b8b-b1af-31075a31e0cc",
-        "name": "heading-cjk-line-height",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-line-height"
       }
     }
   },
@@ -1611,8 +1465,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f57ffe02-2e41-46f3-a0ac-1feb63bdd748",
-        "name": "heading-cjk-size-l",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-l"
       }
     }
   },
@@ -1622,8 +1475,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "43f45659-314b-45aa-9886-1beb096fc4ce",
-        "name": "heading-cjk-size-m",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-m"
       }
     }
   },
@@ -1633,8 +1485,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c1242a8c-ca10-40d0-8fc4-67bbbce8fc5f",
-        "name": "heading-cjk-size-s",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-s"
       }
     }
   },
@@ -1644,8 +1495,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "43535e5f-607e-43f4-bd37-8230b1f7993f",
-        "name": "heading-cjk-size-xl",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-xl"
       }
     }
   },
@@ -1655,8 +1505,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "132688a7-917d-44b9-a34f-a7135599b299",
-        "name": "heading-cjk-size-xs",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-xs"
       }
     }
   },
@@ -1666,8 +1515,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fbf59302-1ad2-4327-bfde-d638a0ca2429",
-        "name": "heading-cjk-size-xxl",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-xxl"
       }
     }
   },
@@ -1677,8 +1525,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bddd6a96-c280-47ca-8858-20df055e488d",
-        "name": "heading-cjk-size-xxs",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-xxs"
       }
     }
   },
@@ -1688,8 +1535,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5a44e177-2478-4bb0-9212-ba2df64c8b00",
-        "name": "heading-cjk-size-xxxl",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-size-xxxl"
       }
     }
   },
@@ -1699,8 +1545,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "22934d4d-4952-40a7-a5e5-256a7a3c9371",
-        "name": "heading-cjk-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-strong-emphasized-font-style"
       }
     }
   },
@@ -1710,8 +1555,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0080a817-b26f-42f1-84c4-5ed1ac08c12c",
-        "name": "heading-cjk-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-strong-emphasized-font-weight"
       }
     }
   },
@@ -1721,8 +1565,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4f061165-0e86-46b9-83c3-c95eeb8ff956",
-        "name": "heading-cjk-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-strong-font-style"
       }
     }
   },
@@ -1732,8 +1575,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "eaf179aa-4514-4206-b3e2-a99b7d4d2029",
-        "name": "heading-cjk-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-cjk-strong-font-weight"
       }
     }
   },
@@ -1743,8 +1585,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "64f28fe4-20f7-48cb-baeb-ff1898573727",
-        "name": "heading-line-height",
-        "constant-token-duplicate": true
+        "name": "heading-line-height"
       }
     }
   },
@@ -1754,8 +1595,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dd2035b4-506f-41ab-a656-de3668d44e0f",
-        "name": "heading-margin-bottom-multiplier",
-        "constant-token-duplicate": true
+        "name": "heading-margin-bottom-multiplier"
       }
     }
   },
@@ -1765,8 +1605,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "008fa04b-6d74-416b-a6ae-ceec90f08642",
-        "name": "heading-margin-top-multiplier",
-        "constant-token-duplicate": true
+        "name": "heading-margin-top-multiplier"
       }
     }
   },
@@ -1776,8 +1615,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2f17833a-28a4-4152-8999-12b077557797",
-        "name": "heading-sans-serif-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-emphasized-font-style"
       }
     }
   },
@@ -1787,8 +1625,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e4a183fd-53c5-4dbb-afd1-6308e2e74f80",
-        "name": "heading-sans-serif-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-emphasized-font-weight"
       }
     }
   },
@@ -1798,8 +1635,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "234d7b9d-bddc-4988-8be5-ef5e41e08185",
-        "name": "heading-sans-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-font-family"
       }
     }
   },
@@ -1809,8 +1645,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "561d905e-7f44-43da-b2b4-26e12551ef6d",
-        "name": "heading-sans-serif-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-font-style"
       }
     }
   },
@@ -1820,8 +1655,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "1d4d09b4-021a-48e8-a724-bfecc13df325",
-        "name": "heading-sans-serif-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-font-weight"
       }
     }
   },
@@ -1831,8 +1665,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "924c338f-7141-490a-a842-ad632c26160c",
-        "name": "heading-sans-serif-heavy-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-emphasized-font-style"
       }
     }
   },
@@ -1842,8 +1675,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a7cb3274-e48e-435b-a066-32027ac19e84",
-        "name": "heading-sans-serif-heavy-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-emphasized-font-weight"
       }
     }
   },
@@ -1853,8 +1685,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0c4cdd06-8180-40b1-9b1f-d7d973a7b772",
-        "name": "heading-sans-serif-heavy-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-font-style"
       }
     }
   },
@@ -1864,8 +1695,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ef13b8f0-f686-492d-990f-691ec91ebb96",
-        "name": "heading-sans-serif-heavy-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-font-weight"
       }
     }
   },
@@ -1875,8 +1705,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c20ea22a-c34d-4c7c-a816-75b533e28c92",
-        "name": "heading-sans-serif-heavy-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-strong-emphasized-font-style"
       }
     }
   },
@@ -1886,8 +1715,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8779e773-7b37-4eb0-ae7a-2ba0104ad9d5",
-        "name": "heading-sans-serif-heavy-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-strong-emphasized-font-weight"
       }
     }
   },
@@ -1897,8 +1725,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "86775b10-5682-49fb-9d38-6bdb857da801",
-        "name": "heading-sans-serif-heavy-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-strong-font-style"
       }
     }
   },
@@ -1908,8 +1735,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2104c3c2-d834-436a-a26d-508056f1013d",
-        "name": "heading-sans-serif-heavy-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-heavy-strong-font-weight"
       }
     }
   },
@@ -1919,8 +1745,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5f88eb81-7052-4c21-9896-f14cb09f0e70",
-        "name": "heading-sans-serif-light-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-emphasized-font-style"
       }
     }
   },
@@ -1930,8 +1755,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e882ea46-8f0a-4313-84f5-85bb8d9f1f5e",
-        "name": "heading-sans-serif-light-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-emphasized-font-weight"
       }
     }
   },
@@ -1941,8 +1765,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c5551fd5-4ee2-4c93-b91f-9ed295fa63a4",
-        "name": "heading-sans-serif-light-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-font-style"
       }
     }
   },
@@ -1952,8 +1775,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ff84a748-5923-451d-967c-a346d2dee46c",
-        "name": "heading-sans-serif-light-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-font-weight"
       }
     }
   },
@@ -1963,8 +1785,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bc5d65e0-e13a-424c-a260-9268a0dee66c",
-        "name": "heading-sans-serif-light-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-strong-emphasized-font-style"
       }
     }
   },
@@ -1974,8 +1795,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c297a503-fc3c-4939-8c5a-6611b9b04719",
-        "name": "heading-sans-serif-light-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-strong-emphasized-font-weight"
       }
     }
   },
@@ -1985,8 +1805,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "67271ca0-c9fd-4047-a615-6314d7333f7a",
-        "name": "heading-sans-serif-light-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-strong-font-style"
       }
     }
   },
@@ -1996,8 +1815,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "75437f9a-7ee8-4194-b4b3-0746be097396",
-        "name": "heading-sans-serif-light-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-light-strong-font-weight"
       }
     }
   },
@@ -2007,8 +1825,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f692d35f-1b11-43d1-ad29-967436b90928",
-        "name": "heading-sans-serif-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-strong-emphasized-font-style"
       }
     }
   },
@@ -2018,8 +1835,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9d834e30-53c1-4cea-9e17-2326038cb6cb",
-        "name": "heading-sans-serif-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-strong-emphasized-font-weight"
       }
     }
   },
@@ -2029,8 +1845,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2117cb6e-67f7-4509-b4fb-e9e442b6dc0e",
-        "name": "heading-sans-serif-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-strong-font-style"
       }
     }
   },
@@ -2040,8 +1855,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "79275989-91ed-408a-b884-a31d9f8bac26",
-        "name": "heading-sans-serif-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-sans-serif-strong-font-weight"
       }
     }
   },
@@ -2051,8 +1865,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fe694554-832d-457d-a320-f02629f9c441",
-        "name": "heading-serif-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-emphasized-font-style"
       }
     }
   },
@@ -2062,8 +1875,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a0983216-b0c5-4a3f-97dc-96ee711acb1f",
-        "name": "heading-serif-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-emphasized-font-weight"
       }
     }
   },
@@ -2073,8 +1885,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "f2430818-41b5-439a-8347-6b384e78d141",
-        "name": "heading-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "heading-serif-font-family"
       }
     }
   },
@@ -2084,8 +1895,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "938f3684-44c6-4ae2-935a-b88921fcd7fe",
-        "name": "heading-serif-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-font-style"
       }
     }
   },
@@ -2095,8 +1905,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "350aa193-9996-49c8-b5e4-54d4f7bef3c2",
-        "name": "heading-serif-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-font-weight"
       }
     }
   },
@@ -2106,8 +1915,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a18ac621-eade-4224-9660-3e9a080219ec",
-        "name": "heading-serif-heavy-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-emphasized-font-style"
       }
     }
   },
@@ -2117,8 +1925,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "82e9d579-8918-4114-bafa-3a9757556f84",
-        "name": "heading-serif-heavy-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-emphasized-font-weight"
       }
     }
   },
@@ -2128,8 +1935,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "14532cb8-6c88-46ce-886b-96fac971e7b9",
-        "name": "heading-serif-heavy-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-font-style"
       }
     }
   },
@@ -2139,8 +1945,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6b74c5ea-6bf4-46bb-bee1-3841606f1500",
-        "name": "heading-serif-heavy-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-font-weight"
       }
     }
   },
@@ -2150,8 +1955,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "adf303e8-1e27-4aec-9bbc-5abe166358ec",
-        "name": "heading-serif-heavy-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-strong-emphasized-font-style"
       }
     }
   },
@@ -2161,8 +1965,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2d8e76cd-f123-488d-893d-54a9f48f679e",
-        "name": "heading-serif-heavy-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-strong-emphasized-font-weight"
       }
     }
   },
@@ -2172,8 +1975,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b2875bbe-b5cb-452f-b7d6-3dcb4fc59921",
-        "name": "heading-serif-heavy-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-strong-font-style"
       }
     }
   },
@@ -2183,8 +1985,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "af0010c7-5134-4fe4-bee1-bbb7dd31de3a",
-        "name": "heading-serif-heavy-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-heavy-strong-font-weight"
       }
     }
   },
@@ -2194,8 +1995,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7bd831cd-3fe0-402b-a105-f65b8e8023e2",
-        "name": "heading-serif-light-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-emphasized-font-style"
       }
     }
   },
@@ -2205,8 +2005,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b5f79fde-07f7-4c07-897e-0bfdf27e2839",
-        "name": "heading-serif-light-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-emphasized-font-weight"
       }
     }
   },
@@ -2216,8 +2015,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5f30418a-aa76-434e-bca9-902d5be0d929",
-        "name": "heading-serif-light-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-font-style"
       }
     }
   },
@@ -2227,8 +2025,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "66958795-6459-4750-8c68-dc39ab383837",
-        "name": "heading-serif-light-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-font-weight"
       }
     }
   },
@@ -2238,8 +2035,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "71c8e302-6bc1-4f45-b804-c847dd153d1b",
-        "name": "heading-serif-light-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-strong-emphasized-font-style"
       }
     }
   },
@@ -2249,8 +2045,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "98c61df3-057d-4345-881e-0c04628757f3",
-        "name": "heading-serif-light-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-strong-emphasized-font-weight"
       }
     }
   },
@@ -2260,8 +2055,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "73906871-24e5-48cc-9140-ec700c08d144",
-        "name": "heading-serif-light-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-strong-font-style"
       }
     }
   },
@@ -2271,8 +2065,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "29ad1c96-62e4-4143-88e8-fc8e08913a52",
-        "name": "heading-serif-light-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-light-strong-font-weight"
       }
     }
   },
@@ -2282,8 +2075,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "da6e1593-9d2a-4fd8-8877-d30d6e1d1c07",
-        "name": "heading-serif-strong-emphasized-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-strong-emphasized-font-style"
       }
     }
   },
@@ -2293,8 +2085,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cd32f2b7-3e9f-47ae-ad34-2c7783dd5b2f",
-        "name": "heading-serif-strong-emphasized-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-strong-emphasized-font-weight"
       }
     }
   },
@@ -2304,8 +2095,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2e0ef484-406a-4902-995d-9a3d5177ec12",
-        "name": "heading-serif-strong-font-style",
-        "constant-token-duplicate": true
+        "name": "heading-serif-strong-font-style"
       }
     }
   },
@@ -2315,8 +2105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6df0fb95-4aa0-4c67-896d-fa6aa3d34e95",
-        "name": "heading-serif-strong-font-weight",
-        "constant-token-duplicate": true
+        "name": "heading-serif-strong-font-weight"
       }
     }
   },
@@ -2326,8 +2115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "336e434c-9026-4bb3-96b1-5bb44376b868",
-        "name": "heading-size-l",
-        "constant-token-duplicate": true
+        "name": "heading-size-l"
       }
     }
   },
@@ -2337,8 +2125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4cdcefe1-2006-4560-839f-5bdef6db8c1a",
-        "name": "heading-size-m",
-        "constant-token-duplicate": true
+        "name": "heading-size-m"
       }
     }
   },
@@ -2348,8 +2135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "96673fee-b75c-4867-9041-48362af044bc",
-        "name": "heading-size-s",
-        "constant-token-duplicate": true
+        "name": "heading-size-s"
       }
     }
   },
@@ -2359,8 +2145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "94bb5ad9-503a-428a-a8ba-6cf3f70592ac",
-        "name": "heading-size-xl",
-        "constant-token-duplicate": true
+        "name": "heading-size-xl"
       }
     }
   },
@@ -2370,8 +2155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "4f179af6-c31f-48f8-927c-a45150668ad3",
-        "name": "heading-size-xs",
-        "constant-token-duplicate": true
+        "name": "heading-size-xs"
       }
     }
   },
@@ -2381,8 +2165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "464e34cd-e768-4a38-a72b-cae1a4852ef3",
-        "name": "heading-size-xxl",
-        "constant-token-duplicate": true
+        "name": "heading-size-xxl"
       }
     }
   },
@@ -2392,8 +2175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "82a831b4-b624-475b-b2be-4eb949e48626",
-        "name": "heading-size-xxs",
-        "constant-token-duplicate": true
+        "name": "heading-size-xxs"
       }
     }
   },
@@ -2403,8 +2185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "db884bf9-e7b5-420a-b408-bd9a4d6bb0a4",
-        "name": "heading-size-xxxl",
-        "constant-token-duplicate": true
+        "name": "heading-size-xxxl"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/typography/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/typography/desktop.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e2f23ca1-802b-40a2-a211-33090f9a043e",
-        "name": "black-font-weight",
-        "constant-token-duplicate": true
+        "name": "black-font-weight"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
-        "name": "bold-font-weight",
-        "constant-token-duplicate": true
+        "name": "bold-font-weight"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
-        "name": "cjk-font-family",
-        "constant-token-duplicate": true
+        "name": "cjk-font-family"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "12e27721-35f5-4d03-95f3-3fc9e1cf50e4",
-        "name": "cjk-letter-spacing",
-        "constant-token-duplicate": true
+        "name": "cjk-letter-spacing"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4",
-        "name": "cjk-line-height-100",
-        "constant-token-duplicate": true
+        "name": "cjk-line-height-100"
       }
     }
   },
@@ -60,8 +55,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c5a5d186-54b3-44a0-b1c6-e9b102871015",
-        "name": "cjk-line-height-200",
-        "constant-token-duplicate": true
+        "name": "cjk-line-height-200"
       }
     }
   },
@@ -71,8 +65,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "45d43d4e-a4e4-4c5f-94ec-644a81300eb0",
-        "name": "default-font-family",
-        "constant-token-duplicate": true
+        "name": "default-font-family"
       }
     }
   },
@@ -82,8 +75,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "25668698-bf78-46f4-bc6c-8fea068ddb34",
-        "name": "default-font-style",
-        "constant-token-duplicate": true
+        "name": "default-font-style"
       }
     }
   },
@@ -93,8 +85,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ccadf44e-5424-4920-979f-ea1ef39687c4",
-        "name": "extra-bold-font-weight",
-        "constant-token-duplicate": true
+        "name": "extra-bold-font-weight"
       }
     }
   },
@@ -104,8 +95,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8593a326-de37-414d-b3f6-5254b41dce07",
-        "name": "font-size-50",
-        "constant-token-duplicate": false
+        "name": "font-size-50"
       }
     }
   },
@@ -115,8 +105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "55d90327-8cc9-4d4f-891f-9d42751d989a",
-        "name": "font-size-75",
-        "constant-token-duplicate": false
+        "name": "font-size-75"
       }
     }
   },
@@ -126,8 +115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "938e2d24-1e90-48f0-a596-595a69103707",
-        "name": "font-size-100",
-        "constant-token-duplicate": false
+        "name": "font-size-100"
       }
     }
   },
@@ -137,8 +125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b36caaa3-7047-4dfb-8a84-f990a8ac3a91",
-        "name": "font-size-200",
-        "constant-token-duplicate": false
+        "name": "font-size-200"
       }
     }
   },
@@ -148,8 +135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "3dc9b6a4-77e3-484b-be8c-fbc2f50e6175",
-        "name": "font-size-300",
-        "constant-token-duplicate": false
+        "name": "font-size-300"
       }
     }
   },
@@ -159,8 +145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "292a28d6-2e15-46e2-80cd-5171d977e9b5",
-        "name": "font-size-400",
-        "constant-token-duplicate": false
+        "name": "font-size-400"
       }
     }
   },
@@ -170,8 +155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9be56e29-2e79-41e0-b5a9-6a2dabc70aa1",
-        "name": "font-size-500",
-        "constant-token-duplicate": false
+        "name": "font-size-500"
       }
     }
   },
@@ -181,8 +165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "db1d7d01-8dd4-4c27-b58c-686f030e5e46",
-        "name": "font-size-600",
-        "constant-token-duplicate": false
+        "name": "font-size-600"
       }
     }
   },
@@ -192,8 +175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "77da1638-cb39-4c80-8c13-db77b9aa528e",
-        "name": "font-size-700",
-        "constant-token-duplicate": false
+        "name": "font-size-700"
       }
     }
   },
@@ -203,8 +185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8425654d-7f46-4b6d-8997-5ae6b6980e06",
-        "name": "font-size-800",
-        "constant-token-duplicate": false
+        "name": "font-size-800"
       }
     }
   },
@@ -214,8 +195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "df2d6c8d-dc03-4581-96c6-d6a92a270b77",
-        "name": "font-size-900",
-        "constant-token-duplicate": false
+        "name": "font-size-900"
       }
     }
   },
@@ -225,8 +205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "27f694f9-6770-49e0-b7fc-833618b3fc2f",
-        "name": "font-size-1000",
-        "constant-token-duplicate": false
+        "name": "font-size-1000"
       }
     }
   },
@@ -236,8 +215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "00dc3fcd-383f-4bc6-8940-e0884f0ffb7e",
-        "name": "font-size-1100",
-        "constant-token-duplicate": false
+        "name": "font-size-1100"
       }
     }
   },
@@ -247,8 +225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b73bfb12-80ef-453f-b7dc-52bf2258ef47",
-        "name": "font-size-1200",
-        "constant-token-duplicate": false
+        "name": "font-size-1200"
       }
     }
   },
@@ -258,8 +235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e8853e10-cc03-47c1-9b66-11755ff513a5",
-        "name": "font-size-1300",
-        "constant-token-duplicate": false
+        "name": "font-size-1300"
       }
     }
   },
@@ -269,8 +245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
-        "name": "italic-font-style",
-        "constant-token-duplicate": true
+        "name": "italic-font-style"
       }
     }
   },
@@ -280,8 +255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fd477873-3767-4883-ab3f-5ee2758b923b",
-        "name": "light-font-weight",
-        "constant-token-duplicate": true
+        "name": "light-font-weight"
       }
     }
   },
@@ -291,8 +265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dd125d1d-cf4d-45c8-ab21-52331a9a264b",
-        "name": "line-height-100",
-        "constant-token-duplicate": true
+        "name": "line-height-100"
       }
     }
   },
@@ -302,8 +275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "832f2589-0e75-48dd-bbe3-e3f5b98e6c97",
-        "name": "line-height-200",
-        "constant-token-duplicate": true
+        "name": "line-height-200"
       }
     }
   },
@@ -313,8 +285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c966c3b6-1bf5-4064-89f9-00d9ec673fd4",
-        "name": "medium-font-weight",
-        "constant-token-duplicate": true
+        "name": "medium-font-weight"
       }
     }
   },
@@ -324,8 +295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "02a94ddf-1007-4c86-8863-905874e40f95",
-        "name": "regular-font-weight",
-        "constant-token-duplicate": true
+        "name": "regular-font-weight"
       }
     }
   },
@@ -335,8 +305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a552c422-c51c-458a-87b0-c6fe5178bf4b",
-        "name": "sans-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "sans-serif-font-family"
       }
     }
   },
@@ -346,8 +315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7f83198f-26ec-4156-9573-826dd7feb718",
-        "name": "serif-font-family",
-        "constant-token-duplicate": true
+        "name": "serif-font-family"
       }
     }
   }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/typography/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/typography/mobile.json
@@ -5,8 +5,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "e2f23ca1-802b-40a2-a211-33090f9a043e",
-        "name": "black-font-weight",
-        "constant-token-duplicate": true
+        "name": "black-font-weight"
       }
     }
   },
@@ -16,8 +15,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ff246e6b-7515-49a2-9dc6-8cdf1ea9b2d8",
-        "name": "bold-font-weight",
-        "constant-token-duplicate": true
+        "name": "bold-font-weight"
       }
     }
   },
@@ -27,8 +25,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "034892ba-eff6-4193-b4c5-61d20c8f22eb",
-        "name": "cjk-font-family",
-        "constant-token-duplicate": true
+        "name": "cjk-font-family"
       }
     }
   },
@@ -38,8 +35,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "12e27721-35f5-4d03-95f3-3fc9e1cf50e4",
-        "name": "cjk-letter-spacing",
-        "constant-token-duplicate": true
+        "name": "cjk-letter-spacing"
       }
     }
   },
@@ -49,8 +45,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8b4ab68d-9060-4e11-9ecc-3b9d3db27fe4",
-        "name": "cjk-line-height-100",
-        "constant-token-duplicate": true
+        "name": "cjk-line-height-100"
       }
     }
   },
@@ -60,8 +55,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c5a5d186-54b3-44a0-b1c6-e9b102871015",
-        "name": "cjk-line-height-200",
-        "constant-token-duplicate": true
+        "name": "cjk-line-height-200"
       }
     }
   },
@@ -71,8 +65,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "45d43d4e-a4e4-4c5f-94ec-644a81300eb0",
-        "name": "default-font-family",
-        "constant-token-duplicate": true
+        "name": "default-font-family"
       }
     }
   },
@@ -82,8 +75,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "25668698-bf78-46f4-bc6c-8fea068ddb34",
-        "name": "default-font-style",
-        "constant-token-duplicate": true
+        "name": "default-font-style"
       }
     }
   },
@@ -93,8 +85,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ccadf44e-5424-4920-979f-ea1ef39687c4",
-        "name": "extra-bold-font-weight",
-        "constant-token-duplicate": true
+        "name": "extra-bold-font-weight"
       }
     }
   },
@@ -104,8 +95,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "b7561ce1-e12e-4aed-9766-181f7eca309e",
-        "name": "font-size-50",
-        "constant-token-duplicate": false
+        "name": "font-size-50"
       }
     }
   },
@@ -115,8 +105,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "07e1c2a8-3925-4d71-8fae-3486483ff44c",
-        "name": "font-size-75",
-        "constant-token-duplicate": false
+        "name": "font-size-75"
       }
     }
   },
@@ -126,8 +115,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "2f9ee3cf-ccb1-4f0b-aed6-96e472fb7411",
-        "name": "font-size-100",
-        "constant-token-duplicate": false
+        "name": "font-size-100"
       }
     }
   },
@@ -137,8 +125,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7e51ff4e-2749-49d1-b9ed-75de92a73991",
-        "name": "font-size-200",
-        "constant-token-duplicate": false
+        "name": "font-size-200"
       }
     }
   },
@@ -148,8 +135,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9b9a7175-dcca-43aa-98ce-f1c3e4eefda7",
-        "name": "font-size-300",
-        "constant-token-duplicate": false
+        "name": "font-size-300"
       }
     }
   },
@@ -159,8 +145,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "d5ed0e8d-01ac-495f-bd15-fecc30af17c4",
-        "name": "font-size-400",
-        "constant-token-duplicate": false
+        "name": "font-size-400"
       }
     }
   },
@@ -170,8 +155,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a69a5079-1b5b-4ccf-946f-8b6e3fae4d7e",
-        "name": "font-size-500",
-        "constant-token-duplicate": false
+        "name": "font-size-500"
       }
     }
   },
@@ -181,8 +165,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "ac892307-2559-48f5-9e2c-98dabbb0abc2",
-        "name": "font-size-600",
-        "constant-token-duplicate": false
+        "name": "font-size-600"
       }
     }
   },
@@ -192,8 +175,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "6bd6456c-b73b-4926-8e67-7b942e32bbc2",
-        "name": "font-size-700",
-        "constant-token-duplicate": false
+        "name": "font-size-700"
       }
     }
   },
@@ -203,8 +185,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bdfae93d-ae49-456b-af54-8620ea976ca8",
-        "name": "font-size-800",
-        "constant-token-duplicate": false
+        "name": "font-size-800"
       }
     }
   },
@@ -214,8 +195,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5296e771-6d04-4e9a-b1fe-ab22d4dfd92b",
-        "name": "font-size-900",
-        "constant-token-duplicate": false
+        "name": "font-size-900"
       }
     }
   },
@@ -225,8 +205,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "8b158ab0-7e82-4dab-a4d9-84cf7a71fa0a",
-        "name": "font-size-1000",
-        "constant-token-duplicate": false
+        "name": "font-size-1000"
       }
     }
   },
@@ -236,8 +215,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "5eb96c78-c8f6-4e31-9bc8-fa62794ac4db",
-        "name": "font-size-1100",
-        "constant-token-duplicate": false
+        "name": "font-size-1100"
       }
     }
   },
@@ -247,8 +225,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "0ab38fb2-0de9-4be0-8967-8241379706be",
-        "name": "font-size-1200",
-        "constant-token-duplicate": false
+        "name": "font-size-1200"
       }
     }
   },
@@ -258,8 +235,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "bd880141-81f6-47fe-a421-01124fe66b67",
-        "name": "font-size-1300",
-        "constant-token-duplicate": false
+        "name": "font-size-1300"
       }
     }
   },
@@ -269,8 +245,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9a58e4ae-dfa1-428b-9d90-11f4275418da",
-        "name": "italic-font-style",
-        "constant-token-duplicate": true
+        "name": "italic-font-style"
       }
     }
   },
@@ -280,8 +255,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "fd477873-3767-4883-ab3f-5ee2758b923b",
-        "name": "light-font-weight",
-        "constant-token-duplicate": true
+        "name": "light-font-weight"
       }
     }
   },
@@ -291,8 +265,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "dd125d1d-cf4d-45c8-ab21-52331a9a264b",
-        "name": "line-height-100",
-        "constant-token-duplicate": true
+        "name": "line-height-100"
       }
     }
   },
@@ -302,8 +275,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "832f2589-0e75-48dd-bbe3-e3f5b98e6c97",
-        "name": "line-height-200",
-        "constant-token-duplicate": true
+        "name": "line-height-200"
       }
     }
   },
@@ -313,8 +285,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "c966c3b6-1bf5-4064-89f9-00d9ec673fd4",
-        "name": "medium-font-weight",
-        "constant-token-duplicate": true
+        "name": "medium-font-weight"
       }
     }
   },
@@ -324,8 +295,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "02a94ddf-1007-4c86-8863-905874e40f95",
-        "name": "regular-font-weight",
-        "constant-token-duplicate": true
+        "name": "regular-font-weight"
       }
     }
   },
@@ -335,8 +305,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a552c422-c51c-458a-87b0-c6fe5178bf4b",
-        "name": "sans-serif-font-family",
-        "constant-token-duplicate": true
+        "name": "sans-serif-font-family"
       }
     }
   },
@@ -346,8 +315,7 @@
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "7f83198f-26ec-4156-9573-826dd7feb718",
-        "name": "serif-font-family",
-        "constant-token-duplicate": true
+        "name": "serif-font-family"
       }
     }
   }


### PR DESCRIPTION
## Description

Removes dependency on the 'constant-token-duplicate' metadata flag to determine whether token definitions share a uuid. Basically, we'll determine whether tokens need separate light/dark or desktop/mobile tokens depending on whether the actual values differ, instead.

**THESE ARE THE RELEVANT CHANGES FOR SPECTRUM 2**

Related spectrum-tokens PR: https://github.com/adobe/spectrum-tokens/pull/257

## Motivation and context

Simplifying maintenance and reducing errors.

## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<input type="checkbox"/> Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) <br>
<input type="checkbox"/> Minor (add a new token, changing a value; non-breaking change which adds functionality) <br>
<input type="checkbox"/> Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change) <br>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<input type="checkbox"/> I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). <br>
<input type="checkbox"/> I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) <br>
