### PR TITLE
Update small and extra small vertical base & accessory paddings

### DIFF
--- a/src/tokens-studio/spectrum2-non-colors/Platform scale/layout/desktop.json
+++ b/src/tokens-studio/spectrum2-non-colors/Platform scale/layout/desktop.json
@@ -1063,7 +1063,7 @@
       }
     },
     "base-padding-vertical-extra-small": {
-      "value": "4px",
+      "value": "3px",
       "type": "spacing",
       "$extensions": {
         "spectrum-tokens": {
@@ -1072,7 +1072,7 @@
       }
     },
     "base-padding-vertical-small": {
-      "value": "5px",
+      "value": "4px",
       "type": "spacing",
       "$extensions": {
         "spectrum-tokens": {
@@ -1180,7 +1180,7 @@
       }
     },
     "accessory-gap-extra-small": {
-      "value": "4px",
+      "value": "3px",
       "type": "spacing",
       "$extensions": {
         "spectrum-tokens": {
@@ -1189,7 +1189,7 @@
       }
     },
     "accessory-gap-small": {
-      "value": "5px",
+      "value": "4px",
       "type": "spacing",
       "$extensions": {
         "spectrum-tokens": {

--- a/src/tokens-studio/spectrum2-non-colors/Platform scale/layout/mobile.json
+++ b/src/tokens-studio/spectrum2-non-colors/Platform scale/layout/mobile.json
@@ -1063,7 +1063,7 @@
       }
     },
     "base-padding-vertical-extra-small": {
-      "value": "4px",
+      "value": "3px",
       "type": "spacing",
       "$extensions": {
         "spectrum-tokens": {
@@ -1072,7 +1072,7 @@
       }
     },
     "base-padding-vertical-small": {
-      "value": "5px",
+      "value": "4px",
       "type": "spacing",
       "$extensions": {
         "spectrum-tokens": {
@@ -1180,7 +1180,7 @@
       }
     },
     "accessory-gap-extra-small": {
-      "value": "4px",
+      "value": "3px",
       "type": "spacing",
       "$extensions": {
         "spectrum-tokens": {
@@ -1189,7 +1189,7 @@
       }
     },
     "accessory-gap-small": {
-      "value": "5px",
+      "value": "4px",
       "type": "spacing",
       "$extensions": {
         "spectrum-tokens": {


### PR DESCRIPTION
## Description
Updated vertical padding and accessory gaps for small and extra small sizes. Result of this update will ensure small components are 24px tall and extra small components are 20px tall.

## Motivation and context
Web Design / Figma Arch teams agree to revert recent updates to component heights for small and extra small sizes back to their original height values in S2 (prior to layout token refactor)

|  Size | Current | Update (this PR) |
|------|--------|------------------|
| Small | 26px | 24px |
| Extra small | 22px | 20px |

## Related issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in #spectrum_tokens_talk or design workshop, first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue on the next line: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

<li> [ ] Patch (bug fixes, typos, mistakes; non-breaking change which fixes an issue) </li>
<li> [x] Minor (add a new token, changing a value, deprecating a token; non-breaking change which adds functionality) </li>
<li> [ ] Major (deleting a token, changing token value type, renaming a token by deprecating the old one; fix or feature that would cause existing functionality to change) </li>

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<li> [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html). </li>
<li> [x] I updated the token in all applicable sets. This applies if updating, adding, or deleting a token that has data across different sets (for example, if the value differs across color themes.) </li>
