### PR TITLE
Color slider border color token update

### DIFF
--- a/src/tokens-studio/spectrum2-colors/spectrum2/component/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/component/dark.json
@@ -92,7 +92,7 @@
     },
     "color-slider": {
       "border": {
-        "value": "{Palette.gray.900}",
+        "value": "{Palette.gray.1000}",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-colors/spectrum2/component/light.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/component/light.json
@@ -92,7 +92,7 @@
     },
     "color-slider": {
       "border": {
-        "value": "{Palette.gray.900}",
+        "value": "{Palette.gray.1000}",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao -->

## Description
`Color-slider-border-color` token was updated to reference gray-1000 instead of gray-900 in both light and dark themes.

<!--- Describe your changes in detail, including a list of changes -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
S2 color slider design changes. 


## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

This update is a part of this [Jira ticket](https://jira.corp.adobe.com/browse/SDS-13302) body of work.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [X] Minor (add a new token, changing a value; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [X] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
