### PR TITLE
SDS-14325 Action bar - border color update

### DIFF
--- a/src/tokens-studio/spectrum2-colors/spectrum2/component/dark.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/component/dark.json
@@ -1,5 +1,17 @@
 {
   "Component": {
+    "action-bar": {
+      "border": {
+        "value": "{Palette.gray.400}",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "action-bar-border-color"
+          }
+        }
+      }
+    },
     "avatar": {
       "border": {
         "value": "{Palette.gray.25}",

--- a/src/tokens-studio/spectrum2-colors/spectrum2/component/light.json
+++ b/src/tokens-studio/spectrum2-colors/spectrum2/component/light.json
@@ -1,5 +1,17 @@
 {
   "Component": {
+    "action-bar": {
+      "border": {
+        "value": "{Palette.transparent-white.25}",
+        "type": "color",
+        "$extensions": {
+          "spectrum-tokens": {
+            "uuid": "",
+            "name": "action-bar-border-color"
+          }
+        }
+      }
+    },
     "avatar": {
       "border": {
         "value": "{Palette.gray.25}",


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Add reviewers to your PR (@GarthDB, @karstens, @larz0, @lynnhao, @PaliwalSparsh, @mrcjhicks) and tag them in your Slack review request message -->
<!--- Approval: PRs require two reviews at the minimum (one from the engineering team and one from the design team) in order to be considered "approved" and ready to merge -->

## Description

Added action bar border colors:

action-bar-border-color: transparent-white-25 (light theme)
action-bar-border-color: gray-400 (dark theme)

## Motivation and context

Similar to the issues reported for popovers ([SDS-14251](https://jira.corp.adobe.com/browse/SDS-14251)), there isn't sufficient visual contrast of action bars on top of backgrounds in dark theme when used on background-color-layer-2. 

**The solution to this issue in both popovers and action bars should be the same (Popover update has been merged)**

This issue was originally reported by the React team. Attached reference images from their implementation, one without border and one with border that matches the current popover border in dark.

## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
