### PR TITLE
Deprecating "drop-zone-content-maximum-width"

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -3019,7 +3019,7 @@
       }
     }
   },
-  "drop-zone-content-maximum-width": {
+  "🚫 drop-zone-content-maximum-width": {
     "value": "{illustrated-message-maximum-width}",
     "type": "sizing",
     "$extensions": {

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -3019,7 +3019,7 @@
       }
     }
   },
-  "drop-zone-content-maximum-width": {
+  "🚫 drop-zone-content-maximum-width": {
     "value": "{illustrated-message-maximum-width}",
     "type": "sizing",
     "$extensions": {


### PR DESCRIPTION
<!--- Title: Provide a general summary of your changes in the Title above -->
<!--- Reviewers: Add reviewers to your PR (@GarthDB, @karstens, @larz0, @lynnhao, @PaliwalSparsh, @mrcjhicks) and tag them in your Slack review request message -->
<!--- Approval: PRs require two reviews at the minimum (one from the engineering team and one from the design team) in order to be considered "approved" and ready to merge -->

## Description

Deprecated "drop-zone-content-maximum-width" in desktop and mobile.

## Motivation and context
drop-zone-content-maximum-width is an alias of illustrated-message-maximum-width which is a deprecated token. Therefore it should be deprecated.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
