### PR TITLE
Updated values for component pill edge to visual only tokens

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout/desktop.json
@@ -450,7 +450,7 @@
     }
   },
   "component-pill-edge-to-visual-only-100": {
-    "value": "7px",
+    "value": "6px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
@@ -460,7 +460,7 @@
     }
   },
   "component-pill-edge-to-visual-only-200": {
-    "value": "10px",
+    "value": "9px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
@@ -470,7 +470,7 @@
     }
   },
   "component-pill-edge-to-visual-only-300": {
-    "value": "13px",
+    "value": "11px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout/mobile.json
@@ -440,7 +440,7 @@
     }
   },
   "component-pill-edge-to-visual-only-75": {
-    "value": "5px",
+    "value": "6px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
@@ -450,7 +450,7 @@
     }
   },
   "component-pill-edge-to-visual-only-100": {
-    "value": "9px",
+    "value": "8px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
@@ -460,7 +460,7 @@
     }
   },
   "component-pill-edge-to-visual-only-200": {
-    "value": "13px",
+    "value": "11px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {
@@ -470,7 +470,7 @@
     }
   },
   "component-pill-edge-to-visual-only-300": {
-    "value": "16px",
+    "value": "15px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao, @KayiuCarlson, @nabuhasan -->
<!--- Approval: PRs require two reviews at the minimum (one from the engineering team and one from the design team) in order to be considered "approved" and ready to merge -->

Updated values for component pill edge to visual only tokens for both desktop and mobile.

<!--- Describe your changes in detail, including a list of changes -->

These values are updated based on the new workflow icon size.

<!--- Why is this change required? What problem does it solve? -->

n/a

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

n/a

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
