### PR TITLE
Cleaning up corner radius to match s2-foundations proposal

### DIFF
--- a/src/tokens-studio/foundations/spectrum/layout/desktop.json
+++ b/src/tokens-studio/foundations/spectrum/layout/desktop.json
@@ -620,7 +620,7 @@
     }
   },
   "corner-radius-75": {
-    "value": "3px",
+    "value": "4px",
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
@@ -630,7 +630,7 @@
     }
   },
   "corner-radius-100": {
-    "value": "4px",
+    "value": "8px",
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
@@ -640,7 +640,7 @@
     }
   },
   "corner-radius-200": {
-    "value": "5px",
+    "value": "10px",
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
@@ -1539,76 +1539,6 @@
       }
     }
   },
-  "corner-radius-300": {
-    "value": "6px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-300",
-        "uuid": "154642d7-c23d-44fd-9d79-b719ef32922e"
-      }
-    }
-  },
-  "corner-radius-400": {
-    "value": "7px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-400",
-        "uuid": "690db7ae-cae8-49bb-8777-b4f1829b2f0b"
-      }
-    }
-  },
-  "corner-radius-500": {
-    "value": "8px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-500",
-        "uuid": "ada2ea1d-1728-411a-8aae-a198ce390a25"
-      }
-    }
-  },
-  "corner-radius-600": {
-    "value": "9px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-600",
-        "uuid": "abc0f309-3bd2-4800-af12-b27386e86617"
-      }
-    }
-  },
-  "corner-radius-700": {
-    "value": "10px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-700",
-        "uuid": "cb6b72ed-a9a1-4113-b147-1ef369fe6269"
-      }
-    }
-  },
-  "corner-radius-800": {
-    "value": "16px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-800",
-        "uuid": "8fc023ca-8aec-40fe-9130-087aa035bac7"
-      }
-    }
-  },
-  "corner-radius-1000": {
-    "value": "0.5",
-    "type": "number",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-1000",
-        "uuid": "e4ad85b2-97bf-48cf-a5a9-3ff3d1fada5b"
-      }
-    }
-  },
   "corner-radius-none": {
     "value": "{corner-radius-0}",
     "type": "borderRadius",
@@ -1616,146 +1546,6 @@
       "spectrum-tokens": {
         "name": "corner-radius-none",
         "uuid": "7a11b308-bed2-4b6f-bb4a-c9ae4ef8e03d"
-      }
-    }
-  },
-  "corner-radius-small-default": {
-    "value": "{corner-radius-100}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-small-default",
-        "uuid": "b4971f86-aeea-42c9-9ba7-a74cf4d1a545"
-      }
-    }
-  },
-  "corner-radius-medium-default": {
-    "value": "{corner-radius-500}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-medium-default",
-        "uuid": "a83a882e-430c-46fc-a8be-5ade0dd8a4c6"
-      }
-    }
-  },
-  "corner-radius-large-default": {
-    "value": "{corner-radius-700}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-large-default",
-        "uuid": "29981aef-aea6-4cde-849f-4bc67e320ea7"
-      }
-    }
-  },
-  "corner-radius-extra-large-default": {
-    "value": "{corner-radius-800}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-extra-large-default",
-        "uuid": "d639a0b5-16b4-4d75-ab37-d87815c7b500"
-      }
-    }
-  },
-  "corner-radius-full": {
-    "value": "{corner-radius-1000}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-full",
-        "uuid": "4853520b-bda3-45d1-bd20-8508cac08847"
-      }
-    }
-  },
-  "corner-radius-small-size-small": {
-    "value": "{corner-radius-75}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-small-size-small",
-        "uuid": "3d39e5de-0800-4629-ae1a-99a34706a772"
-      }
-    }
-  },
-  "corner-radius-small-size-medium": {
-    "value": "{corner-radius-100}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-small-size-medium",
-        "uuid": "a62a43dd-cb2a-4e18-bb94-7a9518668400"
-      }
-    }
-  },
-  "corner-radius-small-size-large": {
-    "value": "{corner-radius-200}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-small-size-large",
-        "uuid": "f4f0bfc9-ce6d-473f-8dda-c9f21fb8a7b7"
-      }
-    }
-  },
-  "corner-radius-small-size-extra-large": {
-    "value": "{corner-radius-300}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-small-size-extra-large",
-        "uuid": "d59337d1-4cec-43c0-821e-06a56745cbcc"
-      }
-    }
-  },
-  "corner-radius-medium-size-extra-small": {
-    "value": "{corner-radius-300}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-medium-size-extra-small",
-        "uuid": "d0e02d98-e93f-4f81-8d81-8f95e06ad360"
-      }
-    }
-  },
-  "corner-radius-medium-size-small": {
-    "value": "{corner-radius-400}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-medium-size-small",
-        "uuid": "892bc9de-16b2-4c51-9c18-b239e52ffd14"
-      }
-    }
-  },
-  "corner-radius-medium-size-medium": {
-    "value": "{corner-radius-500}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-medium-size-medium",
-        "uuid": "67fb5355-6d7c-4e4e-a4cb-cdba10a85d84"
-      }
-    }
-  },
-  "corner-radius-medium-size-large": {
-    "value": "{corner-radius-600}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-medium-size-large",
-        "uuid": "ede17e00-83ef-40c5-a1d0-a46372d3fc90"
-      }
-    }
-  },
-  "corner-radius-medium-size-extra-large": {
-    "value": "{corner-radius-700}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-medium-size-extra-large",
-        "uuid": "81752b3e-488a-4273-abb5-4ba8b7f278d9"
       }
     }
   }

