### PR TITLE
Added new accordion tokens

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -239,6 +239,46 @@
       }
     }
   },
+  "accordion-edge-to-content-area-small": {
+    "value": "7px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "accordion-edge-to-content-area-small"
+      }
+    }
+  },
+  "accordion-edge-to-content-area-medium": {
+    "value": "11px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "accordion-edge-to-content-area-medium"
+      }
+    }
+  },
+  "accordion-edge-to-content-area-large": {
+    "value": "14px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "accordion-edge-to-content-area-large"
+      }
+    }
+  },
+  "accordion-edge-to-content-area-extra-large": {
+    "value": "17px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "accordion-edge-to-content-area-extra-large"
+      }
+    }
+  },
   "accordion-edge-to-text": {
     "value": "0px",
     "type": "spacing",

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -239,6 +239,46 @@
       }
     }
   },
+  "accordion-edge-to-content-area-small": {
+    "value": "7px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "accordion-edge-to-content-area-small"
+      }
+    }
+  },
+  "accordion-edge-to-content-area-medium": {
+    "value": "11px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "accordion-edge-to-content-area-medium"
+      }
+    }
+  },
+  "accordion-edge-to-content-area-large": {
+    "value": "14px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "accordion-edge-to-content-area-large"
+      }
+    }
+  },
+  "accordion-edge-to-content-area-extra-large": {
+    "value": "17px",
+    "type": "spacing",
+    "$extensions": {
+      "spectrum-tokens": {
+        "uuid": "",
+        "name": "accordion-edge-to-content-area-extra-large"
+      }
+    }
+  },
   "accordion-edge-to-text": {
     "value": "0px",
     "type": "spacing",


### PR DESCRIPTION
## Description

Added new accordion tokens for desktop and mobile:

accordion-edge-to-content-area-small
7px

accordion-edge-to-content-area-medium
11 px

accordion-edge-to-content-area-large
14px

accordion-edge-to-content-area-extra-large
17px

## Motivation and context

These tokens are required for the accordion component.

## Related issue

SDS-14381

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
