### PR TITLE
S2 Color - Deprecation of negative-subdued-background tokens

### DIFF
--- a/src/tokens-studio/spectrum2-colors/$themes.json
+++ b/src/tokens-studio/spectrum2-colors/$themes.json
@@ -218,10 +218,6 @@
       "Alias.background.semantic.negative.down": "9095addc7f9714ce5fc32b64ae0102ecbf134a85",
       "Alias.background.semantic.negative.key-focus": "d9a32780f52800f4645f0dfdf579613329d35dd8",
       "Alias.background.semantic.negative.subtle-default": "f5288745c7f25c10ecaf7b3ec7add9b15473c861",
-      "Alias.background.semantic.negative-subdued.default": "66085d5299a29a419ec429850e20ec133b40b216",
-      "Alias.background.semantic.negative-subdued.hover": "838c8c9c06d4b3d39b6e4d8a745b0c32d8ffea1f",
-      "Alias.background.semantic.negative-subdued.down": "f0010804af2b5ff6aea1fbe53b0f8c2b6740de80",
-      "Alias.background.semantic.negative-subdued.key-focus": "ec04a1e92ee56604023f7b73d10f9f3eec57d9d2",
       "Alias.background.disabled.default": "a56187cfdbb23df0ea40e02f846cd538dcf5e6ee",
       "Alias.background.disabled.static-black": "db5ade4e714b074e7cf37329a5f43ab611735493",
       "Alias.background.disabled.static-white": "2990a6bbed915eb5432d96adea2b93c3fc7e6229",
@@ -665,7 +661,11 @@
       "Palette.transparent-white.800": "ea5e834dbe202dc1dbbce86ba074ab50155812c1",
       "Palette.transparent-white.900": "cc73dfce811bf9bab293a95d9342fd6a9135c9ab",
       "Palette.transparent-white.1000": "0ae4fb367bd6d70103b8df1fd1fff8a237a94b30",
-      "Icon.primary.disabled.default": "99b973292918e2c767311e3bca5831040c7f9ae9"
+      "Icon.primary.disabled.default": "99b973292918e2c767311e3bca5831040c7f9ae9",
+      "Alias.background.semantic.negative-subdued.🚫 default": "66085d5299a29a419ec429850e20ec133b40b216",
+      "Alias.background.semantic.negative-subdued.🚫 hover": "838c8c9c06d4b3d39b6e4d8a745b0c32d8ffea1f",
+      "Alias.background.semantic.negative-subdued.🚫 down": "f0010804af2b5ff6aea1fbe53b0f8c2b6740de80",
+      "Alias.background.semantic.negative-subdued.🚫 key-focus": "ec04a1e92ee56604023f7b73d10f9f3eec57d9d2"
     },
     "$figmaStyleReferences": {},
     "group": "S2.Color-theme"
@@ -889,10 +889,6 @@
       "Alias.background.semantic.negative.down": "9095addc7f9714ce5fc32b64ae0102ecbf134a85",
       "Alias.background.semantic.negative.key-focus": "d9a32780f52800f4645f0dfdf579613329d35dd8",
       "Alias.background.semantic.negative.subtle-default": "f5288745c7f25c10ecaf7b3ec7add9b15473c861",
-      "Alias.background.semantic.negative-subdued.default": "66085d5299a29a419ec429850e20ec133b40b216",
-      "Alias.background.semantic.negative-subdued.hover": "838c8c9c06d4b3d39b6e4d8a745b0c32d8ffea1f",
-      "Alias.background.semantic.negative-subdued.down": "f0010804af2b5ff6aea1fbe53b0f8c2b6740de80",
-      "Alias.background.semantic.negative-subdued.key-focus": "ec04a1e92ee56604023f7b73d10f9f3eec57d9d2",
       "Alias.background.disabled.default": "a56187cfdbb23df0ea40e02f846cd538dcf5e6ee",
       "Alias.background.disabled.static-black": "db5ade4e714b074e7cf37329a5f43ab611735493",
       "Alias.background.disabled.static-white": "2990a6bbed915eb5432d96adea2b93c3fc7e6229",
@@ -1336,7 +1332,11 @@
       "Palette.transparent-white.800": "ea5e834dbe202dc1dbbce86ba074ab50155812c1",
       "Palette.transparent-white.900": "cc73dfce811bf9bab293a95d9342fd6a9135c9ab",
       "Palette.transparent-white.1000": "0ae4fb367bd6d70103b8df1fd1fff8a237a94b30",