--- a/src/tokens-studio/foundations/spectrum/layout/mobile.json
+++ b/src/tokens-studio/foundations/spectrum/layout/mobile.json
@@ -620,7 +620,7 @@
     }
   },
   "corner-radius-75": {
-    "value": "3px",
+    "value": "4px",
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
@@ -630,7 +630,7 @@
     }
   },
   "corner-radius-100": {
-    "value": "4px",
+    "value": "8px",
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
@@ -640,7 +640,7 @@
     }
   },
   "corner-radius-200": {
-    "value": "5px",
+    "value": "10px",
     "type": "borderRadius",
     "$extensions": {
       "spectrum-tokens": {
@@ -1539,76 +1539,6 @@
       }
     }
   },
-  "corner-radius-300": {
-    "value": "6px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-300",
-        "uuid": "154642d7-c23d-44fd-9d79-b719ef32922e"
-      }
-    }
-  },
-  "corner-radius-400": {
-    "value": "7px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-400",
-        "uuid": "690db7ae-cae8-49bb-8777-b4f1829b2f0b"
-      }
-    }
-  },
-  "corner-radius-500": {
-    "value": "8px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-500",
-        "uuid": "ada2ea1d-1728-411a-8aae-a198ce390a25"
-      }
-    }
-  },
-  "corner-radius-600": {
-    "value": "9px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-600",
-        "uuid": "abc0f309-3bd2-4800-af12-b27386e86617"
-      }
-    }
-  },
-  "corner-radius-700": {
-    "value": "10px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-700",
-        "uuid": "cb6b72ed-a9a1-4113-b147-1ef369fe6269"
-      }
-    }
-  },
-  "corner-radius-800": {
-    "value": "16px",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-800",
-        "uuid": "8fc023ca-8aec-40fe-9130-087aa035bac7"
-      }
-    }
-  },
-  "corner-radius-1000": {
-    "value": "0.5",
-    "type": "number",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-1000",
-        "uuid": "e4ad85b2-97bf-48cf-a5a9-3ff3d1fada5b"
-      }
-    }
-  },
   "corner-radius-none": {
     "value": "{corner-radius-0}",
     "type": "borderRadius",
@@ -1616,146 +1546,6 @@
       "spectrum-tokens": {
         "name": "corner-radius-none",
         "uuid": "7a11b308-bed2-4b6f-bb4a-c9ae4ef8e03d"
-      }
-    }
-  },
-  "corner-radius-small-default": {
-    "value": "{corner-radius-100}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-small-default",
-        "uuid": "b4971f86-aeea-42c9-9ba7-a74cf4d1a545"
-      }
-    }
-  },
-  "corner-radius-medium-default": {
-    "value": "{corner-radius-500}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-medium-default",
-        "uuid": "a83a882e-430c-46fc-a8be-5ade0dd8a4c6"
-      }
-    }
-  },
-  "corner-radius-large-default": {
-    "value": "{corner-radius-700}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-large-default",
-        "uuid": "29981aef-aea6-4cde-849f-4bc67e320ea7"
-      }
-    }
-  },
-  "corner-radius-extra-large-default": {
-    "value": "{corner-radius-800}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-extra-large-default",
-        "uuid": "d639a0b5-16b4-4d75-ab37-d87815c7b500"
-      }
-    }
-  },
-  "corner-radius-full": {
-    "value": "{corner-radius-1000}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-full",
-        "uuid": "4853520b-bda3-45d1-bd20-8508cac08847"
-      }
-    }
-  },
-  "corner-radius-small-size-small": {
-    "value": "{corner-radius-75}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-small-size-small",
-        "uuid": "3d39e5de-0800-4629-ae1a-99a34706a772"
-      }
-    }
-  },
-  "corner-radius-small-size-medium": {
-    "value": "{corner-radius-100}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-small-size-medium",
-        "uuid": "a62a43dd-cb2a-4e18-bb94-7a9518668400"
-      }
-    }
-  },
-  "corner-radius-small-size-large": {
-    "value": "{corner-radius-200}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-small-size-large",
-        "uuid": "f4f0bfc9-ce6d-473f-8dda-c9f21fb8a7b7"
-      }
-    }
-  },
-  "corner-radius-small-size-extra-large": {
-    "value": "{corner-radius-300}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-small-size-extra-large",
-        "uuid": "d59337d1-4cec-43c0-821e-06a56745cbcc"
-      }
-    }
-  },
-  "corner-radius-medium-size-extra-small": {
-    "value": "{corner-radius-300}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-medium-size-extra-small",
-        "uuid": "d0e02d98-e93f-4f81-8d81-8f95e06ad360"
-      }
-    }
-  },
-  "corner-radius-medium-size-small": {
-    "value": "{corner-radius-400}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-medium-size-small",
-        "uuid": "892bc9de-16b2-4c51-9c18-b239e52ffd14"
-      }
-    }
-  },
-  "corner-radius-medium-size-medium": {
-    "value": "{corner-radius-500}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-medium-size-medium",
-        "uuid": "67fb5355-6d7c-4e4e-a4cb-cdba10a85d84"
-      }
-    }
-  },
-  "corner-radius-medium-size-large": {
-    "value": "{corner-radius-600}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-medium-size-large",
-        "uuid": "ede17e00-83ef-40c5-a1d0-a46372d3fc90"
-      }
-    }
-  },
-  "corner-radius-medium-size-extra-large": {
-    "value": "{corner-radius-700}",
-    "type": "borderRadius",
-    "$extensions": {
-      "spectrum-tokens": {
-        "name": "corner-radius-medium-size-extra-large",
-        "uuid": "81752b3e-488a-4273-abb5-4ba8b7f278d9"
       }
     }
   }


### PR DESCRIPTION

## Description

Previously, S2 foundations was matching what was in S2 for corner radius, but this [paper doc](https://paper.dropbox.com/doc/SWC-1.0-S2-corner-rounding-scope-proposal--CY1fqWf7xVF0ITZtalK3Z5B7Ag-D6PcKbhJBbZwgSBqpHJIk) show it needs to be interim values between S1 and S2.

![image](https://github.com/user-attachments/assets/9edd7397-02a6-4229-abf6-3310a35cd599)


## Motivation and context

from the paper doc: It feels like a quick, simple, straightforward solution.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [x] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [ ] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
