### PR TITLE
Added horizontal card tokens

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -1979,6 +1979,36 @@
       }
     }
   },
+  "card-horizontal-edge-to-content-compact": {
+    "value": "12px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "card-horizontal-edge-to-content-compact"
+      }
+    }
+  },
+  "card-horizontal-edge-to-content-default": {
+    "value": "16px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "card-horizontal-edge-to-content-default"
+      }
+    }
+  },
+  "card-horizontal-edge-to-content-spacious": {
+    "value": "20px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "card-horizontal-edge-to-content-spacious"
+      }
+    }
+  },
   "collection-card-minimum-height-extra-small": {
     "value": "88px",
     "type": "sizing",

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -1999,6 +1999,36 @@
       }
     }
   },
+  "card-horizontal-edge-to-content-compact": {
+    "value": "12px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "card-horizontal-edge-to-content-compact"
+      }
+    }
+  },
+  "card-horizontal-edge-to-content-default": {
+    "value": "16px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "card-horizontal-edge-to-content-default"
+      }
+    }
+  },
+  "card-horizontal-edge-to-content-spacious": {
+    "value": "20px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "card-horizontal-edge-to-content-spacious"
+      }
+    }
+  },
   "collection-card-minimum-height-extra-small": {
     "value": "88px",
     "type": "sizing",


### PR DESCRIPTION
## Description

Added horizontal card tokens for desktop and mobile:

card-horizontal-edge-to-content-compact
12px

card-horizontal-edge-to-content-default
16px

card-horizontal-edge-to-content-spacious
20px

## Motivation and context

These tokens are needed for horizontal cards

## Related issue

SDS-14860

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
