### PR TITLE
S2 non-gray-800 colors update

### DIFF
--- a/src/tokens-studio/spectrum2-colors/spectrum2/alias/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/alias/dark.json
@@ -858,7 +858,7 @@
       "semantic": {
         "accent": {
           "default": {
-            "value": "{Alias.semantic.accent.700}",
+            "value": "{Alias.semantic.accent.800}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -868,7 +868,7 @@
             }
           },
           "hover": {
-            "value": "{Alias.semantic.accent.600}",
+            "value": "{Alias.semantic.accent.700}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -878,7 +878,7 @@
             }
           },
           "down": {
-            "value": "{Alias.semantic.accent.600}",
+            "value": "{Alias.semantic.accent.700}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -888,7 +888,7 @@
             }
           },
           "key-focus": {
-            "value": "{Alias.semantic.accent.600}",
+            "value": "{Alias.semantic.accent.700}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -900,7 +900,7 @@
         },
         "informative": {
           "default": {
-            "value": "{Alias.semantic.informative.700}",
+            "value": "{Alias.semantic.informative.800}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -910,7 +910,7 @@
             }
           },
           "hover": {
-            "value": "{Alias.semantic.informative.600}",
+            "value": "{Alias.semantic.informative.700}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -920,7 +920,7 @@
             }
           },
           "down": {
-            "value": "{Alias.semantic.informative.600}",
+            "value": "{Alias.semantic.informative.700}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -930,7 +930,7 @@
             }
           },
           "key-focus": {
-            "value": "{Alias.semantic.informative.600}",
+            "value": "{Alias.semantic.informative.700}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -952,7 +952,7 @@
         },
         "positive": {
           "default": {
-            "value": "{Alias.semantic.positive.700}",
+            "value": "{Alias.semantic.positive.800}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -962,7 +962,7 @@
             }
           },
           "hover": {
-            "value": "{Alias.semantic.positive.600}",
+            "value": "{Alias.semantic.positive.700}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -972,7 +972,7 @@
             }
           },
           "down": {
-            "value": "{Alias.semantic.positive.600}",
+            "value": "{Alias.semantic.positive.700}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -982,7 +982,7 @@
             }
           },
           "key-focus": {
-            "value": "{Alias.semantic.positive.600}",
+            "value": "{Alias.semantic.positive.700}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -1026,7 +1026,7 @@
         },
         "negative": {
           "default": {
-            "value": "{Alias.semantic.negative.700}",
+            "value": "{Alias.semantic.negative.800}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -1036,7 +1036,7 @@
             }
           },
           "hover": {
-            "value": "{Alias.semantic.negative.600}",
+            "value": "{Alias.semantic.negative.700}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -1046,7 +1046,7 @@
             }
           },
           "down": {
-            "value": "{Alias.semantic.negative.600}",
+            "value": "{Alias.semantic.negative.700}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -1056,7 +1056,7 @@
             }
           },
           "key-focus": {
-            "value": "{Alias.semantic.negative.600}",
+            "value": "{Alias.semantic.negative.700}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -1163,7 +1163,7 @@
           }
         },
         "blue": {
-          "value": "{Palette.blue.700}",
+          "value": "{Palette.blue.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1173,7 +1173,7 @@
           }
         },
         "green": {
-          "value": "{Palette.green.700}",
+          "value": "{Palette.green.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1193,7 +1193,7 @@
           }
         },
         "red": {
-          "value": "{Palette.red.700}",
+          "value": "{Palette.red.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1203,7 +1203,7 @@
           }
         },
         "brown": {
-          "value": "{Palette.brown.700}",
+          "value": "{Palette.brown.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1213,7 +1213,7 @@
           }
         },
         "cinnamon": {
-          "value": "{Palette.cinnamon.700}",
+          "value": "{Palette.cinnamon.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1243,7 +1243,7 @@
           }
         },
         "cyan": {
-          "value": "{Palette.cyan.700}",
+          "value": "{Palette.cyan.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1253,7 +1253,7 @@
           }
         },
         "fuchsia": {
-          "value": "{Palette.fuchsia.700}",
+          "value": "{Palette.fuchsia.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1263,7 +1263,7 @@
           }
         },
         "indigo": {
-          "value": "{Palette.indigo.700}",
+          "value": "{Palette.indigo.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1273,7 +1273,7 @@
           }
         },
         "magenta": {
-          "value": "{Palette.magenta.700}",
+          "value": "{Palette.magenta.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1283,7 +1283,7 @@
           }
         },
         "pink": {
-          "value": "{Palette.pink.700}",
+          "value": "{Palette.pink.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1293,7 +1293,7 @@
           }
         },
         "purple": {
-          "value": "{Palette.purple.700}",
+          "value": "{Palette.purple.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1303,7 +1303,7 @@
           }
         },
         "seafoam": {
-          "value": "{Palette.seafoam.700}",
+          "value": "{Palette.seafoam.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1313,7 +1313,7 @@
           }
         },
         "silver": {
-          "value": "{Palette.silver.700}",
+          "value": "{Palette.silver.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -1323,7 +1323,7 @@
           }
         },
         "turquoise": {
-          "value": "{Palette.turquoise.700}",
+          "value": "{Palette.turquoise.800}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-colors/spectrum2/palette/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/palette/dark.json
@@ -224,7 +224,7 @@
         }
       },
       "800": {
-        "value": "#456efe",
+        "value": "#4069fd",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -386,7 +386,7 @@
         }
       },
       "800": {
-        "value": "#068c52",
+        "value": "#068850",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -548,7 +548,7 @@
         }
       },
       "800": {
-        "value": "#cd5600",
+        "value": "#c75200",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -710,7 +710,7 @@
         }
       },
       "800": {
-        "value": "#e63623",
+        "value": "#df3422",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -872,7 +872,7 @@
         }
       },
       "800": {
-        "value": "#458a13",
+        "value": "#428612",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1034,7 +1034,7 @@
         }
       },
       "800": {
-        "value": "#6d8300",
+        "value": "#6a7f00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1196,7 +1196,7 @@
         }
       },
       "800": {
-        "value": "#0f80c2",
+        "value": "#0d7dba",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1358,7 +1358,7 @@
         }
       },
       "800": {
-        "value": "#c040d4",
+        "value": "#ba3cce",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1520,7 +1520,7 @@
         }
       },
       "800": {
-        "value": "#7761fc",
+        "value": "#745bfc",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1682,7 +1682,7 @@
         }
       },
       "800": {
-        "value": "#e72969",
+        "value": "#e02665",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -1844,7 +1844,7 @@
         }
       },
       "800": {
-        "value": "#a154e5",
+        "value": "#9d4ee4",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2006,7 +2006,7 @@
         }
       },
       "800": {
-        "value": "#088a74",
+        "value": "#088670",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2168,7 +2168,7 @@
         }
       },
       "800": {
-        "value": "#a96e00",
+        "value": "#a46a00",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2330,7 +2330,7 @@
         }
       },
       "800": {
-        "value": "#dc2f9c",
+        "value": "#d52d97",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2492,7 +2492,7 @@
         }
       },
       "800": {
-        "value": "#098793",
+        "value": "#09838e",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2654,7 +2654,7 @@
         }
       },
       "800": {
-        "value": "#947649",
+        "value": "#8f7245",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2816,7 +2816,7 @@
         }
       },
       "800": {
-        "value": "#b36740",
+        "value": "#b0623b",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {
@@ -2978,7 +2978,7 @@
         }
       },
       "800": {
-        "value": "#7b7b7b",
+        "value": "#767676",
         "type": "color",
         "$extensions": {
           "spectrum-tokens": {


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: All members of the Spectrum Design Data team are included by default. Tag individuals in your Slack review request message instead. -->
<!--- Approval: PRs require two reviews at the minimum (one from the engineering team and one from the design team) in order to be considered "approved" and ready to merge -->

Note for @GarthDB (?): Tokens Studio currently doesn't have the Wireframe theme so we might have to update `wireframe-blue: 5074c5` manually. It's used as the 800 color for all non-gray colors in the “wireframe” theme.

Updated S2 non-gray-800 tokens in dark theme, and all aliases impacted to refer to the updated tokens:

- silver-800
- magenta-800
- red-800
- orange-800
- brown-800
- yellow-800
- chartreuse-800
- celery-800
- green-800
- seafoam-800
- turquoise-800
- cyan-800
- blue-800
- indigo-800
- purple-800
- fuchsia-800
- pink-800
- cinnamon-800

- accent-background-color-default
- accent-background-color-hover
- accent-background-color-down
- accent-background-color-key-focus
- informative-background-color-default
- informative-background-color-hover
- informative-background-color-down
- informative-background-color-key-focus
- blue-background-color-default

- negative-background-color-default
- negative-background-color-hover
- negative-background-color-down
- negative-background-color-key-focus
- red-background-color-default

- positive-background-color-default
- positive-background-color-hover
- positive-background-color-down
- positive-background-color-key-focus
- green-background-color-default

- seafoam-background-color-default
- cyan-background-color-default
- indigo-background-color-default
- purple-background-color-default
- fuchsia-background-color-default
- magenta-background-color-default
- pink-background-color-default
- turquoise-background-color-default
- brown-background-color-default
- cinnamon-background-color-default
- silver-background-color-default

<!--- Describe your changes in detail, including a list of changes -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? Note that the information here is included directly in Spectrum Tokens releases. When relevant, include language from our Figma library release notes.  -->

These updates to colors ensure we have a color stop that is 4.5:1 with white and 3:1 with gray-100. These color updates will fix accessibility issues for selected, accent variants in some components, like action button and tag.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
