### PR TITLE
SDS-14384 New segmented control token

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -7380,6 +7380,16 @@
       }
     }
   },
+  "segmented-control-item-maximum-width": {
+    "value": "265px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "segmented-control-item-maximum-width"
+      }
+    }
+  },
   "tray-top-to-content-area": {
     "value": "4px",
     "type": "spacing",

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -7380,6 +7380,16 @@
       }
     }
   },
+  "segmented-control-item-maximum-width": {
+    "value": "265px",
+    "type": "sizing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "segmented-control-item-maximum-width"
+      }
+    }
+  },
   "tray-top-to-content-area": {
     "value": "5px",
     "type": "spacing",


### PR DESCRIPTION
## Description

Added a new token for segemented control:
- segmented-control-item-maximum-width: 265px

## Motivation and context

Challenge: handling varying content lengths in the segmented control component
Discussed solution: setting a maximum width for buttons and truncating content if necessary.

## Related issue

[SDS-14383](https://jira.corp.adobe.com/browse/SDS-14383)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
