### PR TITLE
Updated values and added new tokens for Switch

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -319,6 +319,86 @@
       }
     }
   },
+  "switch-handle-size-small": {
+    "value": "6px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-size-small"
+      }
+    }
+  },
+  "switch-handle-selected-size-small": {
+    "value": "8px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-selected-size-small"
+      }
+    }
+  },
+  "switch-handle-selected-size-medium": {
+    "value": "10px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-selected-size-medium"
+      }
+    }
+  },
+  "switch-handle-selected-size-large": {
+    "value": "12px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-selected-size-large"
+      }
+    }
+  },
+  "switch-handle-selected-size-extra-large": {
+    "value": "14px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-selected-size-extra-large"
+      }
+    }
+  },
+  "switch-handle-size-medium": {
+    "value": "8px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-size-medium"
+      }
+    }
+  },
+  "switch-handle-size-large": {
+    "value": "10px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-size-large"
+      }
+    }
+  },
+  "switch-handle-size-extra-large": {
+    "value": "12px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-size-extra-large"
+      }
+    }
+  },
   "action-bar-top-to-item-counter": {
     "value": "14px",
     "type": "spacing",
@@ -2910,7 +2990,7 @@
     }
   },
   "switch-control-height-extra-large": {
-    "value": "18px",
+    "value": "20px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -2920,7 +3000,7 @@
     }
   },
   "switch-control-height-large": {
-    "value": "16px",
+    "value": "18px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -2930,7 +3010,7 @@
     }
   },
   "switch-control-height-medium": {
-    "value": "14px",
+    "value": "16px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -2940,7 +3020,7 @@
     }
   },
   "switch-control-height-small": {
-    "value": "12px",
+    "value": "14px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -2950,7 +3030,7 @@
     }
   },
   "switch-control-width-extra-large": {
-    "value": "33px",
+    "value": "34px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -2960,7 +3040,7 @@
     }
   },
   "switch-control-width-large": {
-    "value": "29px",
+    "value": "30px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -2980,7 +3060,7 @@
     }
   },
   "switch-control-width-small": {
-    "value": "23px",
+    "value": "22px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -319,6 +319,86 @@
       }
     }
   },
+  "switch-handle-size-small": {
+    "value": "10px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-size-small"
+      }
+    }
+  },
+  "switch-handle-selected-size-small": {
+    "value": "12px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-selected-size-small"
+      }
+    }
+  },
+  "switch-handle-selected-size-medium": {
+    "value": "14px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-selected-size-medium"
+      }
+    }
+  },
+  "switch-handle-selected-size-large": {
+    "value": "16px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-selected-size-large"
+      }
+    }
+  },
+  "switch-handle-selected-size-extra-large": {
+    "value": "20px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-selected-size-extra-large"
+      }
+    }
+  },
+  "switch-handle-size-medium": {
+    "value": "12px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-size-medium"
+      }
+    }
+  },
+  "switch-handle-size-large": {
+    "value": "14px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-size-large"
+      }
+    }
+  },
+  "switch-handle-size-extra-large": {
+    "value": "18px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "switch-handle-size-extra-large"
+      }
+    }
+  },
   "action-bar-top-to-item-counter": {
     "value": "16px",
     "type": "spacing",
@@ -2910,7 +2990,7 @@
     }
   },
   "switch-control-height-extra-large": {
-    "value": "22px",
+    "value": "26px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -2920,7 +3000,7 @@
     }
   },
   "switch-control-height-large": {
-    "value": "20px",
+    "value": "22px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -2930,7 +3010,7 @@
     }
   },
   "switch-control-height-medium": {
-    "value": "18px",
+    "value": "20px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -2940,7 +3020,7 @@
     }
   },
   "switch-control-height-small": {
-    "value": "16px",
+    "value": "18px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -2960,7 +3040,7 @@
     }
   },
   "switch-control-width-large": {
-    "value": "41px",
+    "value": "38px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -2970,7 +3050,7 @@
     }
   },
   "switch-control-width-medium": {
-    "value": "36px",
+    "value": "34px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -2980,7 +3060,7 @@
     }
   },
   "switch-control-width-small": {
-    "value": "32px",
+    "value": "30px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {


### PR DESCRIPTION
Updated values and added new tokens for Switch.

<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao -->

Added new tokens: `switch-handle-size-*` and `switch-handle-selected-size-*` for both desktop and mobile.
Update token values on: `switch-control-width-*` and `switch-control-height-*` for both desktop and mobile.

<!--- Describe your changes in detail, including a list of changes -->

The design for Switch in S2 has changed and now has a border when it's not selected. New handle sizes are added and control sizes have been updated. 

<!--- Why is this change required? What problem does it solve? -->

N/A

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

N/A

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [ ] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
