### PR TITLE
S2 Color loupe tokens update (non-color only)

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -1239,8 +1239,8 @@
       }
     }
   },
-  "color-loupe-drop-shadow-blur": {
-    "value": "8px",
+  "🚫 color-loupe-drop-shadow-blur": {
+    "value": "{drop-shadow-elevated-blur}",
     "type": "other",
     "$extensions": {
       "spectrum-tokens": {
@@ -1249,8 +1249,8 @@
       }
     }
   },
-  "color-loupe-drop-shadow-y": {
-    "value": "2px",
+  "🚫 color-loupe-drop-shadow-y": {
+    "value": "{drop-shadow-elevated-y}",
     "type": "other",
     "$extensions": {
       "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -1239,8 +1239,8 @@
       }
     }
   },
-  "color-loupe-drop-shadow-blur": {
-    "value": "8px",
+  "🚫 color-loupe-drop-shadow-blur": {
+    "value": "{drop-shadow-elevated-blur}",
     "type": "other",
     "$extensions": {
       "spectrum-tokens": {
@@ -1249,8 +1249,8 @@
       }
     }
   },
-  "color-loupe-drop-shadow-y": {
-    "value": "2px",
+  "🚫 color-loupe-drop-shadow-y": {
+    "value": "{drop-shadow-elevated-y}",
     "type": "other",
     "$extensions": {
       "spectrum-tokens": {


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao -->

## Description

<!--- Describe your changes in detail, including a list of changes -->
Marked the following tokens for deprecation by adding a "🚫" flag, and then relinked them to global drop-shadow tokens:

- color-loupe-drop-shadow-y (relink to drop-shadow-elevated-y)
- color-loupe-drop-shadow-blur (relink to drop-shadow-elevated-blur)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
These changes occurred as a result of scaling things for S2 design language and experiences.

## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [X] Minor (add a new token, changing a value; non-breaking change which adds functionality) </li>
<li> [X] Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [X] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
