### PR TITLE
Updated coach mark tokens for both desktop and mobile

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -1000,7 +1000,7 @@
     }
   },
   "coach-mark-body-font-size": {
-    "value": "{body-size-s}",
+    "value": "{body-size-m}",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -1100,7 +1100,7 @@
     }
   },
   "coach-mark-title-font-size": {
-    "value": "{heading-size-xs}",
+    "value": "{title-size-m}",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -1001,7 +1001,7 @@
   },
   "coach-mark-body-font-size": {
     "value": "{body-size-m}",
-    "type": "sizing",
+    "type": "fontSizes",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "",
@@ -1071,7 +1071,7 @@
   },
   "coach-mark-pagination-body-font-size": {
     "value": "{body-size-s}",
-    "type": "sizing",
+    "type": "fontSizes",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "",
@@ -1101,7 +1101,7 @@
   },
   "coach-mark-title-font-size": {
     "value": "{title-size-m}",
-    "type": "sizing",
+    "type": "fontSizes",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "",

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -989,13 +989,23 @@
       }
     }
   },
-  "coach-mark-body-size": {
-    "value": "{body-size-s}",
+  "🚫 coach-mark-body-size": {
+    "value": "{coach-mark-body-font-size}",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "eba9f466-deda-48d5-a120-14419d5a670f",
         "name": "coach-mark-body-size"
+      }
+    }
+  },
+  "coach-mark-body-font-size": {
+    "value": "{body-size-s}",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "coach-mark-body-font-size"
       }
     }
   },
@@ -1049,13 +1059,23 @@
       }
     }
   },
-  "coach-mark-pagination-body-size": {
-    "value": "{body-size-s}",
+  "🚫 coach-mark-pagination-body-size": {
+    "value": "{coach-mark-pagination-body-font-size}",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "df8bc8ae-b6fa-4414-93b7-c89d8097fe11",
         "name": "coach-mark-pagination-body-size"
+      }
+    }
+  },
+  "coach-mark-pagination-body-font-size": {
+    "value": "{body-size-s}",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "coach-mark-pagination-body-font-size"
       }
     }
   },
@@ -1069,13 +1089,23 @@
       }
     }
   },
-  "coach-mark-title-size": {
-    "value": "{heading-size-xs}",
+  "🚫 coach-mark-title-size": {
+    "value": "{coach-mark-title-font-size}",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "331604db-3f28-472e-810d-9010ed2c8e33",
         "name": "coach-mark-title-size"
+      }
+    }
+  },
+  "coach-mark-title-font-size": {
+    "value": "{heading-size-xs}",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "coach-mark-title-font-size"
       }
     }
   },

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -1001,7 +1001,7 @@
   },
   "coach-mark-body-font-size": {
     "value": "{body-size-s}",
-    "type": "sizing",
+    "type": "fontSizes",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "",
@@ -1071,7 +1071,7 @@
   },
   "coach-mark-pagination-body-font-size": {
     "value": "{body-size-xs}",
-    "type": "sizing",
+    "type": "fontSizes",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "",
@@ -1101,7 +1101,7 @@
   },
   "coach-mark-title-font-size": {
     "value": "{title-size-s}",
-    "type": "sizing",
+    "type": "fontSizes",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "",

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -989,13 +989,23 @@
       }
     }
   },
-  "coach-mark-body-size": {
-    "value": "{body-size-xs}",
+  "🚫 coach-mark-body-size": {
+    "value": "{coach-mark-body-font-size}",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "a0abef77-dafe-4158-9faa-a4b4b2871e54",
         "name": "coach-mark-body-size"
+      }
+    }
+  },
+  "coach-mark-body-font-size": {
+    "value": "{body-size-xs}",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "coach-mark-body-font-size"
       }
     }
   },
@@ -1049,13 +1059,23 @@
       }
     }
   },
-  "coach-mark-pagination-body-size": {
-    "value": "{body-size-xs}",
+  "🚫 coach-mark-pagination-body-size": {
+    "value": "{coach-mark-pagination-body-font-size}",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "350d9235-ff9e-43d7-9298-56b36d58d6de",
         "name": "coach-mark-pagination-body-size"
+      }
+    }
+  },
+  "coach-mark-pagination-body-font-size": {
+    "value": "{body-size-xs}",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "coach-mark-pagination-body-font-size"
       }
     }
   },
@@ -1069,13 +1089,23 @@
       }
     }
   },
-  "coach-mark-title-size": {
-    "value": "{heading-size-xxs}",
+  "🚫 coach-mark-title-size": {
+    "value": "{coach-mark-title-font-size}",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
         "uuid": "cd4848b6-d560-475a-9d80-f7b5acebce10",
         "name": "coach-mark-title-size"
+      }
+    }
+  },
+  "coach-mark-title-font-size": {
+    "value": "{heading-size-xxs}",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "coach-mark-title-font-size"
       }
     }
   },

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -1000,7 +1000,7 @@
     }
   },
   "coach-mark-body-font-size": {
-    "value": "{body-size-xs}",
+    "value": "{body-size-s}",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {
@@ -1100,7 +1100,7 @@
     }
   },
   "coach-mark-title-font-size": {
-    "value": "{heading-size-xxs}",
+    "value": "{title-size-s}",
     "type": "sizing",
     "$extensions": {
       "spectrum-tokens": {


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao -->

Updated coach mark tokens by creating new and deprecated old Title, Body, Pagination body font size tokens.

<!--- Describe your changes in detail, including a list of changes -->

Added the word "font" in the font size token naming.

<!--- Why is this change required? What problem does it solve? -->

n/a

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

n/a

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