-      "Icon.primary.disabled.default": "99b973292918e2c767311e3bca5831040c7f9ae9"
+      "Icon.primary.disabled.default": "99b973292918e2c767311e3bca5831040c7f9ae9",
+      "Alias.background.semantic.negative-subdued.🚫 default": "66085d5299a29a419ec429850e20ec133b40b216",
+      "Alias.background.semantic.negative-subdued.🚫 hover": "838c8c9c06d4b3d39b6e4d8a745b0c32d8ffea1f",
+      "Alias.background.semantic.negative-subdued.🚫 down": "f0010804af2b5ff6aea1fbe53b0f8c2b6740de80",
+      "Alias.background.semantic.negative-subdued.🚫 key-focus": "ec04a1e92ee56604023f7b73d10f9f3eec57d9d2"
     },
     "$figmaStyleReferences": {},
     "group": "S2.Color-theme"

--- a/src/tokens-studio/spectrum2-colors/$themes.json
+++ b/src/tokens-studio/spectrum2-colors/$themes.json
@@ -662,10 +662,10 @@
       "Palette.transparent-white.900": "cc73dfce811bf9bab293a95d9342fd6a9135c9ab",
       "Palette.transparent-white.1000": "0ae4fb367bd6d70103b8df1fd1fff8a237a94b30",
       "Icon.primary.disabled.default": "99b973292918e2c767311e3bca5831040c7f9ae9",
-      "Alias.background.semantic.negative-subdued.🚫 default": "66085d5299a29a419ec429850e20ec133b40b216",
-      "Alias.background.semantic.negative-subdued.🚫 hover": "838c8c9c06d4b3d39b6e4d8a745b0c32d8ffea1f",
-      "Alias.background.semantic.negative-subdued.🚫 down": "f0010804af2b5ff6aea1fbe53b0f8c2b6740de80",
-      "Alias.background.semantic.negative-subdued.🚫 key-focus": "ec04a1e92ee56604023f7b73d10f9f3eec57d9d2"
+      "Alias.background.semantic.🚫 negative-subdued.default": "66085d5299a29a419ec429850e20ec133b40b216",
+      "Alias.background.semantic.🚫 negative-subdued.hover": "838c8c9c06d4b3d39b6e4d8a745b0c32d8ffea1f",
+      "Alias.background.semantic.🚫 negative-subdued.down": "f0010804af2b5ff6aea1fbe53b0f8c2b6740de80",
+      "Alias.background.semantic.🚫 negative-subdued.key-focus": "ec04a1e92ee56604023f7b73d10f9f3eec57d9d2"
     },
     "$figmaStyleReferences": {},
     "group": "S2.Color-theme"
@@ -1333,10 +1333,10 @@
       "Palette.transparent-white.900": "cc73dfce811bf9bab293a95d9342fd6a9135c9ab",
       "Palette.transparent-white.1000": "0ae4fb367bd6d70103b8df1fd1fff8a237a94b30",
       "Icon.primary.disabled.default": "99b973292918e2c767311e3bca5831040c7f9ae9",
-      "Alias.background.semantic.negative-subdued.🚫 default": "66085d5299a29a419ec429850e20ec133b40b216",
-      "Alias.background.semantic.negative-subdued.🚫 hover": "838c8c9c06d4b3d39b6e4d8a745b0c32d8ffea1f",
-      "Alias.background.semantic.negative-subdued.🚫 down": "f0010804af2b5ff6aea1fbe53b0f8c2b6740de80",
-      "Alias.background.semantic.negative-subdued.🚫 key-focus": "ec04a1e92ee56604023f7b73d10f9f3eec57d9d2"
+      "Alias.background.semantic.🚫 negative-subdued.default": "66085d5299a29a419ec429850e20ec133b40b216",
+      "Alias.background.semantic.🚫 negative-subdued.hover": "838c8c9c06d4b3d39b6e4d8a745b0c32d8ffea1f",
+      "Alias.background.semantic.🚫 negative-subdued.down": "f0010804af2b5ff6aea1fbe53b0f8c2b6740de80",
+      "Alias.background.semantic.🚫 negative-subdued.key-focus": "ec04a1e92ee56604023f7b73d10f9f3eec57d9d2"
     },
     "$figmaStyleReferences": {},
     "group": "S2.Color-theme"

