### PR TITLE
S2 Color loupe tokens update (color-only)

### DIFF
--- a/src/tokens-studio/spectrum2-colors/$themes.json
+++ b/src/tokens-studio/spectrum2-colors/$themes.json
@@ -16,7 +16,6 @@
       "Component.color-area.border": "34a0ec3c7e0acfc890c6ac1021b0fe841c934d32",
       "Component.color-handle.inner-border": "3bdc6483aefb8301420b9ba71fe8172e966ce4f7",
       "Component.color-handle.outer-border": "e7cda9a602a097be1a3a44ea283144c54ab7b405",
-      "Component.color-loupe.drop-shadow": "7a15aeef80d9cc9623427a57fb2e7d9533cc11d6",
       "Component.color-loupe.inner-border": "d30912dc7cc1e51c87b32a85fc4afeeaf3a1619c",
       "Component.color-loupe.outer-border": "a935c8b35086cf6351b5e18b5861eac9d8ae6e99",
       "Component.color-slider.border": "a3cdc27e253e9f4b1d5f92a6e412d33ff9fa1f43",
@@ -571,7 +570,8 @@
       "Palette.transparent-white.800": "ea5e834dbe202dc1dbbce86ba074ab50155812c1",
       "Palette.transparent-white.900": "cc73dfce811bf9bab293a95d9342fd6a9135c9ab",
       "Palette.transparent-white.1000": "0ae4fb367bd6d70103b8df1fd1fff8a237a94b30",
-      "Alias.🚫 drop-shadow": "0e6900e9ce8ddf2c72e312dcc202679dd76f2516"
+      "Alias.🚫 drop-shadow": "0e6900e9ce8ddf2c72e312dcc202679dd76f2516",
+      "Component.color-loupe.🚫drop-shadow": "7a15aeef80d9cc9623427a57fb2e7d9533cc11d6"
     },
     "$figmaStyleReferences": {},
     "group": "S2.Color-theme"
@@ -593,7 +593,6 @@
       "Component.color-area.border": "34a0ec3c7e0acfc890c6ac1021b0fe841c934d32",
       "Component.color-handle.inner-border": "3bdc6483aefb8301420b9ba71fe8172e966ce4f7",
       "Component.color-handle.outer-border": "e7cda9a602a097be1a3a44ea283144c54ab7b405",
-      "Component.color-loupe.drop-shadow": "7a15aeef80d9cc9623427a57fb2e7d9533cc11d6",
       "Component.color-loupe.inner-border": "d30912dc7cc1e51c87b32a85fc4afeeaf3a1619c",
       "Component.color-loupe.outer-border": "a935c8b35086cf6351b5e18b5861eac9d8ae6e99",
       "Component.color-slider.border": "a3cdc27e253e9f4b1d5f92a6e412d33ff9fa1f43",
@@ -1148,7 +1147,8 @@
       "Palette.transparent-white.800": "ea5e834dbe202dc1dbbce86ba074ab50155812c1",
       "Palette.transparent-white.900": "cc73dfce811bf9bab293a95d9342fd6a9135c9ab",
       "Palette.transparent-white.1000": "0ae4fb367bd6d70103b8df1fd1fff8a237a94b30",
-      "Alias.🚫 drop-shadow": "0e6900e9ce8ddf2c72e312dcc202679dd76f2516"
+      "Alias.🚫 drop-shadow": "0e6900e9ce8ddf2c72e312dcc202679dd76f2516",
+      "Component.color-loupe.🚫drop-shadow": "7a15aeef80d9cc9623427a57fb2e7d9533cc11d6"
     },
     "$figmaStyleReferences": {},
     "group": "S2.Color-theme"

--- a/src/tokens-studio/spectrum2-colors/spectrum2/component/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/component/dark.json
@@ -59,8 +59,8 @@
       }
     },
     "color-loupe": {
-      "drop-shadow": {
-        "value": "{Palette.transparent-black.300}",
+      "🚫drop-shadow": {
+        "value": "{Alias.drop-shadow.elevated}",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-colors/spectrum2/component/light.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/component/light.json
@@ -59,8 +59,8 @@
       }
     },
     "color-loupe": {
-      "drop-shadow": {
-        "value": "{Palette.transparent-black.300}",
+      "🚫drop-shadow": {
+        "value": "{Alias.drop-shadow.elevated}",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao -->

## Description

Marked the following token for deprecation by adding a "🚫" flag, and then relinked them to global drop-shadow color tokens:

- color-loupe-drop-shadow-color (relink to drop-shadow-elevated-color)

This was applied to light and dark sets. 

<!--- Describe your changes in detail, including a list of changes -->

## Motivation and context
These changes occurred as a result of scaling things for S2 design language and experiences.

<!--- Why is this change required? What problem does it solve? -->

## Related issue

<!--- This project only accepts pull requests related to open issues --> 
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

This is related to the S2 color loupe overall token updates:

- [related PR](https://github.com/adobe/spectrum-tokens-studio-data/pull/95)
- [Jira ticket](https://jira.corp.adobe.com/browse/SDS-13348) 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [X] Minor (add a new token, changing a value; non-breaking change which adds functionality) </li>
<li> [X] Major (deleting a token, changing token value type; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [X] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
