### PR TITLE
Fixing misnamed accordion token

### DIFF
--- a/src/tokens-studio/spectrum-non-colors/spectrum/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/layout.component/desktop.json
@@ -189,7 +189,7 @@
       }
     }
   },
-  "accordion-small-top-to-text-spacious": {
+  "🚫 accordion-small-top-to-text-spacious": {
     "value": "9px",
     "type": "spacing",
     "$extensions": {
@@ -306,6 +306,16 @@
       "spectrum-tokens": {
         "uuid": "19c91104-bdf4-4969-8d92-c9cd47d39d13",
         "name": "accordion-top-to-text-spacious-medium"
+      }
+    }
+  },
+  "accordion-top-to-text-spacious-small": {
+    "value": "9px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "accordion-top-to-text-spacious-small"
       }
     }
   },

--- a/src/tokens-studio/spectrum-non-colors/spectrum/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/layout.component/mobile.json
@@ -189,7 +189,7 @@
       }
     }
   },
-  "accordion-small-top-to-text-spacious": {
+  "🚫 accordion-small-top-to-text-spacious": {
     "value": "12px",
     "type": "spacing",
     "$extensions": {
@@ -306,6 +306,16 @@
       "spectrum-tokens": {
         "uuid": "63602a66-5f96-4e6a-8bf0-2ac03321a577",
         "name": "accordion-top-to-text-spacious-medium"
+      }
+    }
+  },
+  "accordion-top-to-text-spacious-small": {
+    "value": "12px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "accordion-top-to-text-spacious-small"
       }
     }
   },

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -189,7 +189,7 @@
       }
     }
   },
-  "accordion-small-top-to-text-spacious": {
+  "🚫 accordion-small-top-to-text-spacious": {
     "value": "9px",
     "type": "spacing",
     "$extensions": {
@@ -306,6 +306,16 @@
       "spectrum-tokens": {
         "uuid": "19c91104-bdf4-4969-8d92-c9cd47d39d13",
         "name": "accordion-top-to-text-spacious-medium"
+      }
+    }
+  },
+  "accordion-top-to-text-spacious-small": {
+    "value": "9px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "accordion-top-to-text-spacious-small"
       }
     }
   },

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -189,7 +189,7 @@
       }
     }
   },
-  "accordion-small-top-to-text-spacious": {
+  "🚫 accordion-small-top-to-text-spacious": {
     "value": "12px",
     "type": "spacing",
     "$extensions": {
@@ -306,6 +306,16 @@
       "spectrum-tokens": {
         "uuid": "63602a66-5f96-4e6a-8bf0-2ac03321a577",
         "name": "accordion-top-to-text-spacious-medium"
+      }
+    }
+  },
+  "accordion-top-to-text-spacious-small": {
+    "value": "12px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "accordion-top-to-text-spacious-small"
       }
     }
   },


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao -->

## Description

Jason Chan found a token misnamed. It is named `accordion-small-top-to-text-spacious` when it should be `accordion-top-to-text-spacious-small`. This pr fixes it.

## Motivation and context

Make the token names consistent.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [x] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [ ] Minor (add a new token, changing a value; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
