### PR TITLE
S2 subtle and visual colors update

### DIFF
--- a/src/tokens-studio/spectrum2-colors/$themes.json
+++ b/src/tokens-studio/spectrum2-colors/$themes.json
@@ -34,7 +34,9 @@
       "Component.popover.border": "716363d37a9959c100d120da64dc12ca43af2cc7",
       "Component.swatch.border": "0921def4f90864fbeb1e361239484a95d7296f3b",
       "Component.swatch.disabled-icon-border": "926608b75d469011fdab4effff4b928a9010a99f",
+      "Component.standard-panel.gripper": "b352e01720f30f5a2223b49cc6871e9120109d7b",
       "Component.standard-panel.gripper-drag": "2ca345196c834ec63d6f65f998770dbdd9717d69",
+      "Component.swatch-group.border": "58366cc3e1840e97d8d556f90e49060f8f66e3ba",
       "Component.table.non-emphasized-selected-row-background": "527483e7ad502b89308da567c4202d583a1fd4fd",
       "Component.table.row-hover": "7400108dc6ecce96e0b2c7801eadc2f060e77828",
       "Component.table.selected-row-background": "1149aafef0a2f857f1acf1ab8b5463fd312cc527",
@@ -677,8 +679,7 @@
       "Palette.transparent-white.700": "fbac60c7cd862f46eba4908ae9cc5c7346156320",
       "Palette.transparent-white.800": "ea5e834dbe202dc1dbbce86ba074ab50155812c1",
       "Palette.transparent-white.900": "cc73dfce811bf9bab293a95d9342fd6a9135c9ab",
-      "Palette.transparent-white.1000": "0ae4fb367bd6d70103b8df1fd1fff8a237a94b30",
-      "Component.standard-panel.gripper": "b352e01720f30f5a2223b49cc6871e9120109d7b"
+      "Palette.transparent-white.1000": "0ae4fb367bd6d70103b8df1fd1fff8a237a94b30"
     },
     "$figmaStyleReferences": {},
     "group": "S2.Color-theme"
@@ -718,7 +719,9 @@
       "Component.popover.border": "716363d37a9959c100d120da64dc12ca43af2cc7",
       "Component.swatch.border": "0921def4f90864fbeb1e361239484a95d7296f3b",
       "Component.swatch.disabled-icon-border": "926608b75d469011fdab4effff4b928a9010a99f",
+      "Component.standard-panel.gripper": "b352e01720f30f5a2223b49cc6871e9120109d7b",
       "Component.standard-panel.gripper-drag": "2ca345196c834ec63d6f65f998770dbdd9717d69",
+      "Component.swatch-group.border": "58366cc3e1840e97d8d556f90e49060f8f66e3ba",
       "Component.table.non-emphasized-selected-row-background": "527483e7ad502b89308da567c4202d583a1fd4fd",
       "Component.table.row-hover": "7400108dc6ecce96e0b2c7801eadc2f060e77828",
       "Component.table.selected-row-background": "1149aafef0a2f857f1acf1ab8b5463fd312cc527",
@@ -1361,8 +1364,7 @@
       "Palette.transparent-white.700": "fbac60c7cd862f46eba4908ae9cc5c7346156320",
       "Palette.transparent-white.800": "ea5e834dbe202dc1dbbce86ba074ab50155812c1",
       "Palette.transparent-white.900": "cc73dfce811bf9bab293a95d9342fd6a9135c9ab",
-      "Palette.transparent-white.1000": "0ae4fb367bd6d70103b8df1fd1fff8a237a94b30",
-      "Component.standard-panel.gripper": "b352e01720f30f5a2223b49cc6871e9120109d7b"
+      "Palette.transparent-white.1000": "0ae4fb367bd6d70103b8df1fd1fff8a237a94b30"
     },
     "$figmaStyleReferences": {},
     "group": "S2.Color-theme"

--- a/src/tokens-studio/spectrum2-colors/spectrum2/alias/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/alias/dark.json
@@ -336,7 +336,7 @@
             }
           },
           "positive": {
-            "value": "{Alias.semantic.positive.800}",
+            "value": "{Alias.semantic.positive.900}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -356,7 +356,7 @@
             }
           },
           "negative": {
-            "value": "{Alias.semantic.negative.700}",
+            "value": "{Alias.semantic.negative.900}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -761,7 +761,7 @@
           }
         },
         "subtle-default": {
-          "value": "{Palette.gray.100}",
+          "value": "{Palette.gray.300}",
           "type": "color",
           "$extensions": {
             "spectrum-tokens": {
@@ -940,7 +940,7 @@
             }
           },
           "subtle-default": {
-            "value": "{Palette.blue.200}",
+            "value": "{Alias.semantic.informative.300}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -992,7 +992,7 @@
             }
           },
           "subtle-default": {
-            "value": "{Palette.green.200}",
+            "value": "{Alias.semantic.positive.300}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -1014,7 +1014,7 @@
             }
           },
           "subtle-default": {
-            "value": "{Palette.orange.200}",
+            "value": "{Alias.semantic.notice.300}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -1066,7 +1066,7 @@
             }
           },
           "subtle-default": {
-            "value": "{Palette.red.200}",
+            "value": "{Alias.semantic.negative.300}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-colors/spectrum2/alias/light.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/alias/light.json
@@ -336,7 +336,7 @@
             }
           },
           "positive": {
-            "value": "{Alias.semantic.positive.700}",
+            "value": "{Alias.semantic.positive.800}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -346,7 +346,7 @@
             }
           },
           "notice": {
-            "value": "{Alias.semantic.notice.700}",
+            "value": "{Alias.semantic.notice.800}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -940,7 +940,7 @@
             }
           },
           "subtle-default": {
-            "value": "{Palette.blue.200}",
+            "value": "{Alias.semantic.informative.200}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -992,7 +992,7 @@
             }
           },
           "subtle-default": {
-            "value": "{Palette.green.200}",
+            "value": "{Alias.semantic.positive.200}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -1014,7 +1014,7 @@
             }
           },
           "subtle-default": {
-            "value": "{Palette.orange.200}",
+            "value": "{Alias.semantic.notice.200}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {
@@ -1066,7 +1066,7 @@
             }
           },
           "subtle-default": {
-            "value": "{Palette.red.200}",
+            "value": "{Alias.semantic.negative.200}",
             "type": "color",
             "$extensions": {
               "spectrum-tokens": {


### PR DESCRIPTION
## Description

Subtle background and visual aliases updates for:

**Light and dark**
- informative-subtle-background-color-default
- positive-subtle-background-color-default 
- notice-subtle-background-color-default
- negative-subtle-background-color-default
- positive-visual-color

**Dark only**
- neutral-subdued-background-color-default
- negative-visual-color

**Light only**
- notice-visual-color

## Motivation and context

Updated token values for subtle background and visual aliases.

## Related issue

None

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
