### PR TITLE
S2 Opacity checkerboard non-color token updates

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -2219,13 +2219,23 @@
       }
     }
   },
-  "opacity-checkerboard-square-size": {
+  "opacity-checkerboard-square-size-small": {
+    "value": "4px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "opacity-checkerboard-square-size-small"
+      }
+    }
+  },
+  "opacity-checkerboard-square-size-medium": {
     "value": "8px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "9ddf2e73-ad74-46d7-a79d-fe961b06dbbd",
-        "name": "opacity-checkerboard-square-size"
+        "name": "opacity-checkerboard-square-size-medium"
       }
     }
   },

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -2219,13 +2219,23 @@
       }
     }
   },
-  "opacity-checkerboard-square-size": {
+  "opacity-checkerboard-square-size-small": {
+    "value": "5px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "opacity-checkerboard-square-size-small"
+      }
+    }
+  },
+  "opacity-checkerboard-square-size-medium": {
     "value": "10px",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "879360e9-a7b0-47e0-bc4a-931a12877014",
-        "name": "opacity-checkerboard-square-size"
+        "name": "opacity-checkerboard-square-size-medium"
       }
     }
   },


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao -->

## Description

Updated opacity checkerboard square size token name (in desktop and mobile sets):

- opacity-checkerboard-square-size-**medium**

Added new opacity checkerboard square size token (in desktop and mobile sets):

- opacity-checkerboard-square-size-**small**

<!--- Describe your changes in detail, including a list of changes -->

## Motivation and context

These changes occurred as a result of scaling things for S2 design language and experiences.
<!--- Why is this change required? What problem does it solve? -->

## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [X] Minor (add a new token, changing a value; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [X] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