--- a/src/tokens-studio/spectrum2-colors/spectrum2/alias/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/alias/dark.json
@@ -1036,7 +1036,7 @@
         },
         "🚫 negative-subdued": {
           "default": {
-            "value": "{Alias.semantic.negative.200}",
+            "value": "{Alias.background.semantic.negative.subtle-default}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-colors/spectrum2/alias/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/alias/dark.json
@@ -1035,7 +1035,7 @@
           }
         },
         "negative-subdued": {
-          "default": {
+          "🚫 default": {
             "value": "{Alias.semantic.negative.200}",
             "type": "color",
             "$extensions": {
@@ -1045,7 +1045,7 @@
               }
             }
           },
-          "hover": {
+          "🚫 hover": {
             "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {
@@ -1055,7 +1055,7 @@
               }
             }
           },
-          "down": {
+          "🚫 down": {
             "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {
@@ -1065,7 +1065,7 @@
               }
             }
           },
-          "key-focus": {
+          "🚫 key-focus": {
             "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {

--- a/src/tokens-studio/spectrum2-colors/spectrum2/alias/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/alias/dark.json
@@ -1034,8 +1034,8 @@
             }
           }
         },
-        "negative-subdued": {
-          "🚫 default": {
+        "🚫 negative-subdued": {
+          "default": {
             "value": "{Alias.semantic.negative.200}",
             "type": "color",
             "$extensions": {
@@ -1045,7 +1045,7 @@
               }
             }
           },
-          "🚫 hover": {
+          "hover": {
             "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {
@@ -1055,7 +1055,7 @@
               }
             }
           },
-          "🚫 down": {
+          "down": {
             "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {
@@ -1065,7 +1065,7 @@
               }
             }
           },
-          "🚫 key-focus": {
+          "key-focus": {
             "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {

--- a/src/tokens-studio/spectrum2-colors/spectrum2/alias/light.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/alias/light.json
@@ -1034,8 +1034,8 @@
             }
           }
         },
-        "negative-subdued": {
-          "🚫 default": {
+        "🚫 negative-subdued": {
+          "default": {
             "value": "{Alias.background.semantic.negative.subtle-default}",
             "type": "color",
             "$extensions": {
@@ -1045,7 +1045,7 @@
               }
             }
           },
-          "🚫 hover": {
+          "hover": {
             "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {
@@ -1055,7 +1055,7 @@
               }
             }
           },
-          "🚫 down": {
+          "down": {
             "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {
@@ -1065,7 +1065,7 @@
               }
             }
           },
-          "🚫 key-focus": {
+          "key-focus": {
             "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {

--- a/src/tokens-studio/spectrum2-colors/spectrum2/alias/light.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/alias/light.json
@@ -1035,8 +1035,8 @@
           }
         },
         "negative-subdued": {
-          "default": {
-            "value": "{Alias.semantic.negative.200}",
+          "🚫 default": {
+            "value": "{Alias.background.semantic.negative.subtle-default}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -1045,7 +1045,7 @@
               }
             }
           },
-          "hover": {
+          "🚫 hover": {
             "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {
@@ -1055,7 +1055,7 @@
               }
             }
           },
-          "down": {
+          "🚫 down": {
             "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {
@@ -1065,7 +1065,7 @@
               }
             }
           },
-          "key-focus": {
+          "🚫 key-focus": {
             "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao, @KayiuCarlson, @nabuhasan -->
<!--- Approval: PRs require two reviews at the minimum (one from the engineering team and one from the design team) in order to be considered "approved" and ready to merge -->

## Description
Marked the the following tokens in Tokens Studio for deprecation:

- negative-subdued-background-color-default ( --> points to negative-subtle-background-color-default)
- negative-subdued-background-color-hover
- negative-subdued-background-color-down
- negative-subdued-background-color-key-focus

Changes were made in light and dark sets and variables were synced in S2/Variables with the latest updates. 

For more information, [view Jira ticket](https://jira.corp.adobe.com/browse/SDS-13415). 

<!--- Describe your changes in detail, including a list of changes -->

## Motivation and context
These tokens were deprecated because the tag "error" variant has been deprecated and are no longer needed in the system. A new "subtle" token has been added for the in-line alert use case.

<!--- Why is this change required? What problem does it solve? -->

## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [X] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [X] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
