### PR TITLE
Fix: Removed erroneous density option for compact group gap

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/Layout/global/modeless.json
+++ b/src/tokens-studio/spectrum2-non-colors/Layout/global/modeless.json
@@ -672,14 +672,8 @@
         }
       },
       "Compact": {
-        "Regular": {
-          "value": "{platformScale.group-gap-compact}",
-          "type": "spacing"
-        },
-        "Spacious": {
-          "value": "{platformScale.group-gap-extra-small-spacious}",
-          "type": "spacing"
-        }
+        "value": "{platformScale.group-gap-compact}",
+        "type": "spacing"
       }
     }
   },


### PR DESCRIPTION
## Description
Group gap compact does not have regular/spacious options, so these have been corrected. A "spacious" option was erroneously added to this token and has been removed. The "regular" option was reverted back to the sole token value for "Group/Gap/Compact"

## Motivation and context
Accuracy of design data

## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [x] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [ ] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
