### PR TITLE
fix: missing overlay-opacity token

### DIFF
--- a/src/tokens-studio/spectrum-non-colors/spectrum/opacity.alias/dark.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/opacity.alias/dark.json
@@ -48,5 +48,15 @@
         "name": "opacity-disabled"
       }
     }
+  },
+  "overlay-opacity": {
+    "value": "0.5",
+    "type": "opacity",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "df41eb51-872f-458d-9439-910064f74b7b",
+        "name": "overlay-opacity"
+      }
+    }
   }
 }

--- a/src/tokens-studio/spectrum-non-colors/spectrum/opacity.alias/darkest.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/opacity.alias/darkest.json
@@ -48,5 +48,15 @@
         "name": "opacity-disabled"
       }
     }
+  },
+  "overlay-opacity": {
+    "value": "0.6",
+    "type": "opacity",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "31d5b502-6266-4309-8f8a-3892e6e158da",
+        "name": "overlay-opacity"
+      }
+    }
   }
 }

--- a/src/tokens-studio/spectrum-non-colors/spectrum/opacity.alias/light.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/opacity.alias/light.json
@@ -48,5 +48,15 @@
         "name": "opacity-disabled"
       }
     }
+  },
+  "overlay-opacity": {
+    "value": "0.4",
+    "type": "opacity",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "26b9803c-577f-4a29-badd-dfc459e8b73e",
+        "name": "overlay-opacity"
+      }
+    }
   }
 }

--- a/src/tokens-studio/spectrum-non-colors/spectrum/opacity.alias/wireframe.json
+++ b/src/tokens-studio/spectrum-non-colors/spectrum/opacity.alias/wireframe.json
@@ -48,5 +48,15 @@
         "name": "opacity-disabled"
       }
     }
+  },
+  "overlay-opacity": {
+    "value": "0.4",
+    "type": "opacity",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "93b904da-5d1f-4fd9-aa26-5aabe19df108",
+        "name": "overlay-opacity"
+      }
+    }
   }
 }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/opacity.alias/dark.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/opacity.alias/dark.json
@@ -48,5 +48,15 @@
         "name": "opacity-disabled"
       }
     }
+  },
+  "overlay-opacity": {
+    "value": "0.6",
+    "type": "opacity",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "31d5b502-6266-4309-8f8a-3892e6e158da",
+        "name": "overlay-opacity"
+      }
+    }
   }
 }

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/opacity.alias/light.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/opacity.alias/light.json
@@ -48,5 +48,15 @@
         "name": "opacity-disabled"
       }
     }
+  },
+  "overlay-opacity": {
+    "value": "0.4",
+    "type": "opacity",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "26b9803c-577f-4a29-badd-dfc459e8b73e",
+        "name": "overlay-opacity"
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Include @karstens, @GarthDB, @mrcjhicks, @lynnhao, @KayiuCarlson, @nabuhasan -->
<!--- Approval: PRs require two reviews at the minimum (one from the engineering team and one from the design team) in order to be considered "approved" and ready to merge -->

## Description

<!--- Describe your changes in detail, including a list of changes -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
