### PR TITLE
Mismatched token names between light and dark

### DIFF
--- a/src/tokens-studio/spectrum2-colors/spectrum2/component/light.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/component/light.json
@@ -269,7 +269,7 @@
           }
         }
       },
-      "gripper-color-drag": {
+      "gripper-drag": {
         "value": "{Palette.gray.800}",
         "type": "color",
         "$extensions": {


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: All members of the Spectrum Design Data team are included by default. Tag individuals in your Slack review request message instead. -->
<!--- Approval: PRs require two reviews at the minimum (one from the engineering team and one from the design team) in order to be considered "approved" and ready to merge -->

## Description

standard-panel/gripper-drag in "light" to standard-panel/gripper-color-drag in "dark".

> WARNING - STUDIO MISSING MODE DEFINITION FOR spectrum2/component/Component/standard-panel/gripper-drag: ["light"]
> WARNING - STUDIO MISSING MODE DEFINITION FOR spectrum2/component/Component/standard-panel/gripper-color-drag: ["dark"]

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [x] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [ ] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
