### PR TITLE
SDS-14641 Static gradient colors 

### DIFF
--- a/src/tokens-studio/spectrum-colors/spectrum/palette/dark.json
+++ b/src/tokens-studio/spectrum-colors/spectrum/palette/dark.json
@@ -2161,6 +2161,116 @@
           }
         }
       }
+    },
+    "static-blue": {
+      "900": {
+        "value": "#3B63FB",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-blue-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#274DEA",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-blue-1000"
+          }
+        }
+      }
+    },
+    "static-fuchsia": {
+      "900": {
+        "value": "#B539C8",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-fuchsia-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#9C28AF",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-fuchsia-1000"
+          }
+        }
+      }
+    },
+    "static-indigo": {
+      "900": {
+        "value": "#7155FA",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-indigo-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#6338EE",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-indigo-1000"
+          }
+        }
+      }
+    },
+    "static-magenta": {
+      "900": {
+        "value": "#D92361",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-magenta-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#BA1650",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-magenta-1000"
+          }
+        }
+      }
+    },
+    "static-red": {
+      "900": {
+        "value": "#D73220",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-red-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#B72818",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-red-1000"
+          }
+        }
+      }
     }
   }
 }

--- a/src/tokens-studio/spectrum-colors/spectrum/palette/darkest.json
+++ b/src/tokens-studio/spectrum-colors/spectrum/palette/darkest.json
@@ -2161,6 +2161,116 @@
           }
         }
       }
+    },
+    "static-blue": {
+      "900": {
+        "value": "#3B63FB",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-blue-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#274DEA",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-blue-1000"
+          }
+        }
+      }
+    },
+    "static-fuchsia": {
+      "900": {
+        "value": "#B539C8",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-fuchsia-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#9C28AF",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-fuchsia-1000"
+          }
+        }
+      }
+    },
+    "static-indigo": {
+      "900": {
+        "value": "#7155FA",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-indigo-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#6338EE",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-indigo-1000"
+          }
+        }
+      }
+    },
+    "static-magenta": {
+      "900": {
+        "value": "#D92361",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-magenta-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#BA1650",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-magenta-1000"
+          }
+        }
+      }
+    },
+    "static-red": {
+      "900": {
+        "value": "#D73220",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-red-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#B72818",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-red-1000"
+          }
+        }
+      }
     }
   }
 }

--- a/src/tokens-studio/spectrum-colors/spectrum/palette/light.json
+++ b/src/tokens-studio/spectrum-colors/spectrum/palette/light.json
@@ -2161,6 +2161,116 @@
           }
         }
       }
+    },
+    "static-blue": {
+      "900": {
+        "value": "#3B63FB",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-blue-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#274DEA",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-blue-1000"
+          }
+        }
+      }
+    },
+    "static-fuchsia": {
+      "900": {
+        "value": "#B539C8",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-fuchsia-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#9C28AF",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-fuchsia-1000"
+          }
+        }
+      }
+    },
+    "static-indigo": {
+      "900": {
+        "value": "#7155FA",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-indigo-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#6338EE",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-indigo-1000"
+          }
+        }
+      }
+    },
+    "static-magenta": {
+      "900": {
+        "value": "#D92361",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-magenta-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#BA1650",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-magenta-1000"
+          }
+        }
+      }
+    },
+    "static-red": {
+      "900": {
+        "value": "#D73220",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-red-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#B72818",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-red-1000"
+          }
+        }
+      }
     }
   }
 }

--- a/src/tokens-studio/spectrum-colors/spectrum/palette/wireframe.json
+++ b/src/tokens-studio/spectrum-colors/spectrum/palette/wireframe.json
@@ -2161,6 +2161,116 @@
           }
         }
       }
+    },
+    "static-blue": {
+      "900": {
+        "value": "#3B63FB",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-blue-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#274DEA",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-blue-1000"
+          }
+        }
+      }
+    },
+    "static-fuchsia": {
+      "900": {
+        "value": "#B539C8",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-fuchsia-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#9C28AF",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-fuchsia-1000"
+          }
+        }
+      }
+    },
+    "static-indigo": {
+      "900": {
+        "value": "#7155FA",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-indigo-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#6338EE",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-indigo-1000"
+          }
+        }
+      }
+    },
+    "static-magenta": {
+      "900": {
+        "value": "#D92361",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-magenta-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#BA1650",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-magenta-1000"
+          }
+        }
+      }
+    },
+    "static-red": {
+      "900": {
+        "value": "#D73220",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-red-900"
+          }
+        }
+      },
+      "1000": {
+        "value": "#B72818",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "static-red-1000"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Add reviewers to your PR (@GarthDB, @karstens, @larz0, @lynnhao, @PaliwalSparsh, @mrcjhicks) and tag them in your Slack review request message -->
<!--- Approval: PRs require two reviews at the minimum (one from the engineering team and one from the design team) in order to be considered "approved" and ready to merge -->

## Description

Added static colors (for premium gradients) to light, dark, darkest, and wireframe themes:

- static-blue-900: #3B63FB
- static-blue-1000: #274DEA
- static-fuchsia-900: #B539C8
- static-fuchsia-1000: #9C28AF
- static-indigo-900: #7155FA
- static-indigo-1000: #6338EE
- static-magenta-900: #D92361
- static-magenta-1000: #BA1650
- static-red-900: #D73220
- static-red-1000: #B72818


## Motivation and context

The Firefly team is looking to add these for usage, and the team agreed that it would be better to have these tokens available then for the team to create their own custom tokens.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
