### PR TITLE
Small accordion token fixes

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -600,7 +600,7 @@
     }
   },
   "accordion-top-to-text-medium": {
-    "value": "12px",
+    "value": "9px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/desktop.json
@@ -330,7 +330,7 @@
     }
   },
   "accordion-focus-indicator-gap": {
-    "value": "0px",
+    "value": "2px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -490,7 +490,7 @@
     }
   },
   "accordion-top-to-text-medium": {
-    "value": "16px",
+    "value": "10px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/spectrum2/layout.component/mobile.json
@@ -330,7 +330,7 @@
     }
   },
   "accordion-focus-indicator-gap": {
-    "value": "0px",
+    "value": "2px",
     "type": "spacing",
     "$extensions": {
       "spectrum-tokens": {


### PR DESCRIPTION
## Description

- `accordion-top-to-text-medium` values in desktop and mobile were incorrect due to changelog error.
- Corrected `accordion-focus-indicator-gap` values. Corrections weren't recorded in the changelog.

## Motivation and context

This is a bug fix.

## Related issue

SDS-15141

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [x] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [ ] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
